### PR TITLE
fix: update nuxt-ui plugin to use pleaseai fork

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
       "description": "Nuxt UI component library with comprehensive documentation, templates, and examples via MCP server",
       "source": {
         "source": "github",
-        "repo": "nuxt/ui"
+        "repo": "pleaseai/nuxt-ui"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Update nuxt-ui plugin repository reference from `nuxt/ui` to `pleaseai/nuxt-ui`

## Reason
The upstream PR to add Claude Code plugin configuration has not been merged yet. This change ensures users install the forked version that includes the necessary plugin setup.

## Changes
- Modified `.claude-plugin/marketplace.json` to point to `pleaseai/nuxt-ui`

## Test plan
- [ ] Verify plugin installation works: `/plugin install nuxt-ui@pleaseai`
- [ ] Confirm MCP server tools are available after installation