### PR TITLE
feat: add GitHub stars display with ISR and optimized caching

### DIFF
--- a/apps/web/app/components/PluginCard.vue
+++ b/apps/web/app/components/PluginCard.vue
@@ -14,6 +14,7 @@ interface Plugin {
   source: PluginSource | string
   marketplaceRepo?: string
   marketplaceJsonName?: string
+  stars?: number
 }
 
 interface PluginMetadata {
@@ -234,6 +235,24 @@ const badges = computed<Badge[]>(() => {
       label: 'MCP',
       color: 'primary',
       title: 'Includes MCP Server',
+    })
+  }
+
+  // GitHub stars badge
+  if (props.plugin.stars !== null && props.plugin.stars !== undefined && props.plugin.stars >= 0) {
+    const formatStars = (count: number): string => {
+      if (count >= 1000) {
+        return `${(count / 1000).toFixed(1)}k`
+      }
+      return count.toString()
+    }
+
+    badgeList.push({
+      key: 'stars',
+      icon: 'i-heroicons-star',
+      label: formatStars(props.plugin.stars),
+      color: 'warning',
+      title: `${props.plugin.stars.toLocaleString()} GitHub stars`,
     })
   }
 

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -35,8 +35,13 @@ const targetPluginName = computed(() => {
   return undefined
 })
 
