### PR TITLE
feat(web): add URL parameter support for auto-opening plugin install modal

### DIFF
--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -97,6 +97,8 @@
 </template>
 
 <script setup lang="ts">
+import { useTimeoutFn } from '@vueuse/core'
+
 interface PluginSource {
   source: 'github'
   repo: string
@@ -123,11 +125,34 @@ interface MarketplaceData {
 
 const searchQuery = ref('')
 const route = useRoute()
+const router = useRouter()
+const toast = useToast()
 const pluginCardRefs = ref<Record<string, any>>({})
+const pendingScrollTimer = ref<{ stop: () => void } | null>(null)
 
-// Get target plugin name from URL query parameter
+// Get target plugin name from URL query parameter with validation
 const targetPluginName = computed(() => {
-  return (route.query.plugin || route.query.install) as string | undefined
+  const pluginParam = route.query.plugin || route.query.install
+
+  // Handle array case (e.g., ?plugin=foo&plugin=bar)
+  if (Array.isArray(pluginParam)) {
+    console.warn('[Plugin URL Navigation] Multiple plugin parameters detected, using first value')
+    return pluginParam[0] || undefined
+  }
+
+  // Handle empty string
+  if (pluginParam === '') {
+    console.warn('[Plugin URL Navigation] Empty plugin parameter detected')
+    return undefined
+  }
+
+  // Normalize and validate
+  if (typeof pluginParam === 'string') {
+    const normalized = pluginParam.trim()
+    return normalized || undefined
+  }
+
+  return undefined
 })
 
 // Fetch marketplace data
@@ -135,6 +160,19 @@ const { data: marketplaceData, pending, error } = await useAsyncData<Marketplace
   'marketplace',
   () => queryCollection('marketplace').first()
 )
+
+// Check if plugin matches search query
+function pluginMatchesSearch(plugin: Plugin, query: string): boolean {
+  const searchFields = [
+    plugin.name,
+    plugin.description,
+    plugin.source.repo
+  ]
+
+  return searchFields.some(field =>
+    field.toLowerCase().includes(query)
+  )
+}
 
 // Filter plugins based on search query
 const filteredPlugins = computed(() => {
@@ -146,13 +184,9 @@ const filteredPlugins = computed(() => {
     return marketplaceData.value.plugins
   }
 
-  return marketplaceData.value.plugins.filter(plugin => {
-    return (
-      plugin.name.toLowerCase().includes(query) ||
-      plugin.description.toLowerCase().includes(query) ||
-      plugin.source.repo.toLowerCase().includes(query)
-    )
-  })
+  return marketplaceData.value.plugins.filter(plugin =>
+    pluginMatchesSearch(plugin, query)
+  )
 })
 
 // Store plugin card refs for scrolling
@@ -162,21 +196,106 @@ const setPluginCardRef = (pluginName: string, el: any) => {
   }
 }
 
-// Auto-scroll to target plugin when page loads
+// Scroll to a specific plugin card with error handling
+function scrollToPlugin(pluginName: string): boolean {
+  const targetCard = pluginCardRefs.value[pluginName]
+
+  if (!targetCard) {
+    // Use debug level for initial attempts - this is expected during loading
+    return false
+  }
+
+  try {
+    const element = targetCard.$el
+
+    if (!element || !(element instanceof HTMLElement)) {
+      throw new Error(`Invalid DOM element for plugin "${pluginName}"`)
+    }
+
+    if (typeof element.scrollIntoView !== 'function') {
+      throw new Error('scrollIntoView not supported')
+    }
+
+    element.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center'
+    })
+
+    return true
+  } catch (error) {
+    console.error(`[Plugin URL Navigation] Failed to scroll to plugin "${pluginName}":`, error)
+    return false
+  }
+}
+
+// Auto-scroll to target plugin when page loads with user feedback
 watch([() => targetPluginName.value, pending], ([pluginName, isLoading]) => {
   if (!pluginName || isLoading) return
 
-  // Wait for next tick to ensure DOM is updated
-  nextTick(() => {
-    const targetCard = pluginCardRefs.value[pluginName]
-    if (targetCard?.$el) {
-      targetCard.$el.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center'
-      })
-    }
-  })
+  // Check if plugin exists in the data first
+  const pluginExists = marketplaceData.value?.plugins?.some(p => p.name === pluginName)
+
+  if (!pluginExists) {
+    // Plugin doesn't exist in marketplace data
+    toast.add({
+      title: 'Plugin Not Found',
+      description: `The plugin "${pluginName}" could not be found. It may have been removed or the link may be incorrect.`,
+      color: 'red',
+      icon: 'i-heroicons-exclamation-triangle'
+    })
+
+    // Clear the query parameter to prevent confusion
+    router.replace({ query: {} })
+    return
+  }
+
+  // Clean up any existing pending timer
+  pendingScrollTimer.value?.stop()
+
+  // Plugin exists, try to scroll with retry logic
+  let retryCount = 0
+  const maxRetries = 5
+  const retryDelay = 200 // ms between retries
+
+  const attemptScroll = () => {
+    // Wait for next tick to ensure DOM is updated
+    nextTick(() => {
+      const scrolled = scrollToPlugin(pluginName)
+
+      if (scrolled) {
+        // Success! Clear timer reference
+        pendingScrollTimer.value = null
+        return
+      }
+
+      // Not ready yet, retry if we haven't exceeded max retries
+      retryCount++
+      if (retryCount < maxRetries) {
+        const timer = useTimeoutFn(attemptScroll, retryDelay)
+        pendingScrollTimer.value = timer
+        timer.start()
+      } else {
+        // Max retries reached, show user feedback
+        console.error(`[Plugin URL Navigation] Failed to scroll to "${pluginName}" after ${maxRetries} attempts`)
+        toast.add({
+          title: 'Navigation Issue',
+          description: `The plugin "${pluginName}" was found but could not be displayed. Try refreshing the page.`,
+          color: 'orange',
+          icon: 'i-heroicons-exclamation-circle'
+        })
+        pendingScrollTimer.value = null
+      }
+    })
+  }
+
+  // Start the scroll attempt cycle
+  attemptScroll()
 }, { immediate: true })
+
+// Clean up pending timer on unmount
+onBeforeUnmount(() => {
+  pendingScrollTimer.value?.stop()
+})
 
 // SEO Meta
 useHead({


### PR DESCRIPTION
## Summary
Enable direct linking to specific plugins with automatic install modal display. Users can now share URLs with query parameters to directly open a plugin's installation instructions.

## Features
- **URL Parameter Support**: Accept `?plugin=` or `?install=` query parameters
- **Auto-scroll**: Smoothly scroll to the target plugin card on page load
- **Auto-open Modal**: Automatically display the install modal for the specified plugin
- **Smooth UX**: 500ms delay ensures scroll completes before modal opens

## Usage Examples
```
https://yoursite.com/?plugin=nanobanana
https://yoursite.com/?install=grafana
https://yoursite.com/?plugin=firebase
```

## Technical Changes
- `apps/web/app/pages/index.vue`: 
  - Added route query parameter detection
  - Implemented plugin card ref tracking for scrolling
  - Added auto-scroll watcher with smooth behavior
- `apps/web/app/components/PluginCard.vue`:
  - Added `autoOpenModal` prop
  - Implemented watcher to auto-open modal when prop is true

## Test Plan
1. Visit `/?plugin=nanobanana` - should scroll to nanobanana card and open install modal
2. Visit `/?install=grafana` - should scroll to grafana card and open install modal
3. Visit `/` without params - should work normally without auto-actions
4. Test with non-existent plugin name - should gracefully handle (no scroll, no modal)

## Screenshots
N/A - Functional feature, behavior-based changes only