### PR TITLE
fix: configure Vercel preset and fix marketplace config loading

### DIFF
--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -3,6 +3,10 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
 
+  nitro: {
+    preset: 'vercel',
+  },
+
   modules: [
     '@nuxt/ui',
     '@nuxt/content',

--- a/apps/web/server/api/marketplaces.get.ts
+++ b/apps/web/server/api/marketplaces.get.ts
@@ -1,7 +1,5 @@
 import type { AggregatedMarketplace, AggregatedPlugin, MarketplaceAPIResponse, MarketplaceSource } from '~/types/marketplace'
-import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
-import process from 'node:process'
+import marketplaceSourcesConfig from '../marketplace-sources.json'
 import { marketplaceSchema, marketplaceSourcesConfigSchema } from '../utils/marketplace-schema'
 
 /**
@@ -10,14 +8,8 @@ import { marketplaceSchema, marketplaceSourcesConfigSchema } from '../utils/mark
  */
 const fetchMarketplaces = defineCachedFunction(
   async (): Promise<MarketplaceAPIResponse> => {
-    // Load marketplace sources configuration
-    // Resolve path from public directory (available in runtime)
-    const configPath = resolve(process.cwd(), 'public/marketplace-sources.json')
-    const configData = await readFile(configPath, 'utf-8')
-    const parsedConfig = JSON.parse(configData)
-
     // Validate configuration with Zod
-    const validatedConfig = marketplaceSourcesConfigSchema.parse(parsedConfig)
+    const validatedConfig = marketplaceSourcesConfigSchema.parse(marketplaceSourcesConfig)
     const enabledSources = validatedConfig.sources
       .filter(s => s.enabled)
       .sort((a, b) => a.priority - b.priority)

--- a/apps/web/server/marketplace-sources.json
+++ b/apps/web/server/marketplace-sources.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "name": "pleaseai",
+      "description": "Community-contributed plugins from PleaseAI",
+      "url": "https://raw.githubusercontent.com/pleaseai/claude-code-plugins/main/.claude-plugin/marketplace.json",
+      "repo": "pleaseai/claude-code-plugins",
+      "enabled": true,
+      "priority": 1
+    },
+    {
+      "name": "claude-code-plugins",
+      "description": "Bundled plugins for Claude Code including Agent SDK development tools, PR review toolkit, and commit workflows",
+      "url": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude-plugin/marketplace.json",
+      "repo": "anthropics/claude-code",
+      "enabled": true,
+      "priority": 2
+    }
+  ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".nuxt/**", "!.nuxt/cache/**", "dist/**",".output/**"],
+      "outputs": [".nuxt/**", "!.nuxt/cache/**", "dist/**",".output/**"]
     },
     "lint": {
       "dependsOn": ["^lint"],


### PR DESCRIPTION
## Summary

- Configure Vercel preset in `nuxt.config.ts` for proper serverless deployment
- Fix marketplace API failing with ENOENT error in production
- Move `marketplace-sources.json` to server directory and import directly instead of using file system APIs
- Clean up `turbo.json` formatting

## Problem

The marketplace API was failing in Vercel's serverless environment with:
```
Error: ENOENT: no such file or directory, open '/var/task/marketplace-sources.json'
```

This occurred because:
1. No Vercel preset was configured, causing incorrect build output
2. The API was trying to read `marketplace-sources.json` from the file system using `process.cwd()`, which differs between dev and production environments

## Solution

1. **Added Vercel preset** to ensure proper serverless build configuration
2. **Moved config file** from `public/` to `server/` directory
3. **Changed from fs.readFile to direct import** - this bundles the config at build time, making it available in any environment
4. **Removed trailing comma** in turbo.json for consistency

## Test Plan

- [x] Build completes successfully with Vercel preset
- [x] Config file is bundled in server output
- [x] No file system dependencies in serverless functions