### PR TITLE
ci: use node-version-file and auto-detect bun version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.2.22'
 
       # ESLint 캐시 복원
       - name: Restore ESLint cache
@@ -64,12 +62,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.2.22'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -89,12 +85,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.2.22'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/pleaseai/claude-code-plugins/issues"
   },
   "homepage": "https://github.com/pleaseai/claude-code-plugins#readme",
-  "packageManager": "bun@1.3.7",
+  "packageManager": "bun@1.3.10",
   "engines": {
     "node": "22.x"
   },


### PR DESCRIPTION
## Summary

- Replace hardcoded `node-version: '22'` with `node-version-file: '.nvmrc'` in all CI jobs so the Node.js version is managed from a single source (`.nvmrc`)
- Remove explicit `bun-version: '1.2.22'` from `oven-sh/setup-bun` — it now auto-detects the version from `packageManager` field in `package.json`
- Update `packageManager` in `package.json` from `bun@1.3.7` to `bun@1.3.10`

## Test plan

- [ ] Verify CI jobs (lint, build, typecheck) pass on this PR
- [ ] Confirm Node.js version matches `.nvmrc` (`v22`) in CI logs
- [ ] Confirm Bun version matches `package.json` `packageManager` (`bun@1.3.10`) in CI logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched CI to read Node.js from .nvmrc and let setup-bun auto-detect Bun from package.json, keeping versions in one place and consistent. Updated packageManager to bun@1.3.10.

- **Refactors**
  - Use actions/setup-node with node-version-file: ".nvmrc".
  - Remove explicit bun-version from oven-sh/setup-bun to auto-detect.

- **Dependencies**
  - Bump packageManager: bun@1.3.7 → bun@1.3.10.

<sup>Written for commit 32c1a7bc8742e7a276001e258b326f75fb1ae4fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

