### PR TITLE
feat: add posthog plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -424,6 +424,17 @@
         "url": "https://github.com/getsentry/sentry-for-claude.git"
       },
       "homepage": "https://github.com/getsentry/sentry-for-claude/tree/main"
+    },
+    {
+      "name": "posthog",
+      "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/PostHog/ai-plugin.git",
+        "sha": "f2f37954ecef9f1afce4fa81b6a612454a96c410"
+      },
+      "homepage": "https://posthog.com/docs/model-context-protocol"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add PostHog plugin entry to `.claude-plugin/marketplace.json`
- Plugin provides access to PostHog analytics, feature flags, experiments, error tracking, and insights from Claude Code
- Uses URL-based source pointing to the official PostHog AI plugin repository at a pinned SHA

## Test Plan

- [ ] Verify marketplace JSON is valid
- [ ] Confirm PostHog plugin entry renders correctly in the marketplace UI
- [ ] Verify the plugin can be installed via `/plugin install posthog`