### PR TITLE
chore: bump antfu plugin versions to 1.1.0

### DIFF
--- a/plugins/antfu/.claude-plugin/plugin.json
+++ b/plugins/antfu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antfu",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Anthony Fu's opinionated tooling and conventions for JavaScript/TypeScript projects",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/nuxt/.claude-plugin/plugin.json
+++ b/plugins/nuxt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Nuxt full-stack Vue framework with SSR, auto-imports, and file-based routing. Use when working with Nuxt apps, server routes, useFetch, middleware, or hybrid rendering.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/pinia/.claude-plugin/plugin.json
+++ b/plugins/pinia/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pinia official Vue state management library, type-safe and extensible. Use when defining stores, working with state/getters/actions, or implementing store patterns in Vue apps.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/pnpm/.claude-plugin/plugin.json
+++ b/plugins/pnpm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Node.js package manager with strict dependency resolution. Use when running pnpm specific commands, configuring workspaces, or managing dependencies with catalogs, patches, or overrides.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/slidev/.claude-plugin/plugin.json
+++ b/plugins/slidev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Create and present web-based slides for developers using Markdown, Vue components, code highlighting, and animations",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/tsdown/.claude-plugin/plugin.json
+++ b/plugins/tsdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdown",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Bundle TypeScript and JavaScript libraries with blazing-fast speed powered by Rolldown",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/turborepo/.claude-plugin/plugin.json
+++ b/plugins/turborepo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "turborepo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Turborepo monorepo build system guidance for task pipelines, caching, CI optimization, and the turbo CLI",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/unocss/.claude-plugin/plugin.json
+++ b/plugins/unocss/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unocss",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "UnoCSS instant atomic CSS engine, superset of Tailwind CSS. Use when configuring UnoCSS, writing utility rules, shortcuts, or working with presets like Wind, Icons, Attributify.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/vite/.claude-plugin/plugin.json
+++ b/plugins/vite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Vite build tool configuration, plugin API, SSR, and Vite 8 Rolldown migration. Use when working with Vite projects, vite.config.ts, Vite plugins, or building libraries/SSR apps with Vite.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/vitepress/.claude-plugin/plugin.json
+++ b/plugins/vitepress/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "VitePress static site generator powered by Vite and Vue. Use when building documentation sites, configuring themes, or writing Markdown with Vue components.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/vitest/.claude-plugin/plugin.json
+++ b/plugins/vitest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Vitest fast unit testing framework powered by Vite with Jest-compatible API. Use when writing tests, mocking, configuring coverage, or working with test filtering and fixtures.",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/vue/.claude-plugin/plugin.json
+++ b/plugins/vue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vue",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Vue 3 core, best practices, router patterns, and testing",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/vueuse/.claude-plugin/plugin.json
+++ b/plugins/vueuse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vueuse",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Apply VueUse composables where appropriate to build concise, maintainable Vue.js / Nuxt features",
   "author": {
     "name": "Anthony Fu",

--- a/plugins/web-design/.claude-plugin/plugin.json
+++ b/plugins/web-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-design",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Review UI code for Web Interface Guidelines compliance",
   "author": {
     "name": "Anthony Fu",

--- a/scripts/generate-antfu-plugins.ts
+++ b/scripts/generate-antfu-plugins.ts
@@ -142,7 +142,7 @@ for (const plugin of pluginList) {
   // Write plugin.json
   const manifest = {
     name: plugin,
-    version: "1.0.0",
+    version: "1.1.0",
     description: desc,
     author: {
       name: "Anthony Fu",


### PR DESCRIPTION
## Summary

Bump version from 1.0.0 to 1.1.0 for all 14 antfu-related plugins.

## Changes

- Updated version in `scripts/generate-antfu-plugins.ts` (generator script)
- Updated version in all 14 plugin.json files:
  - plugins/antfu/.claude-plugin/plugin.json
  - plugins/nuxt/.claude-plugin/plugin.json
  - plugins/pinia/.claude-plugin/plugin.json
  - plugins/pnpm/.claude-plugin/plugin.json
  - plugins/slidev/.claude-plugin/plugin.json
  - plugins/tsdown/.claude-plugin/plugin.json
  - plugins/turborepo/.claude-plugin/plugin.json
  - plugins/unocss/.claude-plugin/plugin.json
  - plugins/vite/.claude-plugin/plugin.json
  - plugins/vitepress/.claude-plugin/plugin.json
  - plugins/vitest/.claude-plugin/plugin.json
  - plugins/vue/.claude-plugin/plugin.json
  - plugins/vueuse/.claude-plugin/plugin.json
  - plugins/web-design/.claude-plugin/plugin.json

## Test Plan

- [x] Version bumped in generator script
- [x] All plugin.json files updated consistently
- [x] No other files modified (tmp/ directory excluded)