### PR TITLE
feat(tosspayments): add tosspayments integration guide plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -396,6 +396,14 @@
       "keywords": ["docus", "nuxt", "documentation", "markdown", "nuxt-content"],
       "tags": ["framework", "docs"],
       "source": "./plugins/docus"
+    },
+    {
+      "name": "tosspayments",
+      "description": "TossPayments payment integration guide - access official documentation for payment widget, checkout, and API integration",
+      "category": "development",
+      "keywords": ["tosspayments", "payment", "checkout", "korea"],
+      "tags": ["mcp", "payment"],
+      "source": "./plugins/tosspayments"
     }
   ]
 }

--- a/plugins/tosspayments/.agents/skills/tosspayments/SKILL.md
+++ b/plugins/tosspayments/.agents/skills/tosspayments/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: TossPayments Integration Guide
+description: TossPayments payment integration documentation access via MCP. Use when integrating TossPayments payment widget, checkout flow, payment approval API, or when user mentions 토스페이먼츠, 결제, 결제위젯, 결제 승인, payment widget, TossPayments SDK, payment approval.
+allowed-tools: mcp__plugin_tosspayments_tosspayments-integration-guide__*
+---
+
+# TossPayments Integration Guide
+
+Access official TossPayments documentation through MCP tools for accurate payment integration guidance.
+
+## Available Tools
+
+- **get-v2-documents**: Search TossPayments V2 documentation (default). Use unless user explicitly asks for V1.
+- **get-v1-documents**: Search TossPayments V1 documentation. Use only when user explicitly requests V1.
+- **document-by-id**: Retrieve full document content by ID. Use to get detailed information after searching.
+
+## When to Use
+
+- Integrating TossPayments payment widget into a checkout page
+- Implementing payment approval (결제 승인) API calls
+- Setting up TossPayments V2 SDK
+- Configuring payment methods (카드, 계좌이체, 가상계좌, etc.)
+- Handling payment webhooks and callbacks
+- Understanding TossPayments API error codes
+
+## Workflow
+
+1. Use `get-v2-documents` to search for relevant documentation
+2. Use `document-by-id` to retrieve full content of matching documents
+3. Apply the documentation to generate accurate integration code
+
+## Prompt Examples
+
+- "V2 SDK로 주문서 내에 결제위젯을 삽입하는 코드를 작성해줘"
+- "결제 승인 요청하는 코드를 작성해줘"
+- "TossPayments 결제 위젯 연동 방법 알려줘"
+- "Write payment approval code using TossPayments API"
+
+## Reference
+
+- [LLM Guide](https://docs.tosspayments.com/guides/v2/get-started/llms-guide)
+- [llms.txt](https://docs.tosspayments.com/llms.txt)

--- a/plugins/tosspayments/.claude-plugin/plugin.json
+++ b/plugins/tosspayments/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "tosspayments",
+  "version": "1.0.0",
+  "description": "TossPayments payment integration guide - access official documentation for payment widget, checkout, and API integration",
+  "author": {
+    "name": "Toss Payments",
+    "url": "https://tosspayments.com"
+  },
+  "homepage": "https://docs.tosspayments.com/guides/v2/get-started/llms-guide",
+  "repository": "https://github.com/tosspayments/integration-guide-mcp",
+  "license": "MIT",
+  "keywords": ["tosspayments", "payment", "checkout", "korea", "mcp"],
+  "skills": "./.agents/skills/",
+  "mcpServers": {
+    "tosspayments-integration-guide": {
+      "command": "npx",
+      "args": ["-y", "@tosspayments/integration-guide-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add TossPayments payment integration guide plugin to the marketplace
- Plugin provides MCP server access to official TossPayments documentation via `@tosspayments/integration-guide-mcp`
- Includes intelligent skill activation for payment-related tasks

## Changes

- `plugins/tosspayments/.claude-plugin/plugin.json` - MCP server configuration using `@tosspayments/integration-guide-mcp`
- `plugins/tosspayments/.agents/skills/tosspayments/SKILL.md` - Skill for intelligent activation on payment/checkout scenarios
- `.claude-plugin/marketplace.json` - Added `tosspayments` marketplace entry

## Test Plan

- [ ] Verify plugin installs correctly: `/plugin install tosspayments@pleaseai`
- [ ] Confirm MCP server starts via `npx -y @tosspayments/integration-guide-mcp`
- [ ] Confirm skill activates when discussing TossPayments payment integration
- [ ] Check marketplace entry appears on the web UI