### PR TITLE
docs(worktree): add README

### DIFF
--- a/plugins/worktree/README.md
+++ b/plugins/worktree/README.md
@@ -51,12 +51,20 @@ The hook uses two strategies:
 
 ## Installation
 
-```sh
-# Interactive (inside Claude Code session)
-/plugin marketplace add pleaseai/claude-code-plugins
-/plugin install worktree@pleaseai
+1. Start the interactive `claude` shell:
+   ```sh
+   claude
+   ```
 
-# Direct (with optional scope: user | project | local)
+2. Within the shell, add the marketplace and install the plugin:
+   ```console
+   /plugin marketplace add pleaseai/claude-code-plugins
+   /plugin install worktree@pleaseai
+   ```
+
+Alternatively, install directly from the command line (with optional `--scope`: `user` | `project` | `local`):
+
+```sh
 claude plugin marketplace add pleaseai/claude-code-plugins --scope project
 claude plugin install worktree@pleaseai --scope project
 ```
@@ -72,8 +80,7 @@ bun test
 
 ```bash
 # SessionStart — worktree detected
-echo '{"cwd":"/path/to/project/.claude/worktrees/my-branch"}' \
-  | bun run hooks/worktree-context.ts
+echo '{"cwd":"/path/to/project/.claude/worktrees/my-branch"}' | bun run hooks/worktree-context.ts
 
 # PreToolUse — path denied (parent project access)
 echo '{


### PR DESCRIPTION
## Summary

- Add `plugins/worktree/README.md` with plugin documentation
- Covers overview, architecture diagram, worktree detection strategies, tool coverage scope, installation instructions, and manual hook testing examples

## Test plan

- [ ] Review README content for accuracy
- [ ] Verify installation instructions work as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add plugins/worktree/README.md documenting the Worktree plugin, how it isolates git worktrees, and how it blocks parent project access.

Clarifies installation (separate interactive vs direct CLI with --scope) and cleans hook test examples; includes overview, hook flow, detection strategies, tool coverage, development tests, and Bash caveats.

<sup>Written for commit 6f206926aee00ae3729f399c714d6a4131b54b58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

