### PR TITLE
feat(web): Add InstallModal with 2-step installation guide

### DIFF
--- a/apps/web/app/components/InstallModal.vue
+++ b/apps/web/app/components/InstallModal.vue
@@ -1,0 +1,214 @@
+<template>
+  <UModal
+    v-model:open="isOpen"
+    title="Installation Instructions"
+    description="Run these two commands in order"
+  >
+    <template #body>
+      <div class="space-y-4">
+        <!-- Clipboard Not Supported Warning -->
+        <UAlert
+          v-if="!isClipboardSupported"
+          color="warning"
+          variant="soft"
+          icon="i-heroicons-exclamation-triangle"
+          title="Clipboard Not Available"
+          description="Your browser doesn't support automatic copying. Please copy the commands manually using Ctrl+C (Cmd+C on Mac)."
+        />
+
+        <!-- Step 1: Add Marketplace -->
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <UBadge color="primary" variant="soft" size="sm">1</UBadge>
+            <span>Add Marketplace</span>
+          </div>
+          <div class="relative">
+            <pre class="bg-default border border-default rounded-lg p-3 text-sm overflow-x-auto"><code>{{ marketplaceCommand }}</code></pre>
+            <UButton
+              @click="copyCommand(marketplaceCommand, 'marketplace')"
+              :variant="copiedStates.marketplace ? 'soft' : 'ghost'"
+              :color="copiedStates.marketplace ? 'success' : 'neutral'"
+              size="xs"
+              :icon="copiedStates.marketplace ? 'i-heroicons-check' : 'i-heroicons-clipboard-document'"
+              class="absolute top-2 right-2"
+              :title="copiedStates.marketplace ? 'Copied!' : 'Copy command'"
+            />
+          </div>
+        </div>
+
+        <!-- Step 2: Install Plugin -->
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <UBadge color="primary" variant="soft" size="sm">2</UBadge>
+            <span>Install Plugin</span>
+          </div>
+          <div class="relative">
+            <pre class="bg-default border border-default rounded-lg p-3 text-sm overflow-x-auto"><code>{{ installCommand }}</code></pre>
+            <UButton
+              @click="copyCommand(installCommand, 'install')"
+              :variant="copiedStates.install ? 'soft' : 'ghost'"
+              :color="copiedStates.install ? 'success' : 'neutral'"
+              size="xs"
+              :icon="copiedStates.install ? 'i-heroicons-check' : 'i-heroicons-clipboard-document'"
+              class="absolute top-2 right-2"
+              :title="copiedStates.install ? 'Copied!' : 'Copy command'"
+            />
+          </div>
+        </div>
+
+        <!-- Copy All Button -->
+        <div class="pt-2 border-t border-default">
+          <UButton
+            @click="copyAllCommands"
+            :variant="copiedStates.all ? 'soft' : 'outline'"
+            :color="copiedStates.all ? 'success' : 'primary'"
+            block
+            :icon="copiedStates.all ? 'i-heroicons-check-circle' : 'i-heroicons-clipboard-document-list'"
+          >
+            {{ copiedStates.all ? 'All Commands Copied!' : 'Copy All Commands' }}
+          </UButton>
+        </div>
+
+        <!-- Manual Copy Tip -->
+        <div class="text-sm text-muted flex items-start gap-2">
+          <UIcon name="i-heroicons-information-circle" class="shrink-0 mt-0.5" />
+          <span>Tip: You can also select and copy the commands manually (Ctrl+C / Cmd+C)</span>
+        </div>
+      </div>
+    </template>
+
+    <template #footer="{ close }">
+      <div class="flex justify-end">
+        <UButton
+          label="Close"
+          color="neutral"
+          variant="outline"
+          @click="close"
+        />
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  pluginName: string
+  open?: boolean
+}
+
+interface Emits {
+  (e: 'update:open', value: boolean): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  open: false
+})
+
+const emit = defineEmits<Emits>()
+
+const isOpen = computed({
+  get: () => props.open,
+  set: (value) => emit('update:open', value)
+})
+
+const marketplaceCommand = '/plugin marketplace add pleaseai/claude-code-plugins'
+const installCommand = computed(() => `/plugin install ${props.pluginName}@pleaseai`)
+
+const copiedStates = reactive({
+  marketplace: false,
+  install: false,
+  all: false
+})
+
+// Check if clipboard API is supported
+const isClipboardSupported = computed(() => {
+  return typeof navigator !== 'undefined' &&
+         'clipboard' in navigator &&
+         typeof navigator.clipboard?.writeText === 'function'
+})
+
+const copyCommand = async (command: string, type: keyof typeof copiedStates) => {
+  try {
+    // Check if clipboard API is available
+    if (!isClipboardSupported.value) {
+      throw new Error('Clipboard API not available')
+    }
+
+    await navigator.clipboard.writeText(command)
+    copiedStates[type] = true
+
+    setTimeout(() => {
+      copiedStates[type] = false
+    }, 2000)
+  } catch (err) {
+    // Log error with full context for debugging
+    console.error('Failed to copy command to clipboard:', {
+      command,
+      type,
+      error: err instanceof Error ? err.message : String(err),
+      clipboardAvailable: isClipboardSupported.value,
+      isSecureContext: typeof window !== 'undefined' ? window.isSecureContext : false
+    })
+
+    // Show user-facing error notification
+    const toast = useToast()
+    toast.add({
+      title: 'Copy Failed',
+      description: 'Could not copy to clipboard. Please copy the command manually.',
+      color: 'error',
+      icon: 'i-heroicons-exclamation-triangle'
+    })
+
+    // DO NOT set success state on failure
+    copiedStates[type] = false
+  }
+}
+
+const copyAllCommands = async () => {
+  const allCommands = `${marketplaceCommand}\n${installCommand.value}`
+
+  try {
+    // Check if clipboard API is available
+    if (!isClipboardSupported.value) {
+      throw new Error('Clipboard API not available')
+    }
+
+    await navigator.clipboard.writeText(allCommands)
+    copiedStates.all = true
+
+    setTimeout(() => {
+      copiedStates.all = false
+    }, 2000)
+  } catch (err) {
+    // Log error with full context for debugging
+    console.error('Failed to copy all commands to clipboard:', {
+      marketplaceCommand,
+      installCommand: installCommand.value,
+      error: err instanceof Error ? err.message : String(err),
+      clipboardAvailable: isClipboardSupported.value,
+      isSecureContext: typeof window !== 'undefined' ? window.isSecureContext : false
+    })
+
+    // Show user-facing error notification
+    const toast = useToast()
+    toast.add({
+      title: 'Copy Failed',
+      description: 'Could not copy commands to clipboard. Please copy them manually from above.',
+      color: 'error',
+      icon: 'i-heroicons-exclamation-triangle'
+    })
+
+    // DO NOT set success state on failure
+    copiedStates.all = false
+  }
+}
+
+// Reset copied states when modal is closed
+watch(isOpen, (newValue) => {
+  if (!newValue) {
+    copiedStates.marketplace = false
+    copiedStates.install = false
+    copiedStates.all = false
+  }
+})
+</script>

