### PR TITLE
chore: add review agent memory files

### DIFF
--- a/.claude/agent-memory/review-review-documentation-analyzer/MEMORY.md
+++ b/.claude/agent-memory/review-review-documentation-analyzer/MEMORY.md
@@ -1,0 +1,3 @@
+# Agent Memory Index
+
+- [Project documentation conventions](project-doc-conventions.md) — Skill reference format: frontmatter with name/description, source comments at bottom, no `allowed-tools` in SKILL.md index files

--- a/.claude/agent-memory/review-review-documentation-analyzer/project-doc-conventions.md
+++ b/.claude/agent-memory/review-review-documentation-analyzer/project-doc-conventions.md
@@ -1,0 +1,14 @@
+---
+name: Project documentation conventions
+description: Established conventions for skill reference files and SKILL.md index files in this plugin marketplace repo
+type: project
+---
+
+Skill reference files use YAML frontmatter with `name` and `description` fields (no `allowed-tools`).
+Source URL comments appear at the bottom of each reference file in an HTML comment block.
+SKILL.md index files use a table structure with Topic/Description/Reference columns, grouped into sections (Core, Features, Advanced, API).
+Plugin-only (knowledge-only) plugins have `plugin.json` with `"skills": "./.agents/skills/"` and no `mcpServers` field.
+The `skills/nuxt-i18n/` top-level directory mirrors `plugins/nuxt-i18n/.agents/skills/nuxt-i18n/` — both sets of files are identical and appear to be duplicates that are generated/synced.
+
+**Why:** Observed in nuxt-i18n PR (2026-03-28), first knowledge-only plugin without MCP server.
+**How to apply:** When reviewing skill-only plugins, expect no `mcpServers` in plugin.json and no `allowed-tools` in SKILL.md.


### PR DESCRIPTION
## Summary
- Add documentation-analyzer agent memory files created during nuxt-i18n plugin review (#117)

## Test plan
- [x] Files are valid markdown with proper frontmatter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add agent memory docs for the documentation-analyzer to codify project documentation conventions and improve review consistency. Includes an index and a conventions note covering skill reference frontmatter, SKILL.md table format, source URL comment placement, and plugin.json rules for knowledge-only plugins.

<sup>Written for commit 6e6c6c27e9cba2a2d109678ca0540c941c153a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

