### PR TITLE
feat(nuxt): add nuxt remote MCP server configuration

### DIFF
--- a/plugins/nuxt/.claude-plugin/plugin.json
+++ b/plugins/nuxt/.claude-plugin/plugin.json
@@ -14,5 +14,11 @@
     "vue",
     "ssr",
     "antfu"
-  ]
+  ],
+  "mcpServers": {
+    "nuxt-remote": {
+      "type": "http",
+      "url": "https://nuxt.com/mcp"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add official Nuxt remote MCP server (`https://nuxt.com/mcp`) to the Nuxt plugin configuration
- Uses HTTP transport type for the MCP server connection

## Changes

- `plugins/nuxt/.claude-plugin/plugin.json`: Added `mcpServers` field with `nuxt-remote` entry pointing to `https://nuxt.com/mcp`

## Test Plan

- [ ] Verify Nuxt plugin loads with the new MCP server configuration
- [ ] Confirm HTTP-based MCP connection to `https://nuxt.com/mcp` is accessible
- [ ] Check that existing Nuxt plugin functionality is unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the official Nuxt remote MCP server to the Nuxt plugin configuration. Enables an HTTP-based connection to https://nuxt.com/mcp.

- **New Features**
  - Added mcpServers.nuxt-remote in plugins/nuxt/.claude-plugin/plugin.json (type: http, url: https://nuxt.com/mcp).

<sup>Written for commit 03525a41c06b32a8733deefc6d218a41a9438c95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

