### PR TITLE
feat(emulate): add Emulate plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -535,6 +535,14 @@
       "keywords": ["tiptap", "rich-text-editor", "prosemirror", "wysiwyg"],
       "tags": ["framework", "editor"],
       "source": "./plugins/tiptap"
+    },
+    {
+      "name": "emulate",
+      "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+      "category": "development",
+      "keywords": ["emulate", "api-emulation", "local-development", "testing"],
+      "tags": ["tooling", "testing"],
+      "source": "./plugins/emulate"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ Helps coding agents integrate and work with the Tiptap rich text editor — exte
 
 **Install:** `/plugin install tiptap@pleaseai` | **Source:** [plugins/tiptap](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/tiptap)
 
+#### Emulate
+Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS.
+
+**Install:** `/plugin install emulate@pleaseai` | **Source:** [plugins/emulate](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/emulate)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:
@@ -349,6 +354,7 @@ Once the marketplace is added, install any plugin individually:
 /plugin install next@pleaseai
 /plugin install react@pleaseai
 /plugin install react-native@pleaseai
+/plugin install emulate@pleaseai
 ```
 
 ## What Are Claude Code Plugins?

--- a/plugins/emulate/.agents/skills/emulate/SKILL.md
+++ b/plugins/emulate/.agents/skills/emulate/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: emulate
+description: Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Use when the user needs to start emulated services, configure seed data, write tests against local APIs, set up CI without network access, or work with the emulate CLI or programmatic API. Triggers include "start the emulator", "emulate services", "mock API locally", "create emulator config", "test against local API", "npx emulate", or any task requiring local service emulation.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+---
+
+# Service Emulation with emulate
+
+Local drop-in replacement services for CI and no-network sandboxes. Fully stateful, production-fidelity API emulation, not mocks.
+
+## Quick Start
+
+```bash
+npx emulate
+```
+
+All services start with sensible defaults:
+
+| Service   | Default Port |
+|-----------|-------------|
+| Vercel    | 4000        |
+| GitHub    | 4001        |
+| Google    | 4002        |
+| Slack     | 4003        |
+| Apple     | 4004        |
+| Microsoft | 4005        |
+| AWS       | 4006        |
+
+## CLI
+
+```bash
+# Start all services (zero-config)
+emulate
+
+# Start specific services
+emulate --service vercel,github
+
+# Custom base port (auto-increments per service)
+emulate --port 3000
+
+# Use a seed config file
+emulate --seed config.yaml
+
+# Generate a starter config
+emulate init
+
+# Generate config for a specific service
+emulate init --service vercel
+
+# List available services
+emulate list
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-p, --port` | `4000` | Base port (auto-increments per service) |
+| `-s, --service` | all | Comma-separated services to enable |
+| `--seed` | auto-detect | Path to seed config (YAML or JSON) |
+
+The port can also be set via `EMULATE_PORT` or `PORT` environment variables.
+
+## Programmatic API
+
+```bash
+npm install emulate
+```
+
+Each call to `createEmulator` starts a single service:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const github = await createEmulator({ service: 'github', port: 4001 })
+const vercel = await createEmulator({ service: 'vercel', port: 4002 })
+
+github.url   // 'http://localhost:4001'
+vercel.url   // 'http://localhost:4002'
+
+await github.close()
+await vercel.close()
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `service` | *(required)* | `'vercel'`, `'github'`, `'google'`, `'slack'`, `'apple'`, `'microsoft'`, or `'aws'` |
+| `port` | `4000` | Port for the HTTP server |
+| `seed` | none | Inline seed data (same shape as YAML config) |
+
+### Instance Methods
+
+| Method | Description |
+|--------|-------------|
+| `url` | Base URL of the running server |
+| `reset()` | Wipe the store and replay seed data |
+| `close()` | Shut down the HTTP server, returns a Promise |
+
+## Vitest / Jest Setup
+
+```typescript
+import { createEmulator, type Emulator } from 'emulate'
+
+let github: Emulator
+let vercel: Emulator
+
+beforeAll(async () => {
+  ;[github, vercel] = await Promise.all([
+    createEmulator({ service: 'github', port: 4001 }),
+    createEmulator({ service: 'vercel', port: 4002 }),
+  ])
+  process.env.GITHUB_URL = github.url
+  process.env.VERCEL_URL = vercel.url
+})
+
+afterEach(() => { github.reset(); vercel.reset() })
+afterAll(() => Promise.all([github.close(), vercel.close()]))
+```
+
+## Configuration
+
+Configuration is optional. The CLI auto-detects config files in this order:
+
+1. `emulate.config.yaml` / `.yml`
+2. `emulate.config.json`
+3. `service-emulator.config.yaml` / `.yml`
+4. `service-emulator.config.json`
+
+Or pass `--seed <file>` explicitly. Run `emulate init` to generate a starter file.
+
+### Config Structure
+
+```yaml
+tokens:
+  my_token:
+    login: admin
+    scopes: [repo, user]
+
+vercel:
+  users:
+    - username: developer
+      name: Developer
+      email: dev@example.com
+  teams:
+    - slug: my-team
+      name: My Team
+  projects:
+    - name: my-app
+      team: my-team
+      framework: nextjs
+  integrations:
+    - client_id: oac_abc123
+      client_secret: secret_abc123
+      name: My Vercel App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/vercel
+
+github:
+  users:
+    - login: octocat
+      name: The Octocat
+      email: octocat@github.com
+  orgs:
+    - login: my-org
+      name: My Organization
+  repos:
+    - owner: octocat
+      name: hello-world
+      language: JavaScript
+      auto_init: true
+  oauth_apps:
+    - client_id: Iv1.abc123
+      client_secret: secret_abc123
+      name: My Web App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/github
+
+google:
+  users:
+    - email: testuser@example.com
+      name: Test User
+  oauth_clients:
+    - client_id: my-client-id.apps.googleusercontent.com
+      client_secret: GOCSPX-secret
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/google
+
+slack:
+  team:
+    name: My Workspace
+    domain: my-workspace
+  users:
+    - name: developer
+      real_name: Developer
+      email: dev@example.com
+  channels:
+    - name: general
+      topic: General discussion
+  bots:
+    - name: my-bot
+  oauth_apps:
+    - client_id: "12345.67890"
+      client_secret: example_client_secret
+      name: My Slack App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/slack
+
+apple:
+  users:
+    - email: testuser@icloud.com
+      name: Test User
+  oauth_clients:
+    - client_id: com.example.app
+      team_id: TEAM001
+      name: My Apple App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/apple
+
+microsoft:
+  users:
+    - email: testuser@outlook.com
+      name: Test User
+  oauth_clients:
+    - client_id: example-client-id
+      client_secret: example-client-secret
+      name: My Microsoft App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/microsoft-entra-id
+
+aws:
+  region: us-east-1
+  s3:
+    buckets:
+      - name: my-app-bucket
+  sqs:
+    queues:
+      - name: my-app-events
+  iam:
+    users:
+      - user_name: developer
+        create_access_key: true
+    roles:
+      - role_name: lambda-execution-role
+```
+
+### Auth
+
+Tokens map to users. Pass them as `Authorization: Bearer <token>` or `Authorization: token <token>`. When no tokens are configured, a default `test_token_admin` is created for the `admin` user.
+
+Each service also has a fallback user. If no token is provided, requests authenticate as the first seeded user.
+
+## Pointing Your App at the Emulator
+
+Set environment variables to override real service URLs:
+
+```bash
+VERCEL_EMULATOR_URL=http://localhost:4000
+GITHUB_EMULATOR_URL=http://localhost:4001
+GOOGLE_EMULATOR_URL=http://localhost:4002
+SLACK_EMULATOR_URL=http://localhost:4003
+APPLE_EMULATOR_URL=http://localhost:4004
+MICROSOFT_EMULATOR_URL=http://localhost:4005
+AWS_EMULATOR_URL=http://localhost:4006
+```
+
+Then use these in your app to construct API and OAuth URLs. See each service's skill for SDK-specific override instructions.
+
+## Architecture
+
+```
+packages/
+  emulate/           # CLI entry point + programmatic API
+  @emulators/
+    core/            # HTTP server (Hono), Store, plugin interface, middleware
+    vercel/          # Vercel API service plugin
+    github/          # GitHub API service plugin
+    google/          # Google OAuth 2.0 / OIDC plugin
+    slack/           # Slack Web API, OAuth, incoming webhooks plugin
+    apple/           # Sign in with Apple / OIDC plugin
+    microsoft/       # Microsoft Entra ID OAuth 2.0 / OIDC plugin
+    aws/             # AWS S3, SQS, IAM, STS plugin
+```
+
+The core provides a generic `Store` with typed `Collection<T>` instances supporting CRUD, indexing, filtering, and pagination. Each service plugin registers routes on the shared Hono app and uses the store for state.

--- a/plugins/emulate/.claude-plugin/plugin.json
+++ b/plugins/emulate/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "emulate",
+  "version": "1.0.0",
+  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+  "license": "Apache-2.0",
+  "keywords": ["emulate", "api-emulation", "local-development", "testing"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/emulate/skills-lock.json
+++ b/plugins/emulate/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "emulate": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "computedHash": "c71f52c30b0bdfdccf008c89f0c2347e532686fe4a34b23abcc21343eb7de5dc"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -438,6 +438,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/emulate": {
+      "release-type": "simple",
+      "component": "emulate",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

- Add Emulate plugin for local drop-in API emulation (Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS)
- Update marketplace configuration in `.claude-plugin/marketplace.json`
- Add plugin entry to README with install instructions
- Add `plugins/emulate` to `release-please-config.json` for versioning

## Test plan

- [ ] Verify `plugins/emulate/.claude-plugin/plugin.json` is valid (`claude plugin validate plugins/emulate`)
- [ ] Confirm marketplace entry appears correctly on the web app
- [ ] Check install command works: `/plugin install emulate@pleaseai`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `emulate` plugin to the marketplace for local, drop-in API emulation of Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS. Install with `/plugin install emulate@pleaseai` and use it to run emulated services for dev and CI.

- **New Features**
  - Added marketplace entry for `emulate` with description, tags, and source path.
  - Added plugin manifest, skill docs, and `skills-lock.json` under `plugins/emulate`.
  - Updated README with install instructions and links; added `plugins/emulate` to `release-please-config.json` for versioning.

<sup>Written for commit 03830d416d94c62bb865553562a16f79a7d4f184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

