### PR TITLE
feat(docus): add docus plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -388,6 +388,14 @@
       "keywords": ["chat-sdk", "chatbot", "slack", "teams", "discord", "linear", "github"],
       "tags": ["framework", "chatbot"],
       "source": "./plugins/chat-sdk"
+    },
+    {
+      "name": "docus",
+      "description": "Write beautiful documentations with Nuxt and Markdown.",
+      "category": "framework",
+      "keywords": ["docus", "nuxt", "documentation", "markdown", "nuxt-content"],
+      "tags": ["framework", "docs"],
+      "source": "./plugins/docus"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ Build multi-platform chat bots with Chat SDK — unified TypeScript SDK for Slac
 
 **Install:** `/plugin install chat-sdk@pleaseai` | **Source:** [plugins/chat-sdk](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/chat-sdk)
 
+#### Docus
+Write beautiful documentations with Nuxt and Markdown.
+
+**Install:** `/plugin install docus@pleaseai` | **Source:** [plugins/docus](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/docus)
+
 ## Installation
 
 ### Add This Marketplace
@@ -277,6 +282,7 @@ Once the marketplace is added, install any plugin with:
 /plugin install worktree@pleaseai
 /plugin install markitdown@pleaseai
 /plugin install chat-sdk@pleaseai
+/plugin install docus@pleaseai
 ```
 
 ## What Are Claude Code Plugins?

--- a/plugins/docus/.agents/skills/create-docs/SKILL.md
+++ b/plugins/docus/.agents/skills/create-docs/SKILL.md
@@ -1,0 +1,499 @@
+---
+name: create-docs
+description: |
+  Create complete documentation sites for projects. Use when asked to:
+  "create docs", "add documentation", "setup docs site", "generate docs",
+  "document my project", "write docs", "initialize documentation",
+  "add a docs folder", "create a docs website". Generates Docus-based sites
+  with search, dark mode, MCP server, and llms.txt integration.
+---
+
+# Create Docs
+
+Generate a complete, production-ready documentation site for any project.
+
+## Workflow
+
+1. **Analyze** - Detect package manager, monorepo structure, read context
+2. **Initialize** - Create docs directory with correct setup
+3. **Generate** - Write documentation pages using templates
+4. **Configure** - Set up AI integration (MCP, llms.txt)
+5. **Finalize** - Provide next steps with correct commands
+
+---
+
+## Package Manager Reference
+
+Detect from lock files, default to npm if none found:
+
+| Lock File | PM | Install | Run | Add |
+|-----------|------|---------|-----|-----|
+| `pnpm-lock.yaml` | pnpm | `pnpm install` | `pnpm run` | `pnpm add` |
+| `package-lock.json` | npm | `npm install` | `npm run` | `npm install` |
+| `yarn.lock` | yarn | `yarn install` | `yarn` | `yarn add` |
+| `bun.lockb` | bun | `bun install` | `bun run` | `bun add` |
+
+Use `[pm]` as placeholder in commands below.
+
+---
+
+## Step 1: Analyze Project
+
+### Detect Project Structure
+
+```
+Check for:
+├── pnpm-workspace.yaml   → pnpm monorepo
+├── turbo.json            → Turborepo monorepo
+├── lerna.json            → Lerna monorepo
+├── nx.json               → Nx monorepo
+├── apps/                 → Apps directory (monorepo)
+├── packages/             → Packages directory (monorepo)
+├── docs/                 → Existing docs (avoid overwriting)
+├── README.md             → Main documentation source
+└── src/ or lib/          → Source code location
+```
+
+### Determine Docs Location
+
+| Project Type | Target Directory | Workspace Entry |
+|--------------|------------------|-----------------|
+| Standard project | `./docs` | N/A |
+| Monorepo with `apps/` | `./apps/docs` | `apps/docs` |
+| Monorepo with `packages/` | `./docs` | `docs` |
+| Existing `docs/` folder | Ask user or `./documentation` | — |
+
+### Read Context Files
+
+| File | Extract |
+|------|---------|
+| `README.md` | Project name, description, features, usage examples |
+| `package.json` | Name, description, dependencies, repository URL |
+| `src/` or `lib/` | Exported functions, composables for API docs |
+
+### Detect i18n Requirement
+
+Check if project needs multi-language docs:
+
+| Indicator | Action |
+|-----------|--------|
+| `@nuxtjs/i18n` in dependencies | Use i18n template |
+| `locales/` or `i18n/` folder exists | Use i18n template |
+| Multiple language README files | Use i18n template |
+| User explicitly mentions multiple languages | Use i18n template |
+| None of the above | Use default template |
+
+---
+
+## Step 2: Initialize Docs
+
+### Create Directory Structure
+
+**Default template:**
+
+```
+[docs-location]/
+├── app/                            # Optional: for customization
+│   ├── app.config.ts
+│   ├── components/
+│   ├── layouts/
+│   └── pages/
+├── content/
+│   ├── index.md
+│   └── 1.getting-started/
+│       ├── .navigation.yml
+│       └── 1.introduction.md
+├── public/
+│   └── favicon.ico
+├── package.json
+└── .gitignore
+```
+
+**i18n template** (if multi-language detected):
+
+```
+[docs-location]/
+├── app/
+│   └── app.config.ts
+├── content/
+│   ├── en/
+│   │   ├── index.md
+│   │   └── 1.getting-started/
+│   │       ├── .navigation.yml
+│   │       └── 1.introduction.md
+│   └── fr/                         # Or other detected languages
+│       ├── index.md
+│       └── 1.getting-started/
+│           ├── .navigation.yml
+│           └── 1.introduction.md
+├── nuxt.config.ts                  # Required for i18n config
+├── public/
+│   └── favicon.ico
+├── package.json
+└── .gitignore
+```
+
+### Create package.json
+
+**Default:**
+
+```json
+{
+  "name": "[project-name]-docs",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev --extends docus",
+    "build": "nuxt build --extends docus",
+    "generate": "nuxt generate --extends docus",
+    "preview": "nuxt preview --extends docus"
+  },
+  "dependencies": {
+    "docus": "latest",
+    "better-sqlite3": "^12.5.0",
+    "nuxt": "^4.2.2"
+  }
+}
+```
+
+**i18n** (add `@nuxtjs/i18n`):
+
+```json
+{
+  "name": "[project-name]-docs",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev --extends docus",
+    "build": "nuxt build --extends docus",
+    "generate": "nuxt generate --extends docus",
+    "preview": "nuxt preview --extends docus"
+  },
+  "dependencies": {
+    "@nuxtjs/i18n": "^10.2.1",
+    "docus": "latest",
+    "better-sqlite3": "^12.5.0",
+    "nuxt": "^4.2.2"
+  }
+}
+```
+
+### Create nuxt.config.ts (i18n only)
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    locales: [
+      { code: 'en', language: 'en-US', name: 'English' },
+      { code: 'fr', language: 'fr-FR', name: 'Français' }
+    ],
+    defaultLocale: 'en'
+  }
+})
+```
+
+### Create .gitignore
+
+```
+node_modules
+.nuxt
+.output
+.data
+dist
+```
+
+### Update Monorepo Configuration (if applicable)
+
+#### pnpm Monorepo
+
+1. Add docs to workspace and configure `onlyBuiltDependencies` (required for better-sqlite3):
+
+```yaml [pnpm-workspace.yaml]
+packages:
+  - 'apps/*'
+  - 'docs'
+
+onlyBuiltDependencies:
+  - better-sqlite3
+```
+
+2. Add dev script to root package.json:
+
+```json [package.json]
+{
+  "scripts": {
+    "docs:dev": "pnpm run --filter [docs-package-name] dev"
+  }
+}
+```
+
+Or with directory path:
+
+```json [package.json]
+{
+  "scripts": {
+    "docs:dev": "cd docs && pnpm dev"
+  }
+}
+```
+
+#### npm/yarn Monorepo
+
+```json [package.json]
+{
+  "workspaces": ["apps/*", "docs"],
+  "scripts": {
+    "docs:dev": "npm run dev --workspace=docs"
+  }
+}
+```
+
+---
+
+## Step 3: Generate Documentation
+
+Use templates from [references/templates.md](references/templates.md).
+
+**CRITICAL: MDC Component Naming**
+
+All Nuxt UI components in MDC must use the `u-` prefix:
+
+| Correct | Wrong |
+|---------|-------|
+| `::u-page-hero` | `::page-hero` |
+| `::u-page-section` | `::page-section` |
+| `:::u-page-feature` | `:::page-feature` |
+| `:::u-button` | `:::button` |
+| `::::u-page-card` | `::::page-card` |
+
+Without the `u-` prefix, Vue will fail to resolve the components.
+
+### Documentation Structure
+
+```
+content/
+├── index.md                        # Landing page
+├── 1.getting-started/
+│   ├── .navigation.yml
+│   ├── 1.introduction.md
+│   └── 2.installation.md
+├── 2.guide/
+│   ├── .navigation.yml
+│   ├── 1.configuration.md
+│   ├── 2.authentication.md
+│   └── 3.deployment.md
+└── 3.api/                          # If applicable
+    ├── .navigation.yml
+    └── 1.reference.md
+```
+
+### Generate Pages
+
+1. **Landing page** (`index.md`) - Hero + features grid
+2. **Introduction** - What & why, use cases
+3. **Installation** - Prerequisites, install commands
+4. **Guide pages** - Feature documentation with action-based H2 headings
+
+For writing style, see [references/writing-guide.md](references/writing-guide.md).
+For MDC components, see [references/mdc-components.md](references/mdc-components.md).
+
+---
+
+## Step 4: Configure AI Integration
+
+Docus automatically includes MCP server (`/mcp`) and llms.txt generation. No configuration needed.
+
+**Do NOT add AI Integration sections to the landing page.** These features work automatically.
+
+Optionally mention in the introduction page:
+
+```markdown
+::note
+This documentation includes AI integration with MCP server and automatic `llms.txt` generation.
+::
+```
+
+### Optional: app.config.ts
+
+```ts [app/app.config.ts]
+export default defineAppConfig({
+  docus: {
+    name: '[Project Name]',
+    description: '[Project description]',
+    url: 'https://[docs-url]',
+    socials: {
+      github: '[org]/[repo]'
+    }
+  }
+})
+```
+
+### Optional: Theme Customization
+
+If the project has a design system or brand colors, customize the docs theme.
+
+#### Custom CSS
+
+Create `app/assets/css/main.css`:
+
+```css [app/assets/css/main.css]
+@import "tailwindcss";
+@import "@nuxt/ui";
+
+@theme {
+  /* Custom font */
+  --font-sans: 'Inter', sans-serif;
+
+  /* Custom container width */
+  --ui-container: 90rem;
+
+  /* Custom primary color (use project brand color) */
+  --color-primary-50: oklch(0.97 0.02 250);
+  --color-primary-500: oklch(0.55 0.2 250);
+  --color-primary-900: oklch(0.25 0.1 250);
+}
+```
+
+#### Extended app.config.ts
+
+```ts [app/app.config.ts]
+export default defineAppConfig({
+  docus: {
+    name: '[Project Name]',
+    description: '[Project description]',
+    url: 'https://[docs-url]',
+    socials: {
+      github: '[org]/[repo]',
+      x: '@[handle]'
+    }
+  },
+  // Customize UI components
+  ui: {
+    colors: {
+      primary: 'emerald',
+      neutral: 'zinc',
+    },
+    pageHero: {
+      slots: {
+        title: 'font-semibold sm:text-6xl'
+      }
+    }
+  }
+})
+```
+
+---
+
+## Step 5: Finalize
+
+Provide instructions using detected package manager.
+
+### Standard Project
+
+```
+Documentation created in [docs-location]
+
+To start:
+
+  cd [docs-location]
+  [pm] install
+  [pm] run dev
+
+Available at http://localhost:3000
+```
+
+### Monorepo
+
+```
+Documentation created in [docs-location]
+
+To start from root:
+
+  [pm] install
+  [pm] run docs:dev
+
+Or from docs directory:
+
+  cd [docs-location]
+  [pm] run dev
+
+Available at http://localhost:3000
+```
+
+### Features Included
+
+- Full-text search
+- Dark mode
+- MCP server for AI tools (/mcp)
+- LLM integration (/llms.txt)
+- SEO optimized
+
+### Next Steps
+
+1. Review generated content
+2. Add more guides in `content/2.guide/`
+3. Customize theme in `app.config.ts`
+4. Deploy to Vercel/Netlify/Cloudflare
+
+### Suggest Follow-ups
+
+After documentation is created, suggest enhancements:
+
+```
+Your documentation is ready!
+
+Would you like me to:
+- **Customize the UI** - Match your brand colors and style
+- **Enhance the landing page** - Add feature cards, code previews, visuals
+- **Add i18n support** - Multi-language documentation
+- **Set up deployment** - Deploy to Vercel, Netlify, or Cloudflare
+
+Let me know what you'd like to improve!
+```
+
+---
+
+## Deployment
+
+| Platform | Command | Output |
+|----------|---------|--------|
+| Vercel | `npx vercel --prod` | Auto-detected |
+| Netlify | `[pm] run generate` | `.output/public` |
+| Cloudflare Pages | `[pm] run generate` | `.output/public` |
+| GitHub Pages | `[pm] run generate` | `.output/public` |
+
+---
+
+## Example: auth-utils
+
+**Detected:** pnpm monorepo, package in packages/
+
+**Generated structure:**
+```
+docs/
+├── content/
+│   ├── index.md
+│   ├── 1.getting-started/
+│   │   ├── .navigation.yml
+│   │   ├── 1.introduction.md
+│   │   └── 2.installation.md
+│   ├── 2.guide/
+│   │   ├── .navigation.yml
+│   │   ├── 1.authentication.md
+│   │   ├── 2.oauth-providers.md
+│   │   └── 3.sessions.md
+│   └── 3.api/
+│       ├── .navigation.yml
+│       └── 1.composables.md
+├── public/
+│   └── favicon.ico
+├── package.json
+└── .gitignore
+```
+
+**Inside `authentication.md`** (action-based H2 headings):
+```markdown
+## Add basic authentication
+## Protect your routes
+## Handle login redirects
+## Customize the session
+```