-// Fetch marketplace data from API
-const { data: apiData, pending, error } = await useFetch<MarketplaceAPIResponse>('/api/marketplaces')
+// Fetch marketplace data using useAsyncData for SSR/ISR support
+// useAsyncData automatically handles server-side fetching and client hydration
+// Data is fetched on the server, cached, and passed to the client without re-fetching
+const { data: apiData, pending, error } = await useAsyncData(
+  'marketplaces',
+  () => $fetch<MarketplaceAPIResponse>('/api/marketplaces'),
+)
 
 // Aggregate all plugins from all marketplaces
 const allPlugins = computed(() => {

--- a/apps/web/app/types/marketplace.ts
+++ b/apps/web/app/types/marketplace.ts
@@ -23,6 +23,7 @@ export interface Plugin {
   author?: string | { name?: string, email?: string }
   category?: string
   source: PluginSource | string
+  stars?: number
 }
 
 export interface Marketplace {

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -7,6 +7,14 @@ export default defineNuxtConfig({
     preset: 'vercel',
   },
 
+  // ISR configuration for marketplace data
+  // Page uses server-side data fetching (useAsyncData), so only page ISR is needed
+  // Data is fetched on the server and included in the cached HTML
+  routeRules: {
+    '/': { isr: 3600 }, // Main page with embedded data: revalidate every 1 hour
+    '/api/marketplaces': { isr: 3600 }, // Keep API endpoint cached for direct API access if needed
+  },
+
   modules: [
     '@nuxt/ui',
     '@nuxt/content',

--- a/apps/web/server/utils/github.ts
+++ b/apps/web/server/utils/github.ts
@@ -1,0 +1,99 @@
+/**
+ * GitHub API utilities for fetching repository information
+ */
+
+interface GitHubRepo {
+  stargazers_count: number
+  forks_count: number
+  open_issues_count: number
+  updated_at: string
+}
+
+/**
+ * Extract owner and repo from GitHub URL or repo string
+ * @param source - GitHub URL (https://github.com/owner/repo) or repo string (owner/repo)
+ * @returns Object with owner and repo, or null if invalid
+ */
+export function parseGitHubRepo(source: string): { owner: string, repo: string } | null {
+  try {
+    // Handle URL format: https://github.com/owner/repo
+    if (source.startsWith('http')) {
+      const url = new URL(source)
+      const parts = url.pathname.split('/').filter(Boolean)
+      if (parts.length >= 2) {
+        return { owner: parts[0], repo: parts[1] }
+      }
+    }
+
+    // Handle repo format: owner/repo
+    const parts = source.split('/')
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      return { owner: parts[0], repo: parts[1] }
+    }
+
+    return null
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Fetch GitHub repository star count
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @returns Star count, or null if fetch fails
+ */
+export async function fetchGitHubStars(owner: string, repo: string): Promise<number | null> {
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}`
+
+    // Use GitHub token if available to increase rate limit
+    const headers: HeadersInit = {
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'claude-code-plugins-marketplace',
+    }
+
+    const githubToken = process.env.GITHUB_TOKEN
+    if (githubToken) {
+      headers.Authorization = `token ${githubToken}`
+    }
+
+    const response = await $fetch<GitHubRepo>(url, {
+      headers,
+      // Add timeout to prevent hanging
+      timeout: 5000,
+    })
+
+    return response.stargazers_count
+  }
+  catch (error) {
+    console.warn(`Failed to fetch stars for ${owner}/${repo}:`, error)
+    return null
+  }
+}
+
+/**
+ * Fetch stars for a plugin based on its source
+ * @param source - Plugin source (GitHub URL or repo string)
+ * @returns Star count, or null if fetch fails
+ */
+export async function fetchPluginStars(source: string | { source: string, repo: string }): Promise<number | null> {
+  // Handle object format with repo property
+  if (typeof source === 'object' && source.repo) {
+    const parsed = parseGitHubRepo(source.repo)
+    if (!parsed)
+      return null
+    return fetchGitHubStars(parsed.owner, parsed.repo)
+  }
+
+  // Handle string format
+  if (typeof source === 'string') {
+    const parsed = parseGitHubRepo(source)
+    if (!parsed)
+      return null
+    return fetchGitHubStars(parsed.owner, parsed.repo)
+  }
+
+  return null
+}

--- a/apps/web/server/utils/marketplace-schema.ts
+++ b/apps/web/server/utils/marketplace-schema.ts
@@ -26,6 +26,7 @@ export const pluginSchema = z.object({
   ]).optional(),
   category: z.string().optional(),
   source: pluginSourceSchema,
+  stars: z.number().optional(),
 })
 
 export const marketplaceSchema = z.object({


### PR DESCRIPTION
## Summary

Adds GitHub stars display to the marketplace with ISR caching and intelligent API call optimization.

## Features

- ⭐ **GitHub Stars Badge**: All plugin cards now display repository star counts
- 🚀 **ISR Caching**: 1-hour revalidation reduces API calls and improves performance
- 📊 **Smart Formatting**: Stars displayed as "1.5k" for counts over 1000
- 🎯 **Local Plugin Support**: Local plugins show marketplace repository stars
- ⚡ **Optimized API Calls**: Duplicate calls eliminated with caching

## Technical Changes

### New Files
- `apps/web/server/utils/github.ts` - GitHub API utility functions

### Modified Files
- `apps/web/nuxt.config.ts` - Added ISR route rules
- `apps/web/app/pages/index.vue` - Changed to useAsyncData for SSR
- `apps/web/server/api/marketplaces.get.ts` - Integrated stars fetching with caching
- `apps/web/app/components/PluginCard.vue` - Added stars badge display
- `apps/web/app/types/marketplace.ts` - Added stars field
- `apps/web/server/utils/marketplace-schema.ts` - Updated Zod schema

## Performance Improvements

| Metric | Before | After |
|--------|--------|-------|
| API Calls (per page load) | Many | 1 (cached for 1h) |
| Local plugin duplicate calls | 50+ | 1 per marketplace |
| Rate limit usage | High risk | Minimal |
| Initial page load | Client fetch | Server-side data |

## Example

- **anthropics/claude-code**: 39.1k ⭐
- **pleaseai/spec-kit-plugin**: 1 ⭐

## Configuration

For production, set `GITHUB_TOKEN` environment variable in Vercel to increase rate limit from 60 to 5000 requests/hour.

## Test plan

- [x] Stars display correctly for GitHub-sourced plugins
- [x] Stars display correctly for local plugins (using marketplace repo)
- [x] Duplicate API calls eliminated
- [x] ISR caching works correctly
- [x] Rate limit handled gracefully
- [x] UI displays formatted star counts with tooltips