### PR TITLE
chore: add enabledPlugins and extraKnownMarketplaces to project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,5 +27,62 @@
     "deny": [],
     "ask": []
   },
-  "language": "english"
+  "language": "english",
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "typescript-lsp@language-server-please": true,
+    "graphql-lsp@language-server-please": false,
+    "vue-lsp@language-server-please": true,
+    "eslint-lsp@language-server-please": true,
+    "skill-creator@claude-plugins-official": true,
+    "backend@passionfactory": false,
+    "bun@passionfactory": true,
+    "context@passionfactory": true,
+    "dev-tools@passionfactory": true,
+    "frontend@passionfactory": true,
+    "genkit@passionfactory": false,
+    "github@passionfactory": true,
+    "graphql@passionfactory": false,
+    "please@passionfactory": true,
+    "please-ai@passionfactory": false,
+    "review@passionfactory": true,
+    "reflexion@passionfactory": false,
+    "research@passionfactory": false,
+    "standards@passionfactory": true,
+    "testing@passionfactory": true,
+    "tidy-first@passionfactory": true,
+    "vuefire@passionfactory": false,
+    "auth-skills@better-auth-agent-skills": false,
+    "claude-md-management@passionfactory": true,
+    "nuxt@pleaseai": true,
+    "vue@pleaseai": true,
+    "turborepo@pleaseai": true,
+    "pinia@pleaseai": false,
+    "vitest@pleaseai": true,
+    "tsdown@pleaseai": false,
+    "vueuse@pleaseai": true,
+    "fetch@pleaseai": true,
+    "markitdown@pleaseai": true
+  },
+  "extraKnownMarketplaces": {
+    "passionfactory": {
+      "source": {
+        "source": "github",
+        "repo": "chatbot-pf/engineering-standards"
+      }
+    },
+    "language-server-please": {
+      "source": {
+        "source": "github",
+        "repo": "chatbot-pf/code-please"
+      }
+    },
+    "pleaseai": {
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/claude-code-plugins"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `enabledPlugins` configuration with all marketplace plugins and their enabled/disabled states
- Add `extraKnownMarketplaces` with passionfactory, language-server-please, and pleaseai marketplace sources

## Test plan
- [x] Verify settings.json is valid JSON
- [ ] Confirm plugins load correctly with the new configuration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `enabledPlugins` to control which marketplace plugins load, and register extra plugin marketplaces. This makes plugin loading explicit and enables discovery from `passionfactory`, `language-server-please`, and `pleaseai`.

- New Features
  - Added `enabledPlugins` map listing plugin IDs with on/off states (e.g., `vue-lsp@language-server-please`, `github@passionfactory`, `nuxt@pleaseai`).
  - Added `extraKnownMarketplaces` with GitHub sources for `passionfactory`, `language-server-please`, and `pleaseai`.

<sup>Written for commit e5da037608a3b8766b63b89e3568152c04d532a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

