### PR TITLE
feat(marketplace): add Vercel plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -404,6 +404,16 @@
       "keywords": ["tosspayments", "payment", "checkout", "korea"],
       "tags": ["mcp", "payment"],
       "source": "./plugins/tosspayments"
+    },
+    {
+      "name": "vercel",
+      "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Claude Code.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vercel/vercel-plugin.git"
+      },
+      "homepage": "https://github.com/vercel/vercel-plugin"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Token-efficient browser automation CLI for coding agents — navigate, interact,
 
 **Install:** `/plugin install playwright-cli@pleaseai` | **Repository:** [pleaseai/playwright-cli](https://github.com/pleaseai/playwright-cli)
 
+#### Vercel
+Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Claude Code.
+
+**Install:** `/plugin install vercel@pleaseai` | **Repository:** [vercel/vercel-plugin](https://github.com/vercel/vercel-plugin)
+
 ---
 
 ### Built-in Plugins
@@ -250,6 +255,7 @@ Once the marketplace is added, install any plugin with:
 /plugin install grafana@pleaseai
 /plugin install chrome-devtools-mcp@pleaseai
 /plugin install playwright-cli@pleaseai
+/plugin install vercel@pleaseai
 
 # Built-in plugins
 /plugin install plugin-dev@pleaseai


### PR DESCRIPTION
## Summary

- Add the Vercel deployment platform plugin to the marketplace registry
- Source: `https://github.com/vercel/vercel-plugin.git` (URL-based, category: `deployment`)
- Update `README.md` with plugin description and install instructions

## Test plan

- [ ] Verify `.claude-plugin/marketplace.json` entry is valid (`claude plugin validate .claude-plugin/marketplace.json`)
- [ ] Confirm `/plugin install vercel@pleaseai` resolves the plugin correctly
- [ ] Check README renders the new Vercel section without formatting issues