### PR TITLE
fix(gatekeeper): remove duplicate hooks reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ claude-code-plugins/
 │   ├── mcp-neo4j/             # Neo4j MCP server
 │   ├── chrome-devtools-mcp/   # Chrome DevTools automation
 │   └── context7/              # Up-to-date library documentation
+├── plugins/                    # Built-in plugins (maintained in this repo)
+│   ├── gatekeeper/            # Auto-approve safe commands
+│   ├── plugin-dev/            # Plugin development tools
+│   └── ...                    # Framework-specific plugins (antfu, nuxt, vue, etc.)
 ├── apps/web/                  # Marketplace website
 ├── .claude-plugin/            # Marketplace configuration
 └── hooks/                     # Session hooks
@@ -169,7 +173,6 @@ When integrating an existing MCP server or tool as a Claude Code plugin:
      "repository": "https://github.com/org/tool-repo",
      "license": "MIT",
      "keywords": ["keyword1", "keyword2"],
-     "hooks": "./hooks/hooks.json",
      "mcpServers": {
        "server-name": {
          "command": "npx",
@@ -321,6 +324,10 @@ When integrating an existing MCP server or tool as a Claude Code plugin:
 - `.claude-plugin/plugin.json` must be at this exact path
 - `hooks/`, `commands/`, `agents/` directories at plugin root
 - Use `${CLAUDE_PLUGIN_ROOT}` for all path references
+
+**Hooks Auto-Loading:**
+- `hooks/hooks.json` is auto-loaded by Claude Code — do NOT reference it in `plugin.json`'s `hooks` field
+- `plugin.json`'s `hooks` field should only reference ADDITIONAL hook files beyond the standard path
 
 **Documentation:**
 - Include Claude Code installation in plugin README

--- a/plugins/gatekeeper/.claude-plugin/plugin.json
+++ b/plugins/gatekeeper/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "repository": "https://github.com/pleaseai/claude-code-plugins",
   "license": "MIT",
-  "keywords": ["security", "permissions", "gatekeeper", "hook"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["security", "permissions", "gatekeeper", "hook"]
 }


### PR DESCRIPTION
## Summary

Fix duplicate hooks warning in gatekeeper plugin by removing redundant hooks reference from plugin.json. Claude Code automatically loads `hooks/hooks.json`, so the explicit reference in plugin.json was causing a duplicate hooks warning.

## Changes

- **plugins/gatekeeper/.claude-plugin/plugin.json**: Remove `"hooks": "./hooks/hooks.json"` line
- **CLAUDE.md**: 
  - Add `plugins/` directory to repository structure
  - Document hooks auto-loading behavior in best practices
  - Remove hooks field from plugin.json example (anti-pattern)

## Why This Fix

Claude Code's plugin system automatically loads `hooks/hooks.json` from the plugin root directory. Having an explicit reference in `plugin.json` causes the hooks to be registered twice, resulting in the warning:

```
Warning: Duplicate hooks detected in plugin 'gatekeeper'
```

## Testing

- [x] Verified hooks/hooks.json still exists and is valid
- [x] No other plugins affected (only gatekeeper had this pattern)
- [x] Documentation updated to prevent this pattern in future plugins

## Related Documentation

- Claude Code Plugin Documentation: https://docs.anthropic.com/en/docs/claude-code/plugins
- Plugin Hooks Reference: https://docs.anthropic.com/en/docs/claude-code/hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate hooks reference in the Gatekeeper plugin to stop the “Duplicate hooks detected” warning. Also updated CLAUDE.md to document hooks auto-loading and remove the hooks field from the plugin.json example.

- **Bug Fixes**
  - Gatekeeper: removed "hooks": "./hooks/hooks.json" since Claude Code auto-loads hooks/hooks.json.

<sup>Written for commit b6723ee5118a5ff4cedadbd8b63d1047b525a671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

