### PR TITLE
feat: update chrome-devtools-mcp source repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -80,7 +80,7 @@
       "description": "Control and inspect a live Chrome browser through MCP - automate actions, debug, and analyze performance using Chrome DevTools",
       "source": {
         "source": "github",
-        "repo": "pleaseai/chrome-devtools-mcp"
+        "repo": "ChromeDevTools/chrome-devtools-mcp"
       }
     }
   ]

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,13 +2,16 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/code-review" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/firebase" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/flutter" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/grafana" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/nanobanana" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/postgres" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/security" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/plugins/spec-kit" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/chrome-devtools-mcp" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/code-review" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/firebase" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/flutter" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/grafana" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/mcp-neo4j" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/nanobanana" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/open-aware" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/postgres" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/security" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/external-plugins/spec-kit" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
## Summary
- Update chrome-devtools-mcp plugin source repository from `pleaseai/chrome-devtools-mcp` to `ChromeDevTools/chrome-devtools-mcp`

## Context
Following the merge of the upstream PR, the plugin's source repository needs to point to the official ChromeDevTools organization repository.

## Changes
- Updated `.claude-plugin/marketplace.json` to reference `ChromeDevTools/chrome-devtools-mcp`

## Test plan
- [ ] Verify marketplace configuration is valid
- [ ] Confirm plugin installation works with new repository URL