### PR TITLE
chore: sync gatekeeper plugin.json version on release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,14 @@
     "plugins/gatekeeper": {
       "release-type": "node",
       "package-name": "gatekeeper",
-      "component": "gatekeeper"
+      "component": "gatekeeper",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

- Adds `extra-files` configuration to the gatekeeper package entry in `release-please-config.json`
- Ensures that `release-please` also updates the `version` field in `.claude-plugin/plugin.json` (via JSONPath `$.version`) when a new release is cut

## Test Plan

- [ ] Verify release-please dry run picks up the `plugin.json` file as a version bump target
- [ ] Confirm no other packages are affected by this change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure release-please to bump .claude-plugin/plugin.json’s version for gatekeeper releases using extra-files (JSONPath $.version). This keeps the plugin manifest in sync with the gatekeeper package version and removes manual updates.

<sup>Written for commit 8cab69cd3c2bd87aa24015b3667c65cfbbb14aa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