--- a/plugins/docus/.agents/skills/create-docs/references/mdc-components.md
+++ b/plugins/docus/.agents/skills/create-docs/references/mdc-components.md
@@ -1,0 +1,222 @@
+# MDC Components Reference
+
+Docus uses Nuxt UI components with MDC syntax.
+
+**CRITICAL: Always use the `u-` prefix for Nuxt UI components in MDC:**
+
+```markdown
+::u-page-hero      ✅ Correct (resolves to UPageHero)
+::page-hero        ❌ Wrong (fails to resolve)
+```
+
+---
+
+## Documentation Sources
+
+**Components:**
+- Component list: https://ui.nuxt.com/llms.txt
+- Raw docs: `https://ui.nuxt.com/raw/docs/components/[component].md`
+
+**Typography/Prose:**
+- Introduction: https://ui.nuxt.com/raw/docs/typography.md
+- Headers and text: https://ui.nuxt.com/raw/docs/typography/headers-and-text.md
+- Lists and tables: https://ui.nuxt.com/raw/docs/typography/lists-and-tables.md
+- Code blocks: https://ui.nuxt.com/raw/docs/typography/code-blocks.md
+- Callouts: https://ui.nuxt.com/raw/docs/typography/callouts.md
+- Accordion: https://ui.nuxt.com/raw/docs/typography/accordion.md
+- Tabs: https://ui.nuxt.com/raw/docs/typography/tabs.md
+
+---
+
+## Page Layout Components
+
+Most used components for documentation sites:
+
+| Component | Raw Docs | Use For |
+|-----------|----------|---------|
+| `u-page-hero` | [page-hero.md](https://ui.nuxt.com/raw/docs/components/page-hero.md) | Landing page hero |
+| `u-page-section` | [page-section.md](https://ui.nuxt.com/raw/docs/components/page-section.md) | Content sections |
+| `u-page-grid` | [page-grid.md](https://ui.nuxt.com/raw/docs/components/page-grid.md) | Responsive grid layout |
+| `u-page-card` | [page-card.md](https://ui.nuxt.com/raw/docs/components/page-card.md) | Rich content cards |
+| `u-page-feature` | [page-feature.md](https://ui.nuxt.com/raw/docs/components/page-feature.md) | Feature showcase |
+| `u-page-cta` | [page-cta.md](https://ui.nuxt.com/raw/docs/components/page-cta.md) | Call to action |
+| `u-page-header` | [page-header.md](https://ui.nuxt.com/raw/docs/components/page-header.md) | Page headers |
+
+---
+
+## Quick Syntax Examples
+
+### Hero with Buttons
+
+```markdown
+::u-page-hero
+#title
+Project Name
+
+#description
+Short description
+
+#headline
+  :::u-button{size="sm" to="/changelog" variant="outline"}
+  v1.0.0 →
+  :::
+
+#links
+  :::u-button{color="neutral" size="xl" to="/getting-started" trailing-icon="i-lucide-arrow-right"}
+  Get Started
+  :::
+
+  :::u-button{color="neutral" size="xl" to="https://github.com/..." target="_blank" variant="outline" icon="i-simple-icons-github"}
+  GitHub
+  :::
+::
+```
+
+### Grid with Cards
+
+```markdown
+::u-page-section
+  :::u-page-grid
+    ::::u-page-card{spotlight class="col-span-2 lg:col-span-1" to="/feature"}
+    #title
+    Feature Title
+
+    #description
+    Feature description
+    ::::
+
+    ::::u-page-card{spotlight class="col-span-2"}
+      :::::u-color-mode-image{alt="Screenshot" class="w-full rounded-lg" dark="/images/dark.png" light="/images/light.png"}
+      :::::
+
+    #title
+    Visual Feature
+
+    #description
+    With light/dark mode images
+    ::::
+  :::
+::
+```
+
+### Card with Code Block
+
+```markdown
+::::u-page-card{spotlight class="col-span-2 md:col-span-1"}
+  :::::div{.bg-elevated.rounded-lg.p-3}
+  ```ts [config.ts]
+  export default {
+    option: 'value'
+  }
+  ```
+  :::::
+
+#title
+Configuration
+
+#description
+Easy to configure
+::::
+```
+
+---
+
+## Content Components
+
+| Component | Raw Docs | Use For |
+|-----------|----------|---------|
+| `code-group` | N/A (Nuxt Content) | Multi-tab code blocks |
+| `steps` | N/A (Nuxt Content) | Step-by-step guides |
+| `tabs` | [tabs.md](https://ui.nuxt.com/raw/docs/components/tabs.md) | Tabbed content |
+| `accordion` | [accordion.md](https://ui.nuxt.com/raw/docs/components/accordion.md) | Collapsible sections |
+
+### Code Group (Nuxt Content)
+
+```markdown
+::code-group
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({})
+```
+
+```ts [app.config.ts]
+export default defineAppConfig({})
+```
+::
+```
+
+### Steps (Nuxt Content)
+
+```markdown
+::steps
+### Install
+
+Run the install command.
+
+### Configure
+
+Add your configuration.
+
+### Use
+
+Start using the feature.
+::
+```
+
+---
+
+## Callout Components
+
+| Component | Use For |
+|-----------|---------|
+| `::note` | Additional information |
+| `::tip` | Helpful suggestions |
+| `::warning` | Important cautions |
+| `::caution` | Critical warnings |
+
+```markdown
+::note{title="Custom Title"}
+Additional context here.
+::
+
+::tip
+Pro tip content.
+::
+
+::warning
+Be careful with this.
+::
+
+::caution
+This action cannot be undone.
+::
+```
+
+---
+
+## Images
+
+### Color Mode Image
+
+```markdown
+:u-color-mode-image{alt="Feature" dark="/images/dark.png" light="/images/light.png" class="rounded-lg" width="859" height="400"}
+```
+
+---
+
+## Grid Classes Reference
+
+| Class | Usage |
+|-------|-------|
+| `col-span-2` | Full width |
+| `col-span-2 lg:col-span-1` | Full mobile, half desktop |
+| `col-span-2 md:col-span-1` | Full mobile, half tablet+ |
+
+---
+
+## Full Documentation Reference
+
+- **All components**: https://ui.nuxt.com/llms.txt
+- **Full docs (for LLMs)**: https://ui.nuxt.com/llms-full.txt
+- **Typography introduction**: https://ui.nuxt.com/raw/docs/typography.md
+- **Content integration**: https://ui.nuxt.com/raw/docs/getting-started/integrations/content.md
+- **Theme customization**: https://ui.nuxt.com/raw/docs/getting-started/theme/components.md

--- a/plugins/docus/.agents/skills/create-docs/references/templates.md
+++ b/plugins/docus/.agents/skills/create-docs/references/templates.md
@@ -1,0 +1,362 @@
+# Documentation Templates
+
+Ready-to-use templates for generating documentation pages.
+
+**CRITICAL: All Nuxt UI components must use the `u-` prefix in MDC syntax.**
+- `::u-page-hero` not `::page-hero`
+- `:::u-button` not `:::button`
+- `::::u-page-card` not `::::page-card`
+
+## Table of Contents
+
+- [Landing Page](#landing-page)
+- [Introduction Page](#introduction-page)
+- [Installation Page](#installation-page)
+- [Guide Page](#guide-page)
+- [Navigation YAML](#navigation-yaml)
+
+---
+
+## Landing Page
+
+### Basic Landing Page
+
+```markdown
+---
+seo:
+  title: [Project Name] Documentation
+  description: [Project description]
+---
+
+::u-page-hero
+#title
+[Project Name]
+
+#description
+[Short description - what problem does it solve?]
+
+#links
+  :::u-button
+  ---
+  color: neutral
+  size: xl
+  to: /getting-started/introduction
+  trailing-icon: i-lucide-arrow-right
+  ---
+  Get Started
+  :::
+
+  :::u-button
+  ---
+  color: neutral
+  icon: i-simple-icons-github
+  size: xl
+  to: [GitHub URL]
+  target: _blank
+  variant: outline
+  ---
+  View on GitHub
+  :::
+::
+
+::u-page-section
+#title
+What you can do
+
+#features
+  :::u-page-feature
+  ---
+  icon: [icon]
+  to: /guide/[topic]
+  ---
+  #title
+  [Action verb] [thing]
+
+  #description
+  [One sentence describing the capability]
+  :::
+::
+```
+
+### Advanced Landing Page with Grid Cards
+
+Use `u-page-grid` + `u-page-card` for rich feature showcases:
+
+```markdown
+::u-page-hero
+#title
+[Project Name]
+
+#description
+[Description]
+
+#headline
+  :::u-button
+  ---
+  size: sm
+  to: [changelog-url]
+  variant: outline
+  ---
+  v1.0.0 Released →
+  :::
+
+#links
+  :::u-button
+  ---
+  color: neutral
+  size: xl
+  to: /getting-started
+  trailing-icon: i-lucide-arrow-right
+  ---
+  Get Started
+  :::
+::
+
+::u-page-section
+  :::u-page-grid
+    ::::u-page-card
+    ---
+    spotlight: true
+    class: col-span-2 lg:col-span-1
+    to: /guide/feature-1
+    ---
+    #title
+    Feature One
+
+    #description
+    Description of this feature and what it enables.
+    ::::
+
+    ::::u-page-card
+    ---
+    spotlight: true
+    class: col-span-2
+    ---
+      :::::u-color-mode-image
+      ---
+      alt: Feature screenshot
+      class: w-full rounded-lg
+      dark: /images/feature-dark.png
+      light: /images/feature-light.png
+      ---
+      :::::
+
+    #title
+    Feature with Image
+
+    #description
+    Show off your feature with dark/light mode images.
+    ::::
+  :::
+::
+```
+
+### Card with Code Preview
+
+```markdown
+::::u-page-card
+---
+spotlight: true
+class: col-span-2 md:col-span-1
+---
+  :::::div{.bg-elevated.rounded-lg.p-3.overflow-x-auto}
+  ```ts [config.ts]
+  export default {
+    option: 'value'
+  }
+  ```
+  :::::
+
+#title
+Easy Configuration
+
+#description
+Configure with simple options.
+::::
+```
+
+### Card with Custom Component
+
+Create custom components in `app/components/content/` for interactive demos:
+
+```markdown
+::::u-page-card
+---
+spotlight: true
+class: col-span-2
+---
+:my-custom-demo
+
+#title
+Interactive Demo
+
+#description
+Custom Vue component embedded in card.
+::::
+```
+
+### Grid Layout Classes
+
+| Class | Usage |
+|-------|-------|
+| `col-span-2` | Full width (2 columns) |
+| `col-span-2 lg:col-span-1` | Full on mobile, half on desktop |
+| `col-span-2 md:col-span-1` | Full on mobile, half on tablet+ |
+| `min-h-[450px]` | Minimum height for tall cards |
+
+### Optional Enhancement Patterns
+
+Pick and choose based on project needs:
+
+| Pattern | When to Use |
+|---------|-------------|
+| Code preview in card | Libraries, APIs, CLIs |
+| Feature grid with icons | Projects with multiple features |
+| CTA section | Drive users to action |
+| Before/after code | Projects solving a pain point |
+
+See [mdc-components.md](mdc-components.md) for component syntax.
+See https://ui.nuxt.com/llms.txt for full component reference.
+
+---
+
+## Introduction Page
+
+```markdown
+---
+title: Introduction
+description: Learn what [Project Name] is and when to use it
+navigation:
+  icon: i-lucide-house
+---
+
+[Project Name] helps you [main value proposition].
+
+## What is [Project Name]?
+
+[2-3 sentences explaining the project]
+
+## What you can do
+
+- **[Action 1]** - [Brief description]
+- **[Action 2]** - [Brief description]
+- **[Action 3]** - [Brief description]
+
+## When to use [Project Name]
+
+Use [Project Name] when you need to:
+
+- [Use case 1]
+- [Use case 2]
+- [Use case 3]
+```
+
+---
+
+## Installation Page
+
+Use the detected package manager and show all options:
+
+```markdown
+---
+title: Installation
+description: How to install [Project Name]
+navigation:
+  icon: i-lucide-download
+---
+
+## Prerequisites
+
+[List prerequisites if any]
+
+## How to install
+
+::code-group
+```bash [pnpm]
+pnpm add [package-name]
+```
+
+```bash [npm]
+npm install [package-name]
+```
+
+```bash [yarn]
+yarn add [package-name]
+```
+
+```bash [bun]
+bun add [package-name]
+```
+::
+
+## How to verify installation
+
+[Verification steps]
+```
+
+---
+
+## Guide Page
+
+Use action verbs in H2/H3 headings:
+
+```markdown
+---
+title: [Topic]
+description: [Action verb] [thing] in your [Project Name] app
+navigation:
+  icon: [icon]
+---
+
+[One sentence overview]
+
+## Add basic [feature]
+
+[Explanation]
+
+```[language] [[file-path]]
+[code]
+```
+
+## Configure [feature]
+
+[Explanation]
+
+```[language] [[file-path]]
+[code]
+```
+
+## Handle [edge case]
+
+[Explanation]
+
+## Next steps
+
+- [Link to related guide]
+- [Link to advanced topic]
+```
+
+**Action verbs for H2 headings:** Add, Configure, Create, Set up, Enable, Connect, Handle, Customize, Deploy, Use
+
+---
+
+## Navigation YAML
+
+Each section folder needs a `.navigation.yml`:
+
+```yaml
+title: [Section Title]
+icon: [icon-name]
+```
+
+### Recommended Icons by Section
+
+| Section | Icon |
+|---------|------|
+| Getting Started | `i-lucide-rocket` |
+| Guide | `i-lucide-book-open` |
+| Recipes | `i-lucide-chef-hat` |
+| API | `i-lucide-code` |
+| Examples | `i-lucide-lightbulb` |
+| Configuration | `i-lucide-settings` |
+| Advanced | `i-lucide-sparkles` |

--- a/plugins/docus/.agents/skills/create-docs/references/writing-guide.md
+++ b/plugins/docus/.agents/skills/create-docs/references/writing-guide.md
@@ -1,0 +1,111 @@
+# Writing Guide
+
+Guidelines for writing effective documentation content.
+
+## Table of Contents
+
+- [Action-Based Content](#action-based-content)
+- [Page Titles](#page-titles)
+- [Voice and Tone](#voice-and-tone)
+- [Code Examples](#code-examples)
+
+---
+
+## Action-Based Content
+
+Use action verbs in **H2/H3 headings** to make pages scannable and task-oriented.
+
+| Static heading | Action-based heading |
+|----------------|---------------------|
+| Configuration | Configure your app |
+| Database setup | Connect a database |
+| Route protection | Protect your routes |
+| Session management | Handle user sessions |
+| Error handling | Handle errors gracefully |
+| Deployment | Deploy your application |
+
+### Action Verbs to Use
+
+**Primary:** Add, Configure, Create, Set up, Enable, Connect, Handle, Customize, Deploy, Use
+
+**Secondary:** Build, Implement, Integrate, Install, Define, Write, Run, Test, Debug, Update
+
+---
+
+## Page Titles
+
+Different sections use different title styles:
+
+| Section | Style | Examples |
+|---------|-------|----------|
+| Getting Started | Nouns | Introduction, Installation, Quick Start |
+| Guide | Topics | Authentication, Configuration, Deployment |
+| API | Function/Component names | useSession, fetchData, Button |
+| Recipes | Action phrases | Add Dark Mode, Deploy to Vercel |
+
+The action style lives in the **content headings**, not the page titles or file names.
+
+---
+
+## Voice and Tone
+
+### Do
+
+- Use **active voice** and **present tense**
+- Write in **second person** ("you can", "your project")
+- Be **direct** and **actionable**
+- Start sentences with **action verbs** when possible
+
+### Examples
+
+| Passive/Wordy | Active/Direct |
+|---------------|---------------|
+| The configuration can be set by... | Configure your app by... |
+| It is recommended that you... | We recommend... |
+| The file should be created in... | Create the file in... |
+| Authentication is handled by... | Handle authentication with... |
+
+---
+
+## Code Examples
+
+### File Path Labels
+
+Always add file path labels to code blocks:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  // ...
+})
+```
+
+### Multi-Package Manager Examples
+
+Use `::code-group` and show the **detected package manager first**:
+
+```markdown
+::code-group
+```bash [pnpm]
+pnpm add package-name
+```
+
+```bash [npm]
+npm install package-name
+```
+
+```bash [yarn]
+yarn add package-name
+```
+
+```bash [bun]
+bun add package-name
+```
+::
+```
+
+### Best Practices
+
+- Include **working, copy-pasteable** examples
+- Show **complete** code, not fragments
+- Add **comments** for complex logic
+- Use **realistic** variable names

--- a/plugins/docus/.agents/skills/review-docs/SKILL.md
+++ b/plugins/docus/.agents/skills/review-docs/SKILL.md
@@ -1,0 +1,480 @@
+---
+name: review-docs
+description: |
+  Review documentation for quality, clarity, SEO, and technical correctness.
+  Optimized for Docus/Nuxt Content but works with any Markdown documentation.
+  Use when asked to: "review docs", "check documentation", "audit docs",
+  "validate documentation", "improve docs quality", "analyze documentation",
+  "check my docs", "review my documentation pages", "validate MDC syntax",
+  "check for SEO issues", "analyze doc structure".
+  Provides actionable recommendations categorized by priority (Critical, Important, Nice-to-have).
+---
+
+# Review Docs
+
+Comprehensive documentation review, optimized for Docus/Nuxt Content but compatible with any Markdown documentation.
+
+## Workflow Overview
+
+This skill performs a 5-step review process:
+
+1. **Detect Project Type** - Identify Docus/Nuxt Content vs generic Markdown
+2. **Analyze Structure** - Map documentation organization, locales, sections
+3. **Technical Validation** - Check frontmatter, MDC syntax (if applicable), file naming
+4. **Content Quality Review** - Evaluate clarity, SEO, structure, i18n
+5. **Generate Report** - Provide categorized, actionable recommendations
+
+### Priority Levels
+
+- **Critical** - Blocks deployment or causes errors (missing frontmatter, invalid MDC syntax)
+- **Important** - Significantly impacts UX/SEO (poor metadata, passive voice, unclear headings)
+- **Nice-to-have** - Polish and optimization suggestions (add callouts, improve examples)
+
+### Expectations
+
+This skill generates a **detailed report only**. After reviewing, it offers to fix identified issues if requested.
+
+---
+
+## Step 1: Detect Project Type
+
+**Goal:** Determine if this is a Docus/Nuxt Content project or generic Markdown documentation.
+
+### Detection Indicators
+
+**Check for Docus/Nuxt Content:**
+1. **package.json dependencies:**
+   - `"docus"` - Docus theme
+   - `"@nuxt/content"` - Nuxt Content module
+   - `"@nuxtjs/mdc"` - MDC support
+
+2. **Configuration files:**
+   - `nuxt.config.ts` or `nuxt.config.js` with `@nuxt/content` module
+   - `content.config.ts` - Content collections configuration
+
+3. **Content structure:**
+   - `content/` or `docs/content/` directory
+   - `.navigation.yml` files in subdirectories
+   - MDC syntax in markdown files (`::component-name`)
+
+4. **Project structure:**
+   - Numbered directories (`1.getting-started/`, `2.guide/`)
+   - Frontmatter with `navigation`, `seo` fields
+
+### Project Type Classification
+
+**Type A: Docus/Nuxt Content Project**
+- All Docus-specific validations apply
+- MDC component syntax checks (u- prefix requirement)
+- Nuxt Content frontmatter structure
+- Navigation files (.navigation.yml)
+- Full technical validation
+
+**Type B: Generic Markdown Documentation**
+- Basic Markdown validation only
+- Generic frontmatter (title, description, date, author)
+- Standard Markdown syntax
+- Focus on content quality (SEO, clarity, structure)
+- No Docus-specific technical checks
+
+### Detection Output
+
+After detection, note in the report:
+```
+Project Type: [Docus/Nuxt Content | Generic Markdown]
+Validation Mode: [Full (Docus-specific) | Basic (Markdown-only)]
+```
+
+**Adapt validation steps based on detected type:**
+- **Type A (Docus):** Execute all steps with full validation
+- **Type B (Generic):** Skip Docus-specific checks, focus on content quality
+
+---
+
+## Step 2: Analyze Documentation Structure
+
+### Locate Content Directory
+
+Find the documentation content directory:
+- Check for `docs/content/` (most common)
+- Check for `content/` (root-level)
+- Check for `app/content/` (alternative location)
+
+### Detect Locales
+
+Identify language structure by examining subdirectories:
+
+**Single language** (no locale subdirectories):
+```
+content/
+├── index.md
+├── 1.getting-started/
+└── 2.guide/
+```
+
+**Multi-language** (locale subdirectories):
+```
+content/
+├── en/
+│   ├── index.md
+│   ├── 1.getting-started/
+│   └── 2.guide/
+└── fr/
+    ├── index.md
+    ├── 1.getting-started/
+    └── 2.guide/
+```
+
+**Detection logic:**
+- If immediate subdirectories are 2-letter codes (en, fr, es, de, etc.), it's multi-language
+- If immediate subdirectories are numbered (1.getting-started), it's single language
+
+### List Documentation Sections
+
+Identify all numbered directories within each locale:
+- `1.getting-started/`
+- `2.guide/` or `2.concepts/`
+- `3.api/` or `3.essentials/`
+- `4.advanced/` or `4.ai/`
+
+For each section, note:
+- Section name
+- Presence of `.navigation.yml` file
+- Number of pages (count `.md` files)
+- Page file names
+
+### Verify Core Files
+
+Check for required files:
+- [ ] `index.md` exists at root of each locale
+- [ ] `.navigation.yml` in each section directory
+- [ ] Numbered files follow pattern (`1.introduction.md`, `2.installation.md`)
+
+### Create Structure Map
+
+Document the structure for the report:
+```
+Project: [project-name]
+Locales: [en, fr] (or "Single language")
+Sections:
+  - 1.getting-started: 5 pages, .navigation.yml ✅
+  - 2.guide: 8 pages, .navigation.yml ✅
+  - 3.api: 3 pages, .navigation.yml ❌ (missing)
+```
+
+---
+
+## Step 3: Technical Validation
+
+**Adapt validation based on project type detected in Step 1.**
+
+### For Docus/Nuxt Content Projects (Type A)
+
+Perform full technical validation using [references/technical-checks.md](references/technical-checks.md):
+
+**Validate:**
+1. **Frontmatter structure** - Required: `title`, `description`. Optional: `navigation`, `seo`, `links`
+2. **MDC component syntax** - All Nuxt UI components MUST have `u-` prefix (`::u-page-hero`, `:::u-button`)
+3. **Code block labels** - All code blocks representing files need descriptive labels (` ```vue [App.vue] `, ` ```ts [config.ts] `)
+4. **Code language consistency** - Code examples should match the project's language stack (e.g., TypeScript if the project uses TypeScript, `lang="ts"` on Vue `<script setup>`)
+5. **Package manager coverage** - `::code-group` install blocks must cover all package managers the project/ecosystem supports
+6. **Code preview** - Use `::code-preview` for visually renderable examples (tables, lists, rendered markdown, etc.)
+7. **Code group scope** - Only group equivalent alternatives (e.g., package managers, framework variants) — don't mix unrelated steps (e.g., install command + config file)
+8. **File naming** - Numbered directories/files, kebab-case, `.navigation.yml` in each section
+9. **Hidden pages** - Use `navigation: false` for pages that should exist as routes but not appear in sidebar
+
+**Common Critical Errors:**
+- Missing `u-` prefix: `::page-hero` → should be `::u-page-hero`
+- Missing required frontmatter: `title`, `description`
+- Invalid `.navigation.yml` structure
+- Missing section `index.md` causing 404 on section root URL
+
+See [references/technical-checks.md](references/technical-checks.md) for complete validation rules, examples, and error patterns.
+
+### For Generic Markdown Projects (Type B)
+
+**Simplified validation** - Skip Docus-specific checks:
+
+**Basic Frontmatter Validation:**
+- Check for common fields: `title`, `description`, `date`, `author`, `tags`
+- No strict requirements - just recommendations
+- Flag if completely missing frontmatter
+
+**Standard Markdown Syntax:**
+- Validate basic markdown (headings, lists, links, code blocks)
+- Check for broken internal links
+- Verify image paths exist
+
+**Skip:**
+- MDC component syntax (not applicable)
+- Nuxt Content frontmatter structure
+- `.navigation.yml` files
+- Docus-specific conventions
+
+**Focus on:**
+- Content quality (next step)
+- SEO optimization
+- Clarity and readability
+- General structure
+
+---
+
+## Step 4: Content Quality Review
+
+**This step applies to ALL project types** (both Docus and generic Markdown).
+
+Evaluate content quality across four dimensions. Refer to reference files for detailed checklists.
+
+### Clarity Review
+
+Use [references/clarity-checks.md](references/clarity-checks.md) to check:
+- **Voice & Tone:** Active voice, present tense, second person
+- **Sentence Structure:** 15-20 words target, avoid wordy phrases
+- **Paragraph Structure:** 2-5 sentences, 200-400 words between headings
+- **Action-Based Headings:** Page titles (H1) and headings (H2/H3) use action verbs for guides (Nuxt pattern)
+  - Examples: "Create Your First Module", "Configure your app", "Build a Plugin"
+  - Exceptions: Getting Started (nouns), API (function names), Concepts (descriptive)
+- **Terminology:** Consistent naming, technical terms defined
+- **Code Examples:** Complete, copy-pasteable, realistic, with file labels
+
+### SEO Review
+
+Use [references/seo-checks.md](references/seo-checks.md) to check:
+- **Titles:** 50-60 chars, keywords, unique
+- **Descriptions:** 120-160 chars, compelling, unique
+- **Headings:** Single H1, logical hierarchy (H1→H2→H3), descriptive
+- **URLs:** Kebab-case, descriptive, stable
+- **Links:** Descriptive anchors, "Next steps" sections
+- **Content Length:** 300+ words for landing, 400+ for guides, 200-400 per section
+- **Images:** Alt text, color mode variants
+
+### Structure Review
+
+Use [references/structure-checks.md](references/structure-checks.md) to check:
+- **Hierarchy:** Max 3 levels, logical progression
+- **Organization:** 2-15 pages per section, `.navigation.yml` present, appropriate icons
+- **Flow:** Logical progression, "Next Steps" links, no orphaned pages
+- **Landing Page:** Hero, features, quick start
+- **Consistency:** Similar structure across pages
+
+### i18n Review (if multi-language)
+
+Use [references/i18n-checks.md](references/i18n-checks.md) to check:
+- **Parallel Structure:** Same directories, files, page counts across locales
+- **Translation Completeness:** Similar content length (±30%), same headings
+- **Navigation:** Same icons, translated titles
+- **Locale-Specific:** No mixed languages, correct internal links, translated comments
+
+---
+
+## Step 5: Generate Report
+
+Create a comprehensive review report using [assets/report-template.md](assets/report-template.md).
+
+**Adapt report based on project type:**
+- **Docus/Nuxt Content:** Include all sections (Technical, SEO, Clarity, Structure, i18n)
+- **Generic Markdown:** Focus on content quality (SEO, Clarity, Structure), omit Docus-specific technical issues
+
+### Report Structure
+
+```markdown
+# Documentation Review Report
+
+**Generated:** [current date and time]
+**Project:** [project name from package.json or directory]
+**Reviewed:** [X] pages across [Y] sections in [locales]
+
+---
+
+## Executive Summary
+
+- **Critical Issues:** [count] (must fix - block deployment/cause errors)
+- **Important Issues:** [count] (significant impact on UX/SEO)
+- **Nice-to-Have:** [count] (polish and optimization recommendations)
+
+**Overall Assessment:** [1-2 sentence summary of documentation quality]
+
+---
+
+## Critical Issues
+
+[List all Critical issues grouped by category]
+
+### Technical: MDC Syntax Errors
+
+#### Missing u- prefix on Nuxt UI components
+
+**File:** `/content/en/1.getting-started/1.introduction.md:15`
+
+**Problem:** Page hero component missing `u-` prefix
+
+**Current:**
+\`\`\`markdown
+::page-hero
+#title
+Welcome
+::
+\`\`\`
+
+**Should Be:**
+\`\`\`markdown
+::u-page-hero
+#title
+Welcome
+::
+\`\`\`
+
+**Impact:** Component will not render, causing build errors
+
+---
+
+### Technical: Missing Frontmatter
+
+[Similar format for each issue]
+
+---
+
+## Important Issues
+
+[List all Important issues grouped by category: SEO, Clarity, Structure]
+
+### SEO: Suboptimal Metadata
+
+[Details with file paths and recommendations]
+
+### Clarity: Passive Voice
+
+[Details with examples and suggested rewrites]
+
+### Structure: Poor Navigation
+
+[Details with organizational recommendations]
+
+---
+
+## Nice-to-Have Suggestions
+
+[List optimization suggestions by category]
+
+### SEO Optimizations
+- **[File]**: [Suggestion]
+
+### Clarity Improvements
+- **[File]**: Consider adding `::tip` callout for [specific content]
+
+### Structure Enhancements
+- **[Section]**: Consider splitting into subsections
+
+---
+
+## Locale-Specific Issues
+
+[Only if multi-language detected]
+
+### French (`/fr/`)
+- [Translation issues]
+
+---
+
+## Statistics
+
+### Content Overview
+
+| Section | Pages (en) | Pages (fr) | Avg Words/Page |
+|---------|------------|------------|----------------|
+| Getting Started | [X] | [X] | ~[XXX] |
+| Guide | [X] | [X] | ~[XXX] |
+
+### Issue Breakdown
+
+| Category | Critical | Important | Nice-to-Have | Total |
+|----------|----------|-----------|--------------|-------|
+| Technical | [X] | [X] | [X] | [X] |
+| SEO | [X] | [X] | [X] | [X] |
+| Clarity | [X] | [X] | [X] | [X] |
+| Structure | [X] | [X] | [X] | [X] |
+| i18n | [X] | [X] | [X] | [X] |
+| **Total** | **[X]** | **[X]** | **[X]** | **[X]** |
+
+---
+
+## Positive Highlights
+
+[Call out 2-3 things done well]
+- Good use of callouts and code examples
+- Consistent MDC component usage
+- Well-organized section structure
+
+---
+
+## Recommended Action Plan
+
+### Priority 1: Fix Critical Issues (Today)
+1. [Specific actionable items]
+
+**Estimated fixes:** [X] files
+
+### Priority 2: Important Issues (This Week)
+1. [Specific actionable items]
+
+**Estimated fixes:** [X] files
+
+### Priority 3: Nice-to-Have (Next Sprint)
+1. [Specific actionable items]
+
+**Estimated fixes:** [X] files
+
+---
+
+## Next Steps
+
+**Would you like me to:**
+
+1. **Fix all Critical issues** - I can automatically correct MDC syntax and frontmatter issues
+2. **Rewrite specific sections** - Point out which pages need clarity improvements, and I'll rewrite them
+3. **Optimize SEO metadata** - I can update all titles and descriptions to optimal lengths
+4. **Restructure content** - If sections need reorganization, I can help restructure
+5. **Complete translations** - If you need i18n content completed
+
+**Or specify what you'd like to focus on first.**
+```
+
+### Report Generation Guidelines
+
+**Be specific:**
+- Include exact file paths and line numbers
+- Show current vs. recommended code
+- Explain why each issue matters (impact)
+
+**Be actionable:**
+- Provide clear fix instructions
+- Include code examples
+- Prioritize by impact
+
+**Be balanced:**
+- Highlight positive aspects
+- Don't overwhelm with minor issues
+- Focus on high-impact improvements
+
+**After generating the report:**
+- Offer to fix issues if the user requests
+- Be ready to address specific categories or files
+- Suggest starting with Critical issues
+
+---
+
+## Quick Reference
+
+**Most Common Issues:**
+- Missing `u-` prefix on Nuxt UI components (`::page-hero` → `::u-page-hero`)
+- SEO descriptions too short (need 120-160 chars)
+- Passive voice in instructions ("can be done" → "do it")
+- Generic headings ("Configuration" → "Configure your app")
+- Code blocks missing file name labels (every block representing a file should have one)
+- Code language not matching the project's stack (e.g., missing `lang="ts"` on Vue `<script setup>` in a TypeScript project)
+- Incomplete package manager coverage in `::code-group` install blocks (check against the ecosystem/project)
+- Unrelated steps grouped in `::code-group` (e.g., install command + config file) — keep as separate blocks
+- Missing `::code-preview` where rendered preview would add clarity (tables, lists, etc.)
+- Section landing page missing → 404 on section root URL (add `index.md` with `navigation: false` if needed)
+
+**See reference files for complete checklists and examples.**

--- a/plugins/docus/.agents/skills/review-docs/assets/report-template.md
+++ b/plugins/docus/.agents/skills/review-docs/assets/report-template.md
@@ -1,0 +1,214 @@
+# Documentation Review Report
+
+**Generated:** [timestamp]
+**Project:** [project-name]
+**Reviewed:** [number] pages across [number] sections in [locales]
+
+---
+
+## Executive Summary
+
+- **Critical Issues:** X (must fix - block deployment/cause errors)
+- **Important Issues:** Y (significant impact on UX/SEO)
+- **Nice-to-Have:** Z (polish and optimization recommendations)
+
+**Overall Assessment:** [Brief 1-2 sentence summary of documentation quality]
+
+---
+
+## Critical Issues
+
+> Issues that must be fixed as they cause build errors or critical functionality problems.
+
+### [Issue Category]
+
+**Priority:** Critical
+**Impact:** [Brief description of what breaks if not fixed]
+
+#### Issue 1: [Short description]
+
+**File:** [/path/to/file.md:line-number]
+
+**Problem:**
+[Detailed explanation of the issue]
+
+**Current:**
+```markdown
+[Current problematic code]
+```
+
+**Should Be:**
+```markdown
+[Corrected code]
+```
+
+**Why:** [Explanation of why this is critical]
+
+---
+
+## Important Issues
+
+> Issues that significantly impact user experience or SEO but don't break functionality.
+
+### SEO Issues
+
+#### Issue 1: [Short description]
+
+**File:** [/path/to/file.md]
+
+**Problem:** [Description]
+
+**Current:** [Example]
+
+**Recommendation:** [Specific fix]
+
+**Impact:** [How this affects SEO or UX]
+
+### Clarity Issues
+
+[Similar structure]
+
+### Structure Issues
+
+[Similar structure]
+
+---
+
+## Nice-to-Have Suggestions
+
+> Recommendations for polish and optimization. Not urgent but improve overall quality.
+
+### SEO Optimizations
+
+- **[File path]**: [Suggestion]
+- **[File path]**: [Suggestion]
+
+### Clarity Improvements
+
+- **[File path]**: Consider adding callout (::tip) for [specific content]
+- **[File path]**: Code example could be more realistic
+
+### Structure Enhancements
+
+- **[Section]**: Consider splitting into subsections for better navigation
+- **[Section]**: Add cross-references to related pages
+
+---
+
+## Locale-Specific Issues
+
+> Multi-language documentation specific concerns (only if i18n detected)
+
+### French (`/fr/`)
+
+- [Issue with French translation/structure]
+- [Issue with French content]
+
+### [Other locale]
+
+- [Locale-specific issues]
+
+---
+
+## Statistics
+
+### Content Overview
+
+| Section | Pages (en) | Pages (fr) | Avg Words/Page |
+|---------|------------|------------|----------------|
+| Getting Started | X | X | ~XXX |
+| Guide | X | X | ~XXX |
+| API | X | X | ~XXX |
+
+### Issue Breakdown
+
+| Category | Critical | Important | Nice-to-Have | Total |
+|----------|----------|-----------|--------------|-------|
+| Technical (MDC/Frontmatter) | X | X | X | X |
+| Code Blocks (labels/lang/groups) | X | X | X | X |
+| SEO | X | X | X | X |
+| Clarity | X | X | X | X |
+| Structure | X | X | X | X |
+| i18n | X | X | X | X |
+| **Total** | **X** | **X** | **X** | **X** |
+
+---
+
+## Positive Highlights
+
+[Call out 2-3 things the documentation does well]
+
+- Good use of callouts and code examples
+- Consistent MDC component usage
+- Well-organized section structure
+- Strong SEO metadata on landing pages
+
+---
+
+## Recommended Action Plan
+
+### Priority 1: Fix Critical Issues (Today)
+
+1. Fix all MDC syntax errors (missing u- prefixes)
+2. Add missing required frontmatter fields
+3. Correct broken navigation structure
+
+**Estimated fixes:** X files
+
+### Priority 2: Important Issues (This Week)
+
+1. Optimize SEO metadata (titles/descriptions)
+2. Rewrite sections with clarity issues (passive voice, unclear sentences)
+3. Fix heading hierarchy problems
+4. Complete missing translations (if applicable)
+
+**Estimated fixes:** X files
+
+### Priority 3: Nice-to-Have (Next Sprint)
+
+1. Add suggested callouts and examples
+2. Enhance internal linking
+3. Improve code example realism
+4. Add FAQ-style headings
+
+**Estimated fixes:** X files
+
+---
+
+## Next Steps
+
+**Would you like me to:**
+
+1. **Fix all Critical issues** - I can automatically correct MDC syntax and frontmatter issues
+2. **Rewrite specific sections** - Point out which pages need clarity improvements, and I'll rewrite them
+3. **Optimize SEO metadata** - I can update all titles and descriptions to optimal lengths
+4. **Restructure content** - If sections need reorganization, I can help restructure
+5. **Complete translations** - If you need i18n content completed
+
+**Or specify what you'd like to focus on first.**
+
+---
+
+## Appendix: Detailed File-by-File Analysis
+
+<details>
+<summary>Click to expand full file-by-file breakdown</summary>
+
+### /en/1.getting-started/1.introduction.md
+
+**Frontmatter:** ✅ Valid
+**MDC Syntax:** ✅ No issues
+**SEO:** ⚠️ Description too short (85 chars, aim for 120-160)
+**Clarity:** ✅ Good active voice, clear structure
+**Structure:** ✅ Logical flow, includes next steps
+
+**Recommendations:**
+- Expand meta description to 120-160 characters
+
+---
+
+### /en/1.getting-started/2.installation.md
+
+[Similar detailed breakdown for each file]
+
+</details>

--- a/plugins/docus/.agents/skills/review-docs/references/clarity-checks.md
+++ b/plugins/docus/.agents/skills/review-docs/references/clarity-checks.md
@@ -1,0 +1,201 @@
+# Clarity Review Guidelines
+
+Guidelines for evaluating content clarity and readability in Docus documentation.
+
+## Voice and Tone
+
+### Active Voice
+✅ Good: "Configure your app by adding..."
+❌ Avoid: "The app can be configured by adding..."
+
+### Present Tense
+✅ Good: "The server handles requests..."
+❌ Avoid: "The server will handle requests..."
+
+### Second Person
+✅ Good: "You can customize the theme..."
+❌ Avoid: "Users can customize the theme..."
+
+## Sentence Structure
+
+**Target:** 15-20 words per sentence
+**Maximum:** 25 words before flagging for review
+
+Examples:
+- Too long (32 words): "When you want to configure your application to use authentication with OAuth providers you should first install the required dependencies and then configure your environment variables."
+- Better (split into 2): "First, install the required dependencies for OAuth. Then, configure your environment variables for authentication."
+
+## Paragraph Structure
+
+**Guidelines:**
+- 2-5 sentences per paragraph
+- One main idea per paragraph
+- 200-400 words between headings
+
+## Action-Based Headings
+
+### Best Practice: Follow the Nuxt Pattern
+
+Modern documentation (like [Nuxt](https://nuxt.com/docs)) uses **action verbs throughout** for guide and tutorial pages. This makes documentation scannable and task-oriented.
+
+### When to Use Action Verbs
+
+**Page Titles (H1)** - Use action verbs for:
+- Guide pages: "Create Your First Module", "Build a Custom Plugin"
+- Tutorial pages: "Deploy Your Application", "Set Up Authentication"
+- How-to pages: "Add Dark Mode", "Configure Environment Variables"
+- Recipe pages: "Implement Real-time Updates"
+
+**Headings (H2/H3)** - Use imperative verbs for:
+- All steps within guides and tutorials
+- Sequential actions
+- Configuration sections
+- Implementation details
+
+### When to Use Nouns (Exceptions)
+
+- **File names:** Always remain nouns/kebab-case (`1.introduction.md`, `2.installation.md`)
+- **Getting Started titles:** "Introduction", "Installation", "Quick Start" (orientation pages)
+- **API reference pages:** Use function/component names ("useSession", "Button", "defineNuxtConfig")
+- **Concept pages:** Can use nouns when explaining theory ("Architecture", "Core Concepts", "Best Practices")
+
+### Action Verb Examples
+
+| Category | Verbs |
+|----------|-------|
+| Primary | Create, Build, Use, Develop, Run, Publish, Add, Configure, Set up, Enable, Connect |
+| Secondary | Handle, Customize, Deploy, Implement, Integrate, Install, Define, Write, Test, Debug, Update |
+
+### Real-World Examples (Nuxt Pattern)
+
+**Page Title (H1):**
+```markdown
+# Create Your First Module
+```
+
+**Section Headings (H2):**
+```markdown
+## Create a Module
+## Use the Starter Template
+## Develop Your Module
+```
+
+**Subsection Headings (H3):**
+```markdown
+### Run Tests
+### Build Your Module
+### Publish to npm
+```
+
+### Bad vs Good Examples
+
+| Static/Noun (Avoid) | Action-Based (Use) |
+|---------------------|-------------------|
+| Configuration | Configure your app |
+| Module Creation | Create a new module |
+| Database setup | Connect a database |
+| Route protection | Protect your routes |
+| Session management | Handle user sessions |
+| Error handling | Handle errors gracefully |
+| Testing | Run your tests |
+| Deployment | Deploy to production |
+
+## Terminology Consistency
+
+**Check for:**
+- Alternating between "config" and "configuration"
+- Switching between "app" and "application"
+- Inconsistent capitalization ("nuxt" vs "Nuxt")
+- Mixed terminology for same concept
+
+**Validate:**
+- Technical terms defined on first use
+- Consistent naming throughout
+- Product-specific terms used systematically
+
+## Code Examples
+
+### Quality Checklist
+- [ ] Complete and copy-pasteable (not fragments)
+- [ ] File name labels on all code blocks representing files (e.g., ` ```vue [App.vue] `, ` ```ts [server.ts] `, ` ```tsx [App.tsx] `)
+- [ ] Code language matches the project's stack (e.g., TypeScript if the project uses it)
+- [ ] Comments explain non-obvious logic
+- [ ] Realistic variable names (not foo/bar)
+- [ ] Working code (no placeholder values like `YOUR_API_KEY`)
+- [ ] Consistent indentation and style
+
+### Multi-Package Manager Support
+
+Always use `::code-group` for install commands covering **all package managers the project/ecosystem supports**:
+
+```markdown
+::code-group
+```bash [pnpm]
+pnpm add package-name
+```
+
+```bash [npm]
+npm install package-name
+```
+
+```bash [yarn]
+yarn add package-name
+```
+
+```bash [bun]
+bun add package-name
+```
+::
+```
+
+Check the project's README, lock files, or existing docs to determine which package managers to include. Ensure none are missing — a common oversight is omitting newer ones.
+
+### Showing Rendered Output
+
+Use `::code-preview` to show the rendered result alongside the source code for visual features (markdown syntax, tables, lists, etc.):
+
+```markdown
+::code-preview
+- Task 1
+- [x] Task 2 (completed)
+
+#code
+\```mdc
+- Task 1
+- [x] Task 2 (completed)
+\```
+::
+```
+
+### Code Groups Best Practices
+
+**Use `::code-group` for:**
+- Package manager install variants (pnpm/npm/yarn/bun)
+- Framework variants (Vue / React side by side)
+- Code + Output pairs
+- Syntax + AST pairs
+
+**Do NOT use `::code-group` to mix unrelated steps:**
+- A terminal install command with a config file edit — these are sequential actions, not equivalent alternatives. Keep them as separate blocks with transition text between them.
+
+## Common Clarity Issues
+
+### Passive Voice in Instructions
+❌ "The file should be created in the root directory"
+✅ "Create the file in the root directory"
+
+### Wordy Phrases
+| Wordy | Concise |
+|-------|---------|
+| In order to | To |
+| It is important to note that | Note: |
+| At this point in time | Now |
+| Due to the fact that | Because |
+
+### Vague Pronouns
+❌ "This allows you to..."
+✅ "This configuration allows you to..."
+
+### Unexplained Jargon
+❌ "Use SSR for better performance"
+✅ "Use Server-Side Rendering (SSR) for better performance"

--- a/plugins/docus/.agents/skills/review-docs/references/i18n-checks.md
+++ b/plugins/docus/.agents/skills/review-docs/references/i18n-checks.md
@@ -1,0 +1,264 @@
+# Internationalization (i18n) Guidelines
+
+Guidelines for reviewing multi-language documentation consistency in Docus.
+
+**Note:** These checks only apply if multi-language support is detected (multiple locale directories: `en/`, `fr/`, etc.)
+
+## Locale Detection
+
+Check for multiple language directories in `content/`:
+
+```
+content/
+├── en/          # English
+├── fr/          # French
+└── es/          # Spanish (if applicable)
+```
+
+If only one language directory exists, skip i18n checks.
+
+## Parallel Structure
+
+### Directory Parity
+
+All locales should have the same directory structure:
+
+✅ Correct:
+```
+content/
+├── en/
+│   ├── 1.getting-started/
+│   ├── 2.guide/
+│   └── 3.api/
+└── fr/
+    ├── 1.getting-started/
+    ├── 2.guide/
+    └── 3.api/
+```
+
+❌ Inconsistent:
+```
+content/
+├── en/
+│   ├── 1.getting-started/
+│   ├── 2.guide/
+│   ├── 3.api/
+│   └── 4.advanced/        # Only in English
+└── fr/
+    ├── 1.getting-started/
+    └── 2.guide/            # Missing sections
+```
+
+### File Parity
+
+Each locale should have matching files:
+
+✅ Correct:
+```
+en/1.getting-started/
+├── 1.introduction.md
+├── 2.installation.md
+└── 3.quick-start.md
+
+fr/1.getting-started/
+├── 1.introduction.md
+├── 2.installation.md
+└── 3.quick-start.md
+```
+
+❌ Missing translations:
+```
+en/1.getting-started/
+├── 1.introduction.md
+├── 2.installation.md
+└── 3.quick-start.md
+
+fr/1.getting-started/
+├── 1.introduction.md
+└── 2.installation.md     # Missing quick-start
+```
+
+## Translation Completeness
+
+### Content Length Comparison
+
+**Expected:** Similar content length across translations (±30%)
+
+**Red flags:**
+- English page: 1000 words, French page: 200 words (likely incomplete)
+- English page has 5 H2 sections, French has 2 (missing content)
+
+### Structural Completeness
+
+Check that translations include:
+- Same number of major headings (H2)
+- Same sections and subsections
+- Same code examples
+- Same callouts (::note, ::tip, etc.)
+- Same component usage (::u-page-hero, etc.)
+
+### Visual Content
+
+- [ ] Images exist in all language versions
+- [ ] Screenshots localized if they contain text
+- [ ] Diagrams translated if they contain labels
+- [ ] Color mode images (light/dark) available for all locales
+
+## Navigation Consistency
+
+### .navigation.yml Files
+
+Each section should have `.navigation.yml` in all locales:
+
+```yaml
+# en/1.getting-started/.navigation.yml
+title: Getting Started
+icon: i-lucide-rocket
+
+# fr/1.getting-started/.navigation.yml
+title: Premiers Pas
+icon: i-lucide-rocket    # Same icon across locales
+```
+
+**Validation:**
+- [ ] Same icon used across locales
+- [ ] Title translated appropriately
+- [ ] All sections have navigation files in all locales
+
+## Locale-Specific Issues
+
+### Language-Specific Checks
+
+**English:**
+- Active voice
+- Present tense
+- Second person
+
+**French:**
+- Correct formal/informal tone (tu vs vous)
+- Proper accents (é, è, à, etc.)
+- Agreement (gender/number)
+
+**Other languages:**
+- Appropriate formality level
+- Correct grammar and syntax
+- Cultural appropriateness
+
+### Code Examples
+
+**Keep consistent across locales:**
+- Variable names (usually English)
+- Function names
+- Technical terminology
+- Package names
+
+**Translate:**
+- Comments in code blocks
+- String values where appropriate
+- Console output messages
+
+**Example:**
+
+English:
+````markdown
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  // Configure your app
+  app: {
+    name: 'My App'
+  }
+})
+```
+````
+
+French:
+````markdown
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  // Configurez votre application
+  app: {
+    name: 'Mon Application'
+  }
+})
+```
+````
+
+## Common i18n Issues
+
+### Partial Translations
+
+**Issue:** Documentation started in one language, partially translated to others.
+
+**Detection:**
+- Missing files in some locales
+- Incomplete page content (much shorter than original)
+- Untranslated sections within otherwise translated pages
+
+**Fix:** Either complete translations or clearly mark incomplete sections.
+
+### Inconsistent Terminology
+
+**Issue:** Same technical term translated differently across pages.
+
+**Example:**
+- Page 1: "authentication" → "authentification"
+- Page 2: "authentication" → "connexion"
+- Page 3: "authentication" → "identification"
+
+**Fix:** Choose one translation and use consistently. Create a terminology glossary.
+
+### Mixed Languages
+
+**Issue:** English text appearing in non-English locales (besides code/technical terms).
+
+**Common examples:**
+- English headings in French pages
+- Untranslated navigation labels
+- English error messages
+- Mixed language in same paragraph
+
+**Fix:** Translate all user-facing text except code, package names, and established technical terms.
+
+### URL Mismatches
+
+**Issue:** Internal links not updated for locale.
+
+❌ Wrong (in French docs):
+```markdown
+See [installation guide](/en/getting-started/installation)
+```
+
+✅ Correct:
+```markdown
+See [guide d'installation](/fr/getting-started/installation)
+```
+
+### Missing Locale Configuration
+
+Check that `nuxt.config.ts` or `app.config.ts` includes i18n configuration:
+
+```ts
+// nuxt.config.ts or app/app.config.ts
+i18n: {
+  defaultLocale: 'en',
+  locales: [
+    { code: 'en', name: 'English' },
+    { code: 'fr', name: 'Français' }
+  ]
+}
+```
+
+## Validation Checklist
+
+If multi-language detected:
+
+- [ ] All locales have same directory structure
+- [ ] All locales have matching file structure (same page count per section)
+- [ ] All `.navigation.yml` files exist in all locales with same icons
+- [ ] Content length is similar across translations (±30%)
+- [ ] No English text in non-English pages (except code/technical terms)
+- [ ] Internal links point to correct locale
+- [ ] Code comments translated appropriately
+- [ ] Consistent terminology within each locale
+- [ ] Locale configuration present in Nuxt config
+- [ ] Landing pages exist for all locales

--- a/plugins/docus/.agents/skills/review-docs/references/seo-checks.md
+++ b/plugins/docus/.agents/skills/review-docs/references/seo-checks.md
@@ -1,0 +1,219 @@
+# SEO Review Guidelines
+
+Comprehensive SEO best practices for Docus documentation sites.
+
+## Page Titles
+
+### Length Guidelines
+- **Optimal:** 50-60 characters
+- **Maximum:** 70 characters (search engines truncate beyond this)
+- **Minimum:** 30 characters (too short looks incomplete)
+
+### Best Practices
+- [ ] Contains primary keyword
+- [ ] Unique across all pages
+- [ ] Matches or clearly relates to H1
+- [ ] Descriptive and specific (not "Documentation" or "Guide")
+
+### Examples
+
+| Poor | Better | Great |
+|------|--------|-------|
+| Installation | Install | Install Docus in Your Nuxt Project |
+| Configuration | Configure | Configure Docus Theme Settings |
+| API | API Reference | API Reference: Composables and Helpers |
+
+## Meta Descriptions
+
+### Length Guidelines
+- **Optimal:** 120-160 characters
+- **Maximum:** 160 characters (truncated in search results)
+- **Minimum:** 70 characters (too short is a missed opportunity)
+
+### Best Practices
+- [ ] Includes target keywords naturally
+- [ ] Compelling and action-oriented
+- [ ] Accurately summarizes page content
+- [ ] Unique per page (no duplicates)
+
+### Examples
+
+✅ Good (145 chars): "Learn how to install and configure Docus in your Nuxt project. Set up your documentation site with search, dark mode, and AI integration."
+
+❌ Too short (42 chars): "Documentation setup guide for Docus theme"
+
+❌ Too long (185 chars): "This comprehensive guide will walk you through the complete process of installing, configuring, and customizing the Docus documentation theme for your Nuxt application with all features."
+
+## Heading Structure
+
+### H1 Requirements
+- [ ] **Single H1 per page** (critical for SEO)
+- [ ] Matches or relates to `<title>` tag
+- [ ] Contains primary keyword
+- [ ] Descriptive and specific
+
+### Heading Hierarchy
+- [ ] No skipped levels (H1 → H2 → H3, never H1 → H3)
+- [ ] Logical flow and nesting
+- [ ] Each heading is unique on the page
+
+### Descriptive Headings
+
+Avoid generic headings that don't convey meaning:
+
+| Generic (Avoid) | Descriptive (Use) |
+|-----------------|-------------------|
+| Overview | Authentication Overview |
+| Getting Started | Getting Started with OAuth |
+| Details | Configuration Details |
+| Advanced | Advanced Routing Patterns |
+| Options | Configuration Options |
+
+### Keyword Optimization
+
+H2 and H3 headings should:
+- Include relevant keywords naturally
+- Answer user questions (FAQ-style when appropriate)
+- Be scannable (users often skip to headings)
+
+**Example FAQ-style headings:**
+- "How do I rotate an API key?"
+- "What is the difference between OAuth and JWT?"
+- "When should I use server-side rendering?"
+
+## URL Structure
+
+### Best Practices
+- [ ] Lowercase, hyphen-separated (`kebab-case`)
+- [ ] Descriptive and stable (don't change after publishing)
+- [ ] Follows numbered directory pattern (`1.getting-started/`, `2.guide/`)
+- [ ] Matches content hierarchy
+- [ ] Avoids special characters and underscores
+
+### Examples
+
+✅ Good:
+- `/en/getting-started/installation`
+- `/en/guide/authentication`
+- `/en/api/composables`
+
+❌ Avoid:
+- `/en/getting_started/installation` (underscores)
+- `/en/GetStarted/Installation` (not lowercase)
+- `/en/p/123` (not descriptive)
+- `/en/docs-page` (too generic)
+
+## Internal Linking
+
+### Strategy
+- Link to related documentation pages
+- Use descriptive anchor text (not "click here" or "here")
+- Include "Next steps" or "Related" sections
+- Add important links to frontmatter `links` array
+
+### Anchor Text Best Practices
+
+| Poor | Better |
+|------|--------|
+| Click here | Learn about authentication |
+| Read more | Configure OAuth providers |
+| See this page | View the API reference |
+| Documentation | Deployment documentation |
+
+### Links in Frontmatter
+
+For important related links, use frontmatter `links` array:
+
+```yaml
+---
+links:
+  - label: "API Reference"
+    icon: "i-lucide-book"
+    to: "/api/reference"
+  - label: "GitHub Repository"
+    icon: "i-simple-icons-github"
+    to: "https://github.com/..."
+    target: "_blank"
+---
+```
+
+## Content Length
+
+### Guidelines by Page Type
+
+| Page Type | Minimum | Optimal | Notes |
+|-----------|---------|---------|-------|
+| Landing (index.md) | 300 words | 500-800 | Hero + feature overview |
+| Guide page | 400 words | 600-1200 | Detailed instructions |
+| API reference | 200 words | 400-800 | Concise technical reference |
+| Getting Started | 300 words | 500-1000 | Clear onboarding |
+
+### Section Length
+- **Minimum:** 100 words (anything less is "thin content")
+- **Optimal:** 200-400 words per section (between H2/H3 headings)
+- **Maximum:** 1000 words before breaking into subsections
+
+**Red flags:**
+- Pages under 100 words (too thin, low SEO value)
+- Sections over 1000 words without subheadings (poor scannability)
+
+## Image Optimization
+
+### Alt Text
+- [ ] Descriptive and specific (not "image" or "screenshot")
+- [ ] Includes relevant keywords naturally
+- [ ] Describes image content for accessibility
+- [ ] 50-125 characters optimal
+
+### Color Mode Images
+
+Always provide both light and dark variants:
+
+```markdown
+:u-color-mode-image{
+  alt="Dashboard showing user analytics"
+  light="/images/dashboard-light.png"
+  dark="/images/dashboard-dark.png"
+  class="rounded-lg"
+  width="859"
+  height="400"
+}
+```
+
+### Image File Names
+- Use descriptive kebab-case names
+- Include context: `dashboard-analytics.png` not `screenshot-1.png`
+
+## Common SEO Issues
+
+### Duplicate Metadata
+❌ Multiple pages with same title or description
+✅ Each page has unique, descriptive metadata
+
+### Missing Metadata
+❌ No `seo.title` or `seo.description` in frontmatter
+✅ All pages have SEO metadata defined
+
+### Keyword Stuffing
+❌ "Docus Docus documentation Docus theme Docus guide"
+✅ Natural language with keywords integrated contextually
+
+### Broken Internal Links
+❌ Links to `/getting-started/` when actual path is `/en/getting-started/`
+✅ Links match the actual file structure and language prefixes
+
+## Verification Checklist
+
+Run through this checklist for each page:
+
+- [ ] Title: 50-60 chars, contains keyword, unique
+- [ ] Description: 120-160 chars, compelling, accurate
+- [ ] Single H1, matches title
+- [ ] Heading hierarchy is logical (no skipped levels)
+- [ ] H2/H3 headings are descriptive, not generic
+- [ ] URL is stable, descriptive, lowercase-hyphenated
+- [ ] Internal links use descriptive anchor text
+- [ ] Content is 300+ words for substantial pages
+- [ ] Sections are 200-400 words between headings
+- [ ] Images have descriptive alt text
+- [ ] Color mode images have both light/dark variants

--- a/plugins/docus/.agents/skills/review-docs/references/structure-checks.md
+++ b/plugins/docus/.agents/skills/review-docs/references/structure-checks.md
@@ -1,0 +1,317 @@
+# Structure and Organization Guidelines
+
+Guidelines for evaluating documentation structure, organization, and navigation patterns.
+
+## Content Hierarchy
+
+### Recommended Directory Structure
+
+```
+content/
+├── {locale}/
+│   ├── index.md                      # Landing page (required)
+│   ├── 1.getting-started/
+│   │   ├── .navigation.yml
+│   │   ├── 1.introduction.md
+│   │   ├── 2.installation.md
+│   │   └── 3.quick-start.md
+│   ├── 2.guide/                      # or 2.concepts/
+│   │   ├── .navigation.yml
+│   │   ├── 1.configuration.md
+│   │   ├── 2.authentication.md
+│   │   └── 3.deployment.md
+│   ├── 3.api/                        # if applicable
+│   │   ├── .navigation.yml
+│   │   └── 1.reference.md
+│   └── 4.advanced/                   # optional
+│       ├── .navigation.yml
+│       └── 1.customization.md
+```
+
+### Depth Guidelines
+
+**Recommended:** Maximum 3 levels of nesting
+- Level 1: Main sections (`1.getting-started/`)
+- Level 2: Pages within sections (`1.introduction.md`)
+- Level 3: Subsections via headings (H2, H3 within pages)
+
+**Avoid:** Deep folder nesting (4+ levels) - use H2/H3 headings instead.
+
+## Section Organization
+
+### Standard Section Types
+
+**1. Getting Started** (Always first)
+- Introduction (what & why)
+- Installation (prerequisites, commands)
+- Quick Start / First Steps
+- Project Structure (if applicable)
+
+**2. Guide / Concepts** (Core documentation)
+- Feature documentation
+- Configuration guides
+- Integration tutorials
+- Best practices
+
+**3. API / Reference** (If applicable)
+- Component reference
+- Composable reference
+- Function reference
+- Configuration options
+
+**4. Advanced / Recipes** (Optional)
+- Advanced patterns
+- Customization guides
+- Troubleshooting
+- Migration guides
+
+### Pages Per Section
+
+**Guidelines:**
+- **Minimum:** 2 pages per section (1 page = should be merged into another section)
+- **Optimal:** 3-8 pages per section
+- **Maximum:** 15 pages (beyond this, consider splitting into subsections)
+
+**Red flags:**
+- Section with 1 page only
+- Section with 20+ pages (too broad, hard to navigate)
+
+## Navigation Files
+
+### .navigation.yml Structure
+
+Each section directory should have `.navigation.yml`:
+
+```yaml
+title: Getting Started
+icon: i-lucide-rocket
+```
+
+**Required fields:**
+- `title`: Section display name in sidebar
+- `icon`: Lucide icon (format: `i-lucide-{name}`)
+
+### Icon Recommendations
+
+| Section | Suggested Icons |
+|---------|----------------|
+| Getting Started | `i-lucide-rocket`, `i-lucide-play` |
+| Guide / Concepts | `i-lucide-book-open`, `i-lucide-layers` |
+| API / Reference | `i-lucide-code`, `i-lucide-book` |
+| Advanced | `i-lucide-settings`, `i-lucide-wrench` |
+| Deployment | `i-lucide-cloud`, `i-lucide-upload` |
+| Troubleshooting | `i-lucide-alert-circle`, `i-lucide-help-circle` |
+
+## Content Flow
+
+### Logical Progression
+
+Documentation should follow a learning path:
+
+1. **Orientation** - What is this? Why use it?
+2. **Setup** - How do I install it?
+3. **Basics** - How do I use core features?
+4. **Advanced** - How do I customize or extend?
+5. **Reference** - Where can I find detailed API info?
+
+### Page Structure
+
+Each page should follow this pattern:
+
+```markdown
+---
+frontmatter here
+---
+
+# H1 Page Title (matches frontmatter title)
+
+Brief introduction (1-2 sentences describing what this page covers)
+
+## First Major Topic (H2)
+
+Content explaining the topic (200-400 words)
+
+### Subtopic (H3)
+
+Detailed information
+
+## Second Major Topic (H2)
+
+More content
+
+## Next Steps
+
+- Link to related pages
+- Suggested reading order
+```
+
+### Next Steps / Related Content
+
+**Every guide page should include:**
+- Links to related documentation
+- Suggested next pages
+- Prerequisites or dependencies
+
+**Examples:**
+
+```markdown
+## Next Steps
+
+- [Configure your theme](/guide/configuration)
+- [Add custom components](/guide/customization)
+- [Deploy to production](/guide/deployment)
+
+## Related
+
+- [API Reference](/api/reference) - Detailed API documentation
+- [Examples](/examples) - Real-world usage examples
+```
+
+## Cross-Referencing
+
+### Internal Links
+
+**Use relative links from the content root:**
+
+✅ Good:
+```markdown
+Learn more about [authentication](/guide/authentication).
+```
+
+❌ Avoid:
+```markdown
+Learn more about [authentication](../guide/authentication.md).
+```
+
+### Link Patterns
+
+**Inline links** for contextual references:
+```markdown
+Configure your app by setting up [environment variables](/guide/configuration#environment-variables).
+```
+
+**Callout links** for important related content:
+```markdown
+::note
+This feature requires authentication. See the [Authentication Guide](/guide/authentication) for setup instructions.
+::
+```
+
+**Frontmatter links** for primary related pages:
+```yaml
+---
+links:
+  - label: API Reference
+    to: /api/reference
+    icon: i-lucide-book
+---
+```
+
+## Consistency Checks
+
+### Across Pages
+
+- [ ] Consistent heading style (action-based in guide sections)
+- [ ] Similar page structure (intro → content → next steps)
+- [ ] Consistent code example format
+- [ ] Consistent terminology usage
+
+### Across Sections
+
+- [ ] All sections have `.navigation.yml`
+- [ ] Numbered directories for consistent ordering
+- [ ] Similar depth levels (avoid 2 levels in one section, 5 in another)
+- [ ] Consistent icon style (all Lucide, no mixing)
+
+## Common Structure Issues
+
+### Orphaned Pages
+- Pages with no incoming links
+- No path from landing page to this page
+- Not included in navigation
+
+**Fix:** Add links from parent/related pages
+
+### Redundant Content
+- Multiple pages covering the same topic
+- Duplicate information across sections
+- Overlapping content without clear differentiation
+
+**Fix:** Consolidate or clearly differentiate purpose
+
+### Missing Landing Page
+- Section without index.md
+- Direct jump to numbered pages (causes 404 on the section root URL)
+
+**Fix:** Add `index.md` with section overview. If the page should not appear in the sidebar navigation, use `navigation: false` in frontmatter:
+
+```yaml
+---
+title: Section Name
+description: Overview of this section
+navigation: false
+---
+```
+
+This pattern is useful for section landing pages that serve as entry points (e.g. via redirect or direct URL) but shouldn't clutter the sidebar.
+
+### Inconsistent Numbering
+- Gaps in numbering (1, 2, 4, 5 - where's 3?)
+- Duplicate numbers (1.intro.md, 1.install.md in same directory)
+
+**Fix:** Renumber files consistently
+
+### Poor Information Architecture
+- Guide content in Getting Started section
+- Basic setup in Advanced section
+- API reference mixed with tutorials
+
+**Fix:** Reorganize into appropriate sections
+
+## Landing Page Structure
+
+The main landing page (`index.md`) should include:
+
+1. **Hero Section** - Project name, tagline, CTA
+2. **Key Features** - 3-6 main features with icons
+3. **Quick Start** - Minimal example or install command
+4. **Links to Sections** - Getting Started, Guide, API
+5. **Optional:** Showcase, testimonials, sponsors
+
+**Example Structure:**
+
+```markdown
+---
+title: Project Name
+description: Project tagline
+---
+
+::u-page-hero
+# Hero content
+::
+
+::u-page-section
+# Features
+  :::u-page-grid
+  # Feature cards
+  :::
+::
+
+::u-page-section
+# Quick Start
+# Minimal code example
+::
+```
+
+## Validation Checklist
+
+- [ ] Landing page (index.md) exists at root of each locale
+- [ ] All sections have `.navigation.yml` with title and icon
+- [ ] Numbered directories follow consistent pattern (1., 2., 3.)
+- [ ] Pages within sections are numbered consistently
+- [ ] Maximum 3 levels of hierarchy (folders + headings)
+- [ ] Each section has 2-15 pages (not 1, not 20+)
+- [ ] Pages include "Next Steps" or related links
+- [ ] No orphaned pages (all reachable from navigation)
+- [ ] Logical progression (Getting Started → Guide → API → Advanced)
+- [ ] Consistent heading depth (no lonely H4s without H3)

--- a/plugins/docus/.agents/skills/review-docs/references/technical-checks.md
+++ b/plugins/docus/.agents/skills/review-docs/references/technical-checks.md
@@ -1,0 +1,538 @@
+# Technical Validation Guidelines
+
+Technical correctness checks for Docus documentation, focusing on MDC syntax, frontmatter structure, and component usage.
+
+## Frontmatter Structure
+
+### Required Fields
+
+Every documentation page MUST have:
+
+```yaml
+---
+title: Page Title
+description: Page description
+---
+```
+
+### Optional but Recommended Fields
+
+```yaml
+---
+title: Page Title
+description: Page description
+navigation:
+  icon: i-lucide-icon-name
+  title: Custom Sidebar Label  # Optional override
+seo:
+  title: SEO-Optimized Title
+  description: SEO-Optimized Description
+links:
+  - label: Related Link
+    icon: i-lucide-link
+    to: /path/to/page
+---
+```
+
+### Field Validation Rules
+
+**title:**
+- Type: String
+- Required: Yes
+- Max length: 100 characters (recommended 60 for SEO)
+- Must be unique across pages
+
+**description:**
+- Type: String
+- Required: Yes
+- Max length: 200 characters (recommended 160 for SEO)
+- Should be concise and descriptive
+
+**navigation.icon:**
+- Type: String
+- Format: `i-{collection}-{icon-name}` (e.g., `i-lucide-house`, `i-lucide-code-xml`)
+- Must start with `i-`
+- Lucide icons preferred for consistency
+
+**navigation.title:**
+- Type: String
+- Optional: Overrides default sidebar title
+- Keep short (1-3 words)
+
+**seo.title:**
+- Type: String
+- Optimal: 50-60 characters
+- Can differ from page title for SEO optimization
+
+**seo.description:**
+- Type: String
+- Optimal: 120-160 characters
+- More detailed than main description if needed
+
+**links:**
+- Type: Array of objects
+- Each object requires: `label`, `to`
+- Optional: `icon`, `target` (for external links)
+
+### Common Frontmatter Errors
+
+❌ **Missing required fields:**
+```yaml
+---
+title: My Page
+# ERROR: description is missing
+---
+```
+
+❌ **Invalid icon format:**
+```yaml
+---
+navigation:
+  icon: lucide-house  # ERROR: must start with 'i-'
+---
+```
+
+❌ **Invalid links structure:**
+```yaml
+---
+links:
+  - "https://example.com"  # ERROR: must be object with label and to
+---
+```
+
+✅ **Correct structure:**
+```yaml
+---
+title: Installation
+description: Learn how to install Docus in your project
+navigation:
+  icon: i-lucide-download
+seo:
+  title: Install Docus in Your Nuxt Project
+  description: Step-by-step guide to installing and configuring Docus documentation theme.
+links:
+  - label: Quick Start
+    icon: i-lucide-zap
+    to: /getting-started/quick-start
+---
+```
+
+## MDC Component Syntax
+
+### Critical Rule: u- Prefix
+
+**ALL Nuxt UI components in MDC MUST use the `u-` prefix.**
+
+This is the most common error and causes build failures.
+
+### Common Components Requiring u- Prefix
+
+| Component | Incorrect | Correct |
+|-----------|-----------|---------|
+| Page Hero | `::page-hero` | `::u-page-hero` |
+| Page Section | `::page-section` | `::u-page-section` |
+| Page Grid | `::page-grid` | `::u-page-grid` |
+| Page Card | `::page-card` | `::u-page-card` |
+| Page Feature | `::page-feature` | `::u-page-feature` |
+| Button | `::button` or `:::button` | `:::u-button` |
+| Badge | `::badge` | `::u-badge` |
+| Color Mode Image | `:color-mode-image` | `:u-color-mode-image` |
+
+### Component Nesting Levels
+
+MDC uses colons to indicate nesting depth:
+
+```markdown
+::u-page-hero           # Level 1: 2 colons
+  :::u-button           # Level 2: 3 colons
+    ::::div             # Level 3: 4 colons (HTML elements)
+      :::::span         # Level 4: 5 colons
+```
+
+**Validation:** Ensure nesting levels are consistent and logical.
+
+### Component Attributes
+
+**Inline attributes** (use curly braces):
+
+```markdown
+:::u-button{color="neutral" size="xl" to="/path" trailing-icon="i-lucide-arrow-right"}
+Button Text
+:::
+```
+
+**Block attributes** (use --- separator):
+
+```markdown
+:::u-button
+---
+color: neutral
+size: xl
+to: /path
+trailing-icon: i-lucide-arrow-right
+---
+Button Text
+:::
+```
+
+**Common attribute errors:**
+
+❌ Wrong: `:::u-button(color="neutral")`
+✅ Correct: `:::u-button{color="neutral"}`
+
+❌ Wrong: `:::u-button[size=xl]`
+✅ Correct: `:::u-button{size="xl"}`
+
+### Slot Syntax
+
+Components with named slots use `#slot-name`:
+
+```markdown
+::u-page-hero
+#title
+Your Title Here
+
+#description
+Your description text
+
+#links
+  :::u-button{to="/start"}
+  Get Started
+  :::
+::
+```
+
+**Validation:** Ensure slot names match component documentation.
+
+### Content vs Nuxt Content Components
+
+**Nuxt Content components** (no u- prefix):
+- `::code-group` - Multi-tab code blocks
+- `::steps` - Step-by-step instructions
+- `::note`, `::tip`, `::warning`, `::caution` - Callouts
+
+**Nuxt UI components** (require u- prefix):
+- `::u-page-*` - Page layout components
+- `::u-button`, `::u-badge` - Interactive elements
+- `:u-color-mode-image` - Images with theme variants
+
+### Code Block Validation
+
+#### File Path Labels
+
+**ALL code blocks should include file name labels**, not just config files. This applies to every code example that represents a file:
+
+✅ Good:
+````markdown
+```vue [App.vue]
+<script setup lang="ts">
+import { ref } from 'vue'
+</script>
+```
+````
+
+````markdown
+```typescript [parse.ts]
+import { parse } from 'comark'
+```
+````
+
+````markdown
+```tsx [App.tsx]
+export default function App() {}
+```
+````
+
+❌ Missing label:
+````markdown
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+</script>
+```
+````
+
+**Label naming conventions:**
+- Vue components: `[App.vue]`, `[components/Alert.vue]`, `[pages/index.vue]`
+- TypeScript files: `[parse.ts]`, `[config.ts]`, `[server.ts]`
+- React components: `[App.tsx]`, `[components/Card.tsx]`
+- Config files: `[nuxt.config.ts]`, `[app.config.ts]`
+- CSS files: `[styles.css]`, `[app/assets/css/main.css]`
+- Terminal commands: `[Terminal]`
+
+**Exceptions** (no label needed):
+- Type definitions / interfaces
+- MDC syntax examples (` ```mdc `)
+- Inline snippets that don't represent a file
+
+#### Code Language Consistency
+
+Code examples should match the project's language stack. Check the project's `tsconfig.json`, `package.json`, or existing code to determine the default language.
+
+**For TypeScript projects**, all code examples should use TypeScript. Common mismatches to flag:
+- Vue `<script setup>` missing `lang="ts"` → should be `<script setup lang="ts">`
+- `.js` file extensions in examples when the project uses `.ts`
+- Missing type annotations in function signatures when the project uses strict TypeScript
+
+#### Language Tags
+
+Always specify language for syntax highlighting:
+
+✅ Good: ` ```ts `, ` ```bash `, ` ```vue `
+❌ Avoid: ` ``` ` (no language)
+
+#### Code Groups
+
+Use `::code-group` for multi-variant examples (package managers, frameworks, etc.):
+
+````markdown
+::code-group
+```bash [pnpm]
+pnpm add docus
+```
+
+```bash [npm]
+npm install docus
+```
+
+```bash [yarn]
+yarn add docus
+```
+
+```bash [bun]
+bun add docus
+```
+::
+````
+
+**Ensure all package managers the project/ecosystem supports are represented.** Check the project's README, `package.json` scripts, or lock files to determine which ones to include. Common omissions: forgetting newer package managers (e.g., bun) or removing one by mistake.
+
+#### Code Groups: What NOT to Group
+
+**Do NOT group a terminal command with a config file** — these are separate steps:
+
+❌ Bad (mixing install + config in one group):
+````markdown
+::code-group
+```bash [Terminal]
+npm install my-package
+```
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['my-package']
+})
+```
+::
+````
+
+✅ Good (separate blocks with transition text):
+````markdown
+```bash [Terminal]
+npm install my-package
+```
+
+Add the module to your `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['my-package']
+})
+```
+````
+
+**When to use `::code-group`:**
+- Package manager variants (pnpm/npm/yarn/bun)
+- Framework variants (Vue/React)
+- Code + Output pairs (`[Code]` / `[Output]`)
+- Syntax + AST pairs (`[Syntax]` / `[AST]`)
+
+#### Code Preview
+
+Use `::code-preview` to show rendered output alongside source code. This is ideal for documenting visual features like markdown syntax, code block metadata, component rendering:
+
+````markdown
+::code-preview
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+#code
+```mdc
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+```
+::
+````
+
+**When to use `::code-preview`:**
+- Markdown syntax examples (headings, lists, tables, blockquotes, task lists, emojis)
+- Code block features (filename labels, line highlighting)
+- Any feature where seeing the rendered result adds clarity
+
+**When NOT to use `::code-preview`:**
+- API/TypeScript code examples (no visual preview)
+- Component examples with unregistered custom components
+
+
+## File and Directory Naming
+
+### Directory Structure
+
+Documentation sections should follow numbered pattern:
+
+```
+content/
+├── en/
+│   ├── index.md
+│   ├── 1.getting-started/
+│   ├── 2.guide/
+│   ├── 3.api/
+│   └── 4.advanced/
+```
+
+**Rules:**
+- Directories start with number for ordering: `1.`, `2.`, `3.`
+- Use kebab-case for directory names
+- Name reflects section content
+
+### File Naming
+
+**Pattern:** `{number}.{name}.md`
+
+Examples:
+- `1.introduction.md`
+- `2.installation.md`
+- `3.configuration.md`
+
+**Rules:**
+- Start with number for ordering within section
+- Use kebab-case (lowercase with hyphens)
+- Descriptive name (not `page-1.md` or `doc.md`)
+
+### Navigation Files
+
+**Each section directory must have `.navigation.yml`:**
+
+```yaml
+# 1.getting-started/.navigation.yml
+title: Getting Started
+icon: i-lucide-rocket
+```
+
+**Purpose:** Controls sidebar display and section metadata.
+
+## Common Technical Errors
+
+### 1. Missing u- Prefix (Most Common)
+
+**Error pattern:**
+```markdown
+::page-hero
+#title
+Welcome
+::
+```
+
+**Fix:**
+```markdown
+::u-page-hero
+#title
+Welcome
+::
+```
+
+### 2. Inconsistent Nesting
+
+**Error pattern:**
+```markdown
+::u-page-section
+::::u-button  # Wrong: skipped nesting level
+Close
+::::
+::
+```
+
+**Fix:**
+```markdown
+::u-page-section
+  :::u-button
+  Close
+  :::
+::
+```
+
+### 3. Invalid Component Names
+
+**Error pattern:**
+```markdown
+::u-hero  # Component doesn't exist
+```
+
+**Fix:**
+```markdown
+::u-page-hero  # Use correct component name
+```
+
+### 4. Missing File Labels in Code Blocks
+
+**Error pattern:**
+````markdown
+```typescript
+export default defineNuxtConfig({})
+```
+````
+
+**Fix:**
+````markdown
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({})
+```
+````
+
+### 5. Broken Component Attributes
+
+**Error pattern:**
+```markdown
+:::u-button color=neutral size=xl
+```
+
+**Fix:**
+```markdown
+:::u-button{color="neutral" size="xl"}
+```
+
+## Validation Checklist
+
+For each page, verify:
+
+### Frontmatter
+- [ ] `title` and `description` fields present
+- [ ] `navigation.icon` starts with `i-` if present
+- [ ] `links` array has correct object structure
+- [ ] No invalid YAML syntax
+- [ ] Use `navigation: false` for pages that should exist (e.g. index redirects) but not appear in sidebar
+
+### MDC Components
+- [ ] All Nuxt UI components use `u-` prefix
+- [ ] Nesting levels are consistent (::, :::, ::::)
+- [ ] Component names are valid
+- [ ] Attributes use correct syntax `{key="value"}`
+- [ ] Slot names match component docs
+- [ ] `::code-preview` used for visually renderable examples (markdown syntax, tables, lists, etc.)
+
+### Code Blocks
+- [ ] Language tags specified (ts, js, vue, bash, etc.)
+- [ ] File name labels on all code blocks representing files (not just config files)
+- [ ] Code language matches the project's stack (e.g., `lang="ts"` on Vue `<script setup>` for TypeScript projects)
+- [ ] Use `::code-group` for multi-variant examples (package managers, frameworks, etc.)
+- [ ] Package manager `::code-group` covers all supported package managers (check against the project/ecosystem)
+- [ ] Only group equivalent alternatives — don't mix unrelated steps (e.g., install + config) in a `::code-group`
+- [ ] `::code-preview` used where rendered preview adds clarity
+
+### File Structure
+- [ ] Directory follows numbered pattern (`1.section/`)
+- [ ] Files follow numbered pattern (`1.page.md`)
+- [ ] `.navigation.yml` exists in each section
+- [ ] File and directory names are kebab-case

--- a/plugins/docus/.claude-plugin/plugin.json
+++ b/plugins/docus/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "docus",
+  "version": "1.0.0",
+  "description": "Write beautiful documentations with Nuxt and Markdown.",
+  "author": {
+    "name": "Nuxt",
+    "url": "https://github.com/nuxt-content"
+  },
+  "homepage": "https://docus.dev",
+  "repository": "https://github.com/nuxt-content/docus",
+  "license": "MIT",
+  "keywords": [
+    "docus",
+    "nuxt",
+    "documentation",
+    "markdown",
+    "nuxt-content"
+  ],
+  "mcpServers": {
+    "docus": {
+      "type": "http",
+      "url": "https://docus.dev/mcp"
+    }
+  },
+  "skills": "./.agents/skills/"
+}

--- a/plugins/docus/skills-lock.json
+++ b/plugins/docus/skills-lock.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "skills": {
+    "create-docs": {
+      "source": "nuxt-content/docus",
+      "sourceType": "github",
+      "computedHash": "3c6d7d6f6084ff5ebbd59fe8b348f99bced0d303da45cd61069a0f6dac8199f6"
+    },
+    "review-docs": {
+      "source": "nuxt-content/docus",
+      "sourceType": "github",
+      "computedHash": "016eca30a60e4d1ec38cf162753d47e52dbb543a931f77f8050d4bc4f6bc5e6b"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -339,6 +339,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/docus": {
+      "release-type": "simple",
+      "component": "docus",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

- Add Docus documentation plugin with `create-docs` and `review-docs` skills installed from `nuxt-content/docus` via `skills.sh`
- Add Docus MCP server configuration (`https://docus.dev/mcp`)
- Update marketplace, release-please config, and README entries

## Test plan

- [ ] Verify plugin appears in marketplace listing
- [ ] Confirm `create-docs` skill loads and is functional
- [ ] Confirm `review-docs` skill loads and is functional
- [ ] Validate Docus MCP server connection via `https://docus.dev/mcp`
- [ ] Check release-please config includes docus package entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `docus` plugin to the marketplace with `create-docs` and `review-docs` skills for building and auditing Docus/Nuxt Content docs. Sets up the MCP server and release automation, and updates the marketplace and README with install instructions.

- New Features
  - Added `plugins/docus` with `.claude-plugin/plugin.json` (MCP server at `https://docus.dev/mcp`) and skills directory.
  - Included `create-docs` and `review-docs` skills with references, templates, and a review report template.
  - Updated `.claude-plugin/marketplace.json` and README with install command `/plugin install docus@pleaseai`.
  - Configured `release-please-config.json` to version `plugins/docus` and added `skills-lock.json` to pin skill sources.

<sup>Written for commit 5a81a72f57fbe8067e0271c9c221a78a419e3487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

