### PR TITLE
feat(hooks): auto-allow Read for skill reference files

### DIFF
--- a/hooks/allow-skill-references.sh
+++ b/hooks/allow-skill-references.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# PreToolUse hook: auto-allow reading skill reference files
+# Allows Read tool calls targeting ${CLAUDE_PLUGIN_ROOT}/skills/*/references/*.md
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+
+if [ "$tool_name" != "Read" ]; then
+  exit 0
+fi
+
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Normalize to absolute path
+case "$file_path" in
+  /*)
+    abs_path="$file_path"
+    ;;
+  *)
+    abs_path="${CLAUDE_PROJECT_DIR:-$PWD}/${file_path}"
+    ;;
+esac
+
+# Canonicalize path to prevent traversal attacks
+if ! abs_path="$(realpath -m "$abs_path" 2>/dev/null || python3 -c "import pathlib, sys; print(str(pathlib.Path(sys.argv[1]).resolve(strict=False)))" "$abs_path" 2>/dev/null)"; then
+  exit 0
+fi
+
+# Canonicalize plugin root
+plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "$plugin_root" ]; then
+  exit 0
+fi
+
+if ! plugin_root="$(realpath -m "$plugin_root" 2>/dev/null || python3 -c "import pathlib, sys; print(str(pathlib.Path(sys.argv[1]).resolve(strict=False)))" "$plugin_root" 2>/dev/null)"; then
+  exit 0
+fi
+
+plugin_root="${plugin_root%/}"
+
+# Match: <plugin_root>/skills/<skill>/references/<file>.md
+# Require exactly two path components between skills/ and references/
+case "$abs_path" in
+  "${plugin_root}/skills/"*/references/*.md)
+    # Verify no extra path segments between skills/ and references/
+    remainder="${abs_path#${plugin_root}/skills/}"
+    skill_name="${remainder%%/*}"
+    after_skill="${remainder#${skill_name}/}"
+    if [[ "$after_skill" == references/*.md && "$after_skill" != *"/"*"/"* ]]; then
+      echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/agent-browser/hooks/allow-skill-references.sh
+++ b/plugins/agent-browser/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/agent-browser/hooks/hooks.json
+++ b/plugins/agent-browser/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/ai-sdk/hooks/allow-skill-references.sh
+++ b/plugins/ai-sdk/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/ai-sdk/hooks/hooks.json
+++ b/plugins/ai-sdk/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/antfu/hooks/allow-skill-references.sh
+++ b/plugins/antfu/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/antfu/hooks/hooks.json
+++ b/plugins/antfu/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-md-management/hooks/allow-skill-references.sh
+++ b/plugins/claude-md-management/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/claude-md-management/hooks/hooks.json
+++ b/plugins/claude-md-management/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mastra/hooks/allow-skill-references.sh
+++ b/plugins/mastra/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/mastra/hooks/hooks.json
+++ b/plugins/mastra/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/nuxt-ui/hooks/allow-skill-references.sh
+++ b/plugins/nuxt-ui/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/nuxt-ui/hooks/hooks.json
+++ b/plugins/nuxt-ui/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/nuxt/hooks/allow-skill-references.sh
+++ b/plugins/nuxt/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/nuxt/hooks/hooks.json
+++ b/plugins/nuxt/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/pinia/hooks/allow-skill-references.sh
+++ b/plugins/pinia/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/pinia/hooks/hooks.json
+++ b/plugins/pinia/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/pnpm/hooks/allow-skill-references.sh
+++ b/plugins/pnpm/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/pnpm/hooks/hooks.json
+++ b/plugins/pnpm/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/prisma/hooks/allow-skill-references.sh
+++ b/plugins/prisma/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/prisma/hooks/hooks.json
+++ b/plugins/prisma/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/slidev/hooks/allow-skill-references.sh
+++ b/plugins/slidev/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/slidev/hooks/hooks.json
+++ b/plugins/slidev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/supabase/hooks/allow-skill-references.sh
+++ b/plugins/supabase/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/supabase/hooks/hooks.json
+++ b/plugins/supabase/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/unocss/hooks/allow-skill-references.sh
+++ b/plugins/unocss/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/unocss/hooks/hooks.json
+++ b/plugins/unocss/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vite/hooks/allow-skill-references.sh
+++ b/plugins/vite/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/vite/hooks/hooks.json
+++ b/plugins/vite/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vitepress/hooks/allow-skill-references.sh
+++ b/plugins/vitepress/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/vitepress/hooks/hooks.json
+++ b/plugins/vitepress/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vitest/hooks/allow-skill-references.sh
+++ b/plugins/vitest/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/vitest/hooks/hooks.json
+++ b/plugins/vitest/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vue/hooks/allow-skill-references.sh
+++ b/plugins/vue/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/vue/hooks/hooks.json
+++ b/plugins/vue/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vueuse/hooks/allow-skill-references.sh
+++ b/plugins/vueuse/hooks/allow-skill-references.sh
@@ -1,0 +1,1 @@
+../../../hooks/allow-skill-references.sh

--- a/plugins/vueuse/hooks/hooks.json
+++ b/plugins/vueuse/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/allow-skill-references.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `hooks/allow-skill-references.sh`: a common PreToolUse hook script that automatically grants `allow` permission when Claude reads `skills/*/references/*.md` files under a plugin root, eliminating repeated permission prompts during skill reference loading
- Add `plugins/*/hooks/hooks.json` with a `PreToolUse` entry (`matcher: Read`) for 18 plugins that contain `skills/*/references/` directories
- Add `plugins/*/hooks/allow-skill-references.sh` symlinks pointing to the common script

**Plugins updated:** agent-browser, ai-sdk, antfu, claude-md-management, mastra, nuxt, nuxt-ui, pinia, pnpm, prisma, slidev, supabase, unocss, vite, vitepress, vitest, vue, vueuse

## How it works

The hook script:
1. Reads `tool_name` and `tool_input.file_path` from stdin JSON
2. Exits silently for non-`Read` tools
3. Canonicalizes the path (prevents traversal attacks)
4. Matches against `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/<file>.md`
5. Outputs `{"hookSpecificOutput":{"permissionDecision":"allow"}}` on match

## Test plan

- [x] Matching path → outputs `allow` decision
- [x] Non-matching path → silent exit 0
- [x] Non-Read tool → silent exit 0
- [x] Path traversal attempt → silent exit 0 (canonicalization prevents bypass)
- [x] All 18 `hooks.json` files pass `jq` validity check
- [x] All symlinks resolve to the correct common script

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-approve Read tool calls for skill reference files under each plugin to remove repeated permission prompts when loading skills. Adds a safe, common PreToolUse hook with path canonicalization.

- **New Features**
  - Added hooks/allow-skill-references.sh: a shared PreToolUse hook that canonicalizes paths and auto-allows reads of ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/*.md.
  - Added hooks.json entries (matcher: Read) for 18 plugins that have skill references.
  - Symlinked the hook into each plugin’s hooks directory.

- **Migration**
  - No action needed; the hook only affects Read tool calls.
  - Ensure CLAUDE_PLUGIN_ROOT is set correctly for plugin paths.

<sup>Written for commit 14c4c1ef82720ac2a2f136979d79d2c6017574ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