--- a/apps/web/app/components/PluginCard.vue
+++ b/apps/web/app/components/PluginCard.vue
@@ -74,19 +74,25 @@
         </UButton>
 
         <UButton
-          @click="copyInstallCommand"
-          :variant="copied ? 'soft' : 'solid'"
-          :color="copied ? 'green' : 'primary'"
+          @click="openInstallModal"
+          variant="solid"
+          color="primary"
           size="sm"
-          :icon="copied ? 'i-heroicons-check-circle' : 'i-heroicons-clipboard-document'"
+          icon="i-heroicons-arrow-down-tray"
           class="flex-1 justify-center"
-          :title="copied ? 'Copied to clipboard!' : 'Copy install command'"
+          title="View installation instructions"
         >
-          {{ copied ? 'Copied!' : 'Install' }}
+          Install
         </UButton>
       </div>
     </template>
   </UCard>
+
+  <!-- Install Modal -->
+  <InstallModal
+    v-model:open="isModalOpen"
+    :plugin-name="plugin.name"
+  />
 </template>
 
 <script setup lang="ts">
@@ -115,7 +121,7 @@ const props = defineProps<{
   plugin: Plugin
 }>()
 
-const copied = ref(false)
+const isModalOpen = ref(false)
 const pluginMetadata = ref<PluginMetadata | null>(null)
 const loading = ref(false)
 
@@ -166,18 +172,7 @@ onMounted(() => {
   fetchPluginMetadata()
 })
 
-const copyInstallCommand = async () => {
-  const command = `claude-code plugins install https://github.com/${props.plugin.source.repo}`
-
-  try {
-    await navigator.clipboard.writeText(command)
-    copied.value = true
-
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
-  } catch (err) {
-    console.error('Failed to copy:', err)
-  }
+const openInstallModal = () => {
+  isModalOpen.value = true
 }
 </script>


### PR DESCRIPTION
## Summary
- Added InstallModal component to guide users through 2-step plugin installation
- Improved error handling for clipboard operations with user-facing feedback
- Enhanced UX with step-by-step instructions and fallback options

## Changes

### New Component: InstallModal
- **Step-by-step installation guide**: Clear instructions for marketplace and plugin installation
- **Individual copy buttons**: Each command has its own copy button
- **Copy all commands**: Convenience button to copy both commands at once
- **Clipboard API detection**: Checks browser support and shows warning if unavailable
- **Error handling**: Toast notifications on copy failure with detailed logging
- **Manual copy fallback**: Instructions for users to copy manually

### Updated Component: PluginCard
- Changed Install button to open modal instead of direct clipboard copy
- Removed old `copyInstallCommand` function
- Cleaner button state management

## Error Handling Improvements
✅ Clipboard API availability check before operations
✅ User-facing toast notifications on copy failure
✅ Never sets success state when operations fail
✅ Detailed error logging with context (command, type, environment)
✅ Manual copy instructions as fallback
✅ Warning message when clipboard not supported

## Test Plan
- [ ] Test modal opening from plugin card
- [ ] Test individual command copy buttons
- [ ] Test "Copy All Commands" button
- [ ] Test clipboard unsupported warning (HTTP context)
- [ ] Test error toast on clipboard failure
- [ ] Verify manual copy instructions are visible
- [ ] Test on different browsers (Chrome, Firefox, Safari)

## Standards Compliance
- ✅ Follows STANDARDS.md error handling guidelines
- ✅ Proper user-facing error messages
- ✅ Detailed error context in logs
- ✅ TypeScript type safety maintained
- ✅ Vue 3 Composition API best practices
- ✅ Nuxt UI v4 component usage