### PR TITLE
chore(husky): add pre-commit hook to protect main branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
+remote="$(git remote get-url origin 2>/dev/null || echo '')"
 
-if [ "$branch" = "main" ]; then
+if [ "$branch" = "main" ] && echo "$remote" | grep -q "pleaseai/claude-code-plugins"; then
   echo ""
   echo "ERROR: Direct commits to the 'main' branch are not allowed."
   echo ""


### PR DESCRIPTION
## Summary

- Add `.husky/pre-commit` hook that blocks direct commits to the `main` branch
- Displays a clear error message with instructions to create a branch and open a PR
- Exits with code 1 to abort the commit; all other branches are unaffected

## Test plan

- [ ] Attempt `git commit --allow-empty -m "test"` on `main` → should be blocked with error message
- [ ] Attempt commit on any feature branch → should proceed normally
- [ ] Verify hook file is executable (`ls -la .husky/pre-commit`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Husky pre-commit hook that blocks direct commits to the main branch on the upstream repo and shows steps to create a branch and open a PR. Forks and other branches are unaffected.

<sup>Written for commit 36e13dbae9ceb9fe4d1ca5eeb9a81abcd59d30f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

