### PR TITLE
docs(web): add design context for marketplace web app

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,26 @@
+## Design Context
+
+### Users
+Developers and engineering teams who use Claude Code and want to extend it with plugins. They arrive with a specific intent: discover, evaluate, and install plugins quickly. Both individual developers seeking productivity tools and teams evaluating plugins for adoption. The interface should evoke **confidence, efficiency, and trust** -- users are installing code that runs in their development environment, so credibility signals matter.
+
+### Brand Personality
+**Polished, modern, trustworthy.**
+
+Voice is technical but approachable. Tone is confident without being corporate. The marketplace should feel like a curated, well-maintained ecosystem rather than a dumping ground. Passion Factory maintains this as a community resource, so it should communicate care and quality.
+
+### Aesthetic Direction
+- **Visual tone:** Clean and refined, similar to Vercel, Linear, or Nuxt Modules. Premium developer tool aesthetic with generous whitespace, clear hierarchy, and purposeful use of color.
+- **References:** Vercel Marketplace (sleek cards, trust signals), Nuxt Modules (clean grid, developer-friendly), Linear (refined spacing, dark mode excellence)
+- **Anti-references:** WordPress plugin directory (cluttered, ad-heavy), generic SaaS landing pages (stock photos, marketing fluff), overly playful/childish aesthetics
+- **Theme:** Light and dark mode (already supported via Nuxt UI). Dark mode should feel first-class, not an afterthought.
+- **Colors:** Nuxt UI defaults with primary color. Badge colors (amber, orange, purple, blue) for author/feature differentiation. No custom brand palette needed -- lean into the design system.
+- **Typography:** System font stack with Korean support (already configured). Prioritize readability and clear hierarchy over decorative typography.
+- **Icons:** Heroicons (UI) + Simple Icons (brand logos). Consistent sizing and alignment.
+
+### Design Principles
+
+1. **Content-first clarity** -- Plugin name, description, and install action should be instantly scannable. Every visual element must earn its place.
+2. **Trust through polish** -- Consistent spacing, aligned elements, and refined details signal that this marketplace (and its plugins) are well-maintained.
+3. **Efficient discovery** -- Users should find what they need in seconds. Search, filter, and card layout should minimize cognitive load.
+4. **Inclusive by default** -- WCAG AA compliance, respects reduced motion preferences, works well in both light and dark modes, supports Korean and English text.
+5. **Design system loyalty** -- Use Nuxt UI components and Tailwind utilities as intended. Avoid custom CSS overrides unless the design system genuinely can't express the intent. Consistency > novelty.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,3 +482,13 @@ Run this before committing new plugins or after modifying `plugin.json`.
 - Each plugin can be independently versioned and released
 - MCP servers provide the runtime interface between Claude Code and plugin functionality
 - Plugins are designed to be easily toggled on/off by users
+
+## Design Context
+
+See `.impeccable.md` for full design context. Key principles for the marketplace web app (`apps/web/`):
+
+1. **Content-first clarity** -- Plugin name, description, and install action should be instantly scannable.
+2. **Trust through polish** -- Consistent spacing, aligned elements, and refined details.
+3. **Efficient discovery** -- Users should find what they need in seconds.
+4. **Inclusive by default** -- WCAG AA, reduced motion, light/dark mode, Korean + English.
+5. **Design system loyalty** -- Use Nuxt UI components and Tailwind as intended. Consistency > novelty.


### PR DESCRIPTION
## Summary

- Add `.impeccable.md` with full design context for the marketplace web app
- Reference `.impeccable.md` from `CLAUDE.md` under a new "Design Context" section
- Document five key design principles for `apps/web/`

## Design Principles Added

1. **Content-first clarity** -- Plugin name, description, and install action should be instantly scannable.
2. **Trust through polish** -- Consistent spacing, aligned elements, and refined details.
3. **Efficient discovery** -- Users should find what they need in seconds.
4. **Inclusive by default** -- WCAG AA, reduced motion, light/dark mode, Korean + English.
5. **Design system loyalty** -- Use Nuxt UI components and Tailwind as intended. Consistency over novelty.

## Test Plan

- [ ] Verify `.impeccable.md` is present and readable at repo root
- [ ] Verify `CLAUDE.md` references `.impeccable.md` correctly in the Design Context section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.impeccable.md` with full design context for the marketplace web app and links it from `CLAUDE.md`. This clarifies users, brand, aesthetic, and five principles guiding `apps/web/` UI/UX.

- **New Features**
  - Added `.impeccable.md` (users, brand personality, aesthetic direction, five design principles for `apps/web/`).
  - Updated `CLAUDE.md` with a "Design Context" section that links to `.impeccable.md` and summarizes the principles.

<sup>Written for commit 6426d56bc6adf973a49fc5d436066d4612f97e9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

