### PR TITLE
chore: remove external marketplace sources

### DIFF
--- a/apps/web/server/marketplace-sources.json
+++ b/apps/web/server/marketplace-sources.json
@@ -7,38 +7,6 @@
       "repo": "pleaseai/claude-code-plugins",
       "enabled": true,
       "priority": 1
-    },
-    {
-      "name": "claude-code-plugins",
-      "description": "Bundled plugins for Claude Code including Agent SDK development tools, PR review toolkit, and commit workflows",
-      "url": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude-plugin/marketplace.json",
-      "repo": "anthropics/claude-code",
-      "enabled": true,
-      "priority": 2
-    },
-    {
-      "name": "anthropic-agent-skills",
-      "description": "Anthropic example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
-      "url": "https://raw.githubusercontent.com/anthropics/skills/main/.claude-plugin/marketplace.json",
-      "repo": "anthropics/skills",
-      "enabled": true,
-      "priority": 3
-    },
-    {
-      "name": "claude-code-workflows",
-      "description": "Production-ready workflow orchestration with 62 focused plugins, 84 specialized agents, and 42 tools - optimized for granular installation and minimal token usage",
-      "url": "https://raw.githubusercontent.com/wshobson/agents/main/.claude-plugin/marketplace.json",
-      "repo": "wshobson/agents",
-      "enabled": true,
-      "priority": 4
-    },
-    {
-      "name": "claude-code-templates",
-      "description": "Ready-to-use Claude Code templates organized by workflow",
-      "url": "https://raw.githubusercontent.com/davila7/claude-code-templates/main/.claude-plugin/marketplace.json",
-      "repo": "davila7/claude-code-templates",
-      "enabled": true,
-      "priority": 5
     }
   ]
 }


### PR DESCRIPTION
## Summary

Simplify marketplace configuration by removing 4 external marketplace sources, keeping only the primary pleaseai source.

## Changes

- Remove `anthropics/claude-code` (claude-code-plugins)
- Remove `anthropics/skills` (anthropic-agent-skills)
- Remove `wshobson/agents` (claude-code-workflows)
- Remove `davila7/claude-code-templates` (claude-code-templates)
- Keep only `pleaseai/claude-code-plugins` as the single marketplace source

## Rationale

This change focuses the marketplace on the primary pleaseai plugin source, simplifying maintenance and reducing external dependencies.

## Test Plan

- [x] Verify `marketplace-sources.json` has valid JSON syntax
- [ ] Verify marketplace web app loads successfully
- [ ] Verify plugins from pleaseai source are still accessible