### PR TITLE
docs(readme): add please-plugins entry and Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Vercel deployment platform integration. Manage deployments, check build status, 
 
 ### Built-in Plugins
 
+#### Please Plugins (Plugin Recommender)
+Auto-detect project dependencies and recommend matching Claude Code plugins from the pleaseai marketplace.
+
+**Install:** `/plugin install please-plugins@pleaseai` | **Source:** [plugins/please-plugins](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/please-plugins)
+
 #### Plugin Dev
 Best practices, guidelines, and validation tools for Claude Code plugin development.
 
@@ -232,7 +237,26 @@ Write beautiful documentations with Nuxt and Markdown.
 
 **Install:** `/plugin install docus@pleaseai` | **Source:** [plugins/docus](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/docus)
 
-## Installation
+## Quick Start
+
+The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:
+
+```bash
+# 1. Add the marketplace
+/plugin marketplace add pleaseai/claude-code-plugins
+
+# 2. Install the plugin recommender
+/plugin install please-plugins@pleaseai
+
+# 3. Scan your project and install recommended plugins
+/please-plugins:setup
+```
+
+The `please-plugins` plugin automatically detects your project's dependencies (`package.json`, lock files, `turbo.json`, etc.) and recommends matching plugins. It also watches for new package installs (`bun add`, `npm install`, `pnpm add`) and suggests plugins on the fly.
+
+**Supported ecosystems:** Nuxt, Vue, Vite, Vitest, Pinia, VueUse, Prisma, Supabase, Firebase, Playwright, Sentry, Stripe, Mastra, AI SDK, Turborepo, pnpm, and more.
+
+## Manual Installation
 
 ### Add This Marketplace
 
@@ -242,7 +266,7 @@ Write beautiful documentations with Nuxt and Markdown.
 
 ### Install a Plugin
 
-Once the marketplace is added, install any plugin with:
+Once the marketplace is added, install any plugin individually:
 
 ```bash
 # External plugins
@@ -258,6 +282,7 @@ Once the marketplace is added, install any plugin with:
 /plugin install vercel@pleaseai
 
 # Built-in plugins
+/plugin install please-plugins@pleaseai
 /plugin install plugin-dev@pleaseai
 /plugin install gatekeeper@pleaseai
 /plugin install cubic@pleaseai


### PR DESCRIPTION
## Summary

- Add `please-plugins` (Plugin Recommender) entry to the Built-in Plugins list in README
- Rename the `Installation` section to `Quick Start` with a guided 3-step setup flow using `please-plugins`
- Add a `Manual Installation` section for users who prefer to install plugins individually
- Add `please-plugins` to the manual install command examples

## Changes

- Add please-plugins description and install command under Built-in Plugins
- Introduce Quick Start section that guides users through marketplace + please-plugins setup
- Rename old Installation → Manual Installation for clarity
- Update wording from "install any plugin with:" to "install any plugin individually:"

## Test Plan

- [ ] Verify all markdown links render correctly
- [ ] Confirm command snippets in Quick Start are accurate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `please-plugins` (Plugin Recommender) to the Built-in Plugins and introduces a Quick Start that installs the marketplace, sets up `please-plugins`, and scans your project to suggest plugins. Also adds a Manual Installation section and updates examples/wording to include `please-plugins` for individual installs.

<sup>Written for commit f7514682409c57a4bc3f89db9e003a8996025669. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

