### PR TITLE
feat(ask): add ASK plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -543,6 +543,17 @@
       "keywords": ["emulate", "api-emulation", "local-development", "testing"],
       "tags": ["tooling", "testing"],
       "source": "./plugins/emulate"
+    },
+    {
+      "name": "ask",
+      "description": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+      "category": "development",
+      "keywords": ["documentation", "registry", "library", "agent-skills", "ask"],
+      "tags": ["tooling", "documentation"],
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/ask"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, 
 
 **Install:** `/plugin install emulate@pleaseai` | **Source:** [plugins/emulate](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/emulate)
 
+#### ASK
+ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries.
+
+**Install:** `/plugin install ask@pleaseai` | **Source:** [pleaseai/ask](https://github.com/pleaseai/ask)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:
@@ -355,6 +360,7 @@ Once the marketplace is added, install any plugin individually:
 /plugin install react@pleaseai
 /plugin install react-native@pleaseai
 /plugin install emulate@pleaseai
+/plugin install ask@pleaseai
 ```
 
 ## What Are Claude Code Plugins?


### PR DESCRIPTION
## Summary

- Add Agent Skills Kit (ASK) plugin (`pleaseai/ask`) to the marketplace
- Categorized under `development` with `tooling` and `documentation` tags
- Keywords: `documentation`, `registry`, `library`, `agent-skills`, `ask`

## Test plan

- [ ] Verify `ask` entry appears correctly in the marketplace JSON
- [ ] Confirm the plugin installs successfully via `/plugin install ask@pleaseai`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ask` (Agent Skills Kit) plugin from `pleaseai/ask` to the marketplace in `.claude-plugin/marketplace.json`, categorized under `development` with `tooling` and `documentation` tags. Updates `README.md` with an ASK section and adds `/plugin install ask@pleaseai` to the install examples.

<sup>Written for commit 836b642aedf2938a7e4f504c1ed81cd2926ff845. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

