### PR TITLE
feat(edgeparse): add EdgeParse plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -568,6 +568,14 @@
         "ref": "main"
       },
       "homepage": "https://github.com/pleaseai/gemini-plugin-cc/tree/main/plugins/gemini"
+    },
+    {
+      "name": "edgeparse",
+      "description": "Extract structured content from any PDF — headings, tables, paragraphs, lists, bounding boxes — deterministically, without ML dependencies or GPU requirements",
+      "category": "document",
+      "keywords": ["pdf", "extraction", "parsing", "markdown", "rag"],
+      "tags": ["skill", "document"],
+      "source": "./plugins/edgeparse"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ ASK (Agent Skills Kit) — AI agent skills for managing library documentation re
 
 **Install:** `/plugin install ask@pleaseai` | **Source:** [pleaseai/ask](https://github.com/pleaseai/ask)
 
+#### EdgeParse
+Extract structured content from any PDF — headings, tables, paragraphs, lists, bounding boxes — deterministically, without ML dependencies or GPU requirements.
+
+**Install:** `/plugin install edgeparse@pleaseai` | **Source:** [plugins/edgeparse](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/edgeparse)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:

--- a/plugins/edgeparse/.agents/skills/edgeparse/SKILL.md
+++ b/plugins/edgeparse/.agents/skills/edgeparse/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: edgeparse
+description: Extract structured content from any PDF for AI agents, RAG pipelines, and Copilot Skills. Use this skill whenever the user wants to read, analyze, or reason about a PDF document; needs to feed document content to an LLM; mentions PDF extraction, parsing, or conversion; wants tables, headings, or bounding boxes from a PDF; is building a RAG pipeline; or asks an agent to process a document. Install with: pip install edgeparse
+license: Apache-2.0
+metadata:
+  authors: "EdgeParse Contributors"
+  version: "0.1.0"
+  package: "edgeparse"
+  install_python: "pip install edgeparse"
+  install_node: "npm install edgeparse"
+  source: "raphaelmansuy/edgeparse"
+---
+
+# EdgeParse Skill
+
+Enables AI agents to extract clean, structured content from any PDF — headings, tables, paragraphs, lists, bounding boxes — deterministically, without ML dependencies or GPU requirements.
+
+**Install:** `pip install edgeparse` · **Node.js:** `npm install edgeparse`  
+**Speed:** ~0.023 s/doc (Apple M4 Max, 200-doc benchmark)
+
+---
+
+## When to reach for this skill
+
+Activate when the workflow involves:
+- Reading or analyzing a PDF document on behalf of a user
+- Building a RAG pipeline that ingests PDFs
+- Feeding PDF content to an LLM for summarization, Q&A, or synthesis
+- Extracting tables from financial reports, research papers, or invoices
+- Processing a batch of documents for indexing or search
+- An agent tool that must "open" a PDF and return its contents
+
+---
+
+## Quick start
+
+```python
+import edgeparse
+
+# Convert any PDF to Markdown — best for LLM context windows
+text = edgeparse.convert("report.pdf", format="markdown")
+
+# Convert to JSON with bounding boxes and full structure
+import json
+doc = json.loads(edgeparse.convert("report.pdf", format="json"))
+
+# Plain text (fast, minimal)
+plain = edgeparse.convert("report.pdf", format="text")
+```
+
+The `format` parameter controls output:
+| Value | Best for |
+|-------|----------|
+| `"markdown"` | LLM context — headings, tables, lists in Markdown |
+| `"json"` | Bounding boxes, citations, structured element metadata |
+| `"html"` | Web rendering, semantic HTML5 |
+| `"text"` | Simple full-text search, minimal output |
+
+---
+
+## Core API
+
+### `edgeparse.convert()`
+
+```python
+result: str = edgeparse.convert(
+    input_path,             # str or Path — required
+    format="markdown",      # output format (see table above)
+    pages=None,             # e.g. "1-5" or "1,3,7-10" — specific pages only
+    password=None,          # for password-protected PDFs
+    reading_order="xycut",  # "xycut" (spatial sort, default) or "off"
+    table_method="default", # "default" (ruling-line) or "cluster" (borderless)
+    image_output="off",     # "off", "embedded" (base64), "external" (files)
+)
+```
+
+Returns the extracted content as a **string**. Raises `FileNotFoundError` for missing files and `ValueError` for corrupt PDFs or bad options.
+
+### `edgeparse.convert_file()`
+
+```python
+out_path: str = edgeparse.convert_file(
+    input_path,
+    output_dir="output",    # write output file to this directory
+    format="markdown",
+    pages=None,
+    password=None,
+)
+```
+
+Writes the output file and returns its path.
+
+---
+
+## Common patterns
+
+### Feed a PDF to an LLM
+
+```python
+import edgeparse
+import anthropic
+
+doc = edgeparse.convert("report.pdf", format="markdown")
+
+client = anthropic.Anthropic()
+response = client.messages.create(
+    model="claude-opus-4-5",
+    max_tokens=4096,
+    messages=[{
+        "role": "user",
+        "content": f"Analyze this document and summarize the key findings:\n\n{doc}"
+    }]
+)
+print(response.content[0].text)
+```
+
+### RAG pipeline — chunk with metadata
+
+```python
+import edgeparse, json
+
+raw = edgeparse.convert("paper.pdf", format="json")
+doc = json.loads(raw)
+
+chunks = []
+for el in doc["elements"]:
+    if el["type"] in ("paragraph", "heading", "table"):
+        chunks.append({
+            "text": el["text"],
+            "metadata": {
+                "page":    el["page_number"],
+                "type":    el["type"],
+                "bbox":    el["bounding_box"],   # for citation highlights
+                "order":   el["reading_order"],
+            }
+        })
+
+# Now embed chunks["text"] and store chunks["metadata"] in your vector store
+```
+
+### Batch processing
+
+```python
+import edgeparse
+from pathlib import Path
+
+results = {}
+for pdf in Path("documents/").glob("*.pdf"):
+    try:
+        results[pdf.name] = edgeparse.convert(str(pdf), format="markdown")
+    except Exception as e:
+        results[pdf.name] = f"ERROR: {e}"
+```
+
+### Extract specific pages only
+
+```python
+# Pages 1–5
+text = edgeparse.convert("report.pdf", format="markdown", pages="1-5")
+
+# Non-contiguous pages
+text = edgeparse.convert("report.pdf", format="markdown", pages="1,3,7-10")
+```
+
+### Borderless table extraction
+
+Many financial reports and invoices use tables without ruling lines.
+Use `table_method="cluster"` to handle them:
+
+```python
+text = edgeparse.convert(
+    "earnings.pdf",
+    format="markdown",
+    table_method="cluster"   # spatial clustering for borderless tables
+)
+```
+
+### Password-protected PDF
+
+```python
+text = edgeparse.convert("secure.pdf", format="markdown", password="mypassword")
+```
+
+---
+
+## Node.js usage
+
+```js
+import { convert } from 'edgeparse';
+
+const markdown = convert('report.pdf', { format: 'markdown' });
+const json     = convert('report.pdf', { format: 'json' });
+
+// With options
+const result = convert('report.pdf', {
+    format:       'markdown',
+    pages:        '1-5',
+    readingOrder: 'xycut',
+    tableMethod:  'cluster',
+});
+```
+
+---
+
+## JSON output schema
+
+When `format="json"`, the output is a JSON string with shape:
+
+```json
+{
+  "page_count": 10,
+  "title": "Document Title",
+  "elements": [
+    {
+      "type": "heading",
+      "level": 1,
+      "text": "Introduction",
+      "page_number": 1,
+      "reading_order": 0,
+      "bounding_box": { "x0": 72, "y0": 144, "x1": 540, "y1": 180 }
+    },
+    {
+      "type": "table",
+      "text": "| Col A | Col B |\n|-------|-------|\n| val1  | val2  |",
+      "page_number": 2,
+      "bounding_box": { "x0": 72, "y0": 200, "x1": 540, "y1": 350 }
+    },
+    {
+      "type": "paragraph",
+      "text": "This is body text...",
+      "page_number": 1,
+      "reading_order": 2,
+      "bounding_box": { "x0": 72, "y0": 190, "x1": 540, "y1": 220 }
+    }
+  ]
+}
+```
+
+Element `type` values: `heading`, `paragraph`, `table`, `list`, `list_item`, `figure`, `caption`, `header`, `footer`.
+
+---
+
+## Error handling
+
+```python
+import edgeparse
+
+try:
+    text = edgeparse.convert("report.pdf", format="markdown")
+except FileNotFoundError:
+    # PDF file not found — check the path
+    pass
+except ValueError as e:
+    # Invalid format, corrupt PDF, wrong password, or bad page range
+    print(f"Extraction failed: {e}")
+```
+
+---
+
+## For more detail
+
+Read these reference files when the SKILL.md body isn't enough:
+- `references/api.md` — complete Python + Node.js API with all parameters and types
+- `references/patterns.md` — LangChain, LlamaIndex, MCP tool, CrewAI, and async batch patterns

--- a/plugins/edgeparse/.agents/skills/edgeparse/references/api.md
+++ b/plugins/edgeparse/.agents/skills/edgeparse/references/api.md
@@ -1,0 +1,228 @@
+# EdgeParse API Reference
+
+Complete Python and Node.js API for the EdgeParse skill.
+
+---
+
+## Python API
+
+### Installation
+
+```bash
+pip install edgeparse
+```
+
+Requires Python 3.9+. Pre-built wheels for macOS (arm64, x86_64), Linux (x86_64, arm64), Windows (x86_64).
+
+---
+
+### `edgeparse.convert()`
+
+Extract content from a PDF and return it as a string.
+
+```python
+def convert(
+    input_path: str | Path,
+    *,
+    format: str = "markdown",
+    pages: str | None = None,
+    password: str | None = None,
+    reading_order: str = "xycut",
+    table_method: str = "default",
+    image_output: str = "off",
+    keep_line_breaks: bool = False,
+    use_struct_tree: bool = False,
+    include_header_footer: bool = False,
+    sanitize: bool = False,
+) -> str: ...
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input_path` | `str \| Path` | required | Path to the PDF file |
+| `format` | `str` | `"markdown"` | Output format: `"markdown"`, `"markdown-with-html"`, `"markdown-with-images"`, `"json"`, `"html"`, `"text"` |
+| `pages` | `str \| None` | `None` | Page range, e.g. `"1-5"` or `"1,3,7-10"`. `None` = all pages |
+| `password` | `str \| None` | `None` | Password for encrypted PDFs |
+| `reading_order` | `str` | `"xycut"` | Reading order algorithm: `"xycut"` (spatial XY-Cut++) or `"off"` |
+| `table_method` | `str` | `"default"` | Table detection: `"default"` (ruling-line) or `"cluster"` (borderless) |
+| `image_output` | `str` | `"off"` | Image handling: `"off"`, `"embedded"` (base64 in output), `"external"` (write files) |
+| `keep_line_breaks` | `bool` | `False` | Preserve original line breaks within paragraphs |
+| `use_struct_tree` | `bool` | `False` | Use tagged PDF structure tree when available |
+| `include_header_footer` | `bool` | `False` | Include page headers and footers |
+| `sanitize` | `bool` | `False` | Enable PII sanitization |
+
+**Returns:** `str` — extracted content in the requested format.
+
+**Raises:**
+- `FileNotFoundError` — PDF file not found at `input_path`
+- `ValueError` — Invalid format, corrupt/unreadable PDF, wrong password, bad page range
+
+---
+
+### `edgeparse.convert_file()`
+
+Extract content from a PDF and write the output to a file.
+
+```python
+def convert_file(
+    input_path: str | Path,
+    output_dir: str | Path = "output",
+    *,
+    format: str = "markdown",
+    pages: str | None = None,
+    password: str | None = None,
+    reading_order: str = "xycut",
+    table_method: str = "default",
+    image_output: str = "off",
+) -> str: ...
+```
+
+**Parameters:** same as `convert()` plus `output_dir`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `output_dir` | `str \| Path` | `"output"` | Directory to write the output file |
+
+**Returns:** `str` — path to the written output file.
+
+---
+
+### Output format reference
+
+#### `format="markdown"` (recommended for LLMs)
+
+| Element | Markdown rendering |
+|---------|-------------------|
+| H1–H6 headings | `# Heading`, `## Heading`, ... |
+| Paragraph | plain text |
+| Table with ruling lines | GFM table `\| col \| col \|` |
+| Table borderless | GFM table (with `table_method="cluster"`) |
+| Bullet list | `- item` |
+| Numbered list | `1. item` |
+| Figure/image | `![alt](path)` (requires `image_output` ≠ `"off"`) |
+| Header/footer | omitted (unless `include_header_footer=True`) |
+
+#### `format="json"` (for structured workflows)
+
+Returns a JSON string. Parse with `json.loads()`.
+
+```json
+{
+  "page_count": 10,
+  "title": "Document Title",
+  "elements": [
+    {
+      "type": "heading",
+      "level": 1,
+      "text": "Introduction",
+      "page_number": 1,
+      "reading_order": 0,
+      "bounding_box": { "x0": 72.0, "y0": 144.0, "x1": 540.0, "y1": 180.0 }
+    },
+    {
+      "type": "table",
+      "text": "| Col A | Col B |\n|-------|-------|\n| val1  | val2  |",
+      "page_number": 2,
+      "reading_order": 5,
+      "bounding_box": { "x0": 72.0, "y0": 200.0, "x1": 540.0, "y1": 350.0 },
+      "rows": [
+        { "cells": [{ "text": "Col A", "rowspan": 1, "colspan": 1 }, { "text": "Col B", "rowspan": 1, "colspan": 1 }] }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "text": "This is body text.",
+      "page_number": 1,
+      "reading_order": 2,
+      "bounding_box": { "x0": 72.0, "y0": 190.0, "x1": 540.0, "y1": 220.0 }
+    }
+  ]
+}
+```
+
+**Element types:** `heading`, `paragraph`, `table`, `list`, `list_item`, `figure`, `caption`, `header`, `footer`
+
+**Bounding box** coordinates are in PDF points from the bottom-left of the page.
+
+---
+
+## Node.js API
+
+### Installation
+
+```bash
+npm install edgeparse
+```
+
+Requires Node.js 18+.
+
+---
+
+### `convert()`
+
+```ts
+import { convert } from 'edgeparse';
+
+function convert(inputPath: string, options?: ConvertOptions): string
+```
+
+**ConvertOptions:**
+
+```ts
+interface ConvertOptions {
+  format?:        string;   // "markdown" | "json" | "html" | "text"  (default: "markdown")
+  pages?:         string;   // e.g. "1-5" or "1,3,7-10"
+  password?:      string;
+  readingOrder?:  string;   // "xycut" | "off"                         (default: "xycut")
+  tableMethod?:   string;   // "default" | "cluster"                   (default: "default")
+  imageOutput?:   string;   // "off" | "embedded" | "external"         (default: "off")
+}
+```
+
+**Returns:** `string` — extracted content.  
+**Throws:** `Error` on file not found, corrupt PDF, or invalid options.
+
+---
+
+## CLI reference
+
+```bash
+edgeparse [OPTIONS] <PDF_FILE>...
+
+# Core flags
+-f, --format <FMT>        markdown | json | html | text   (default: json)
+-o, --output-dir <DIR>    Write output files here
+-p, --password <PW>       Password for encrypted PDFs
+    --pages <RANGE>       e.g. "1-5" or "1,3,7-10"
+-q, --quiet               Suppress log output
+
+# Table and layout
+    --table-method <M>    default | cluster
+    --reading-order <A>   xycut | off
+    --keep-line-breaks    Preserve original line breaks
+    --use-struct-tree     Use tagged PDF structure tree
+    --include-header-footer
+
+# Image options
+    --image-output <M>    off | embedded | external
+    --image-format <F>    png | jpeg
+    --image-dir <DIR>     Directory for extracted images
+```
+
+**Examples:**
+
+```bash
+# Markdown to stdout
+edgeparse report.pdf --format markdown
+
+# JSON to file
+edgeparse report.pdf --format json --output-dir ./output
+
+# Batch
+edgeparse docs/*.pdf --format markdown --output-dir ./output
+
+# Password + page range
+edgeparse secure.pdf --format markdown --password mypass --pages 1-5
+```

--- a/plugins/edgeparse/.agents/skills/edgeparse/references/patterns.md
+++ b/plugins/edgeparse/.agents/skills/edgeparse/references/patterns.md
@@ -1,0 +1,308 @@
+# EdgeParse Integration Patterns
+
+Common patterns for integrating EdgeParse into AI agent frameworks, RAG pipelines, and production workflows.
+
+---
+
+## LangChain
+
+### PDF loader
+
+Use EdgeParse as a custom document loader:
+
+```python
+from langchain.schema import Document
+import edgeparse, json
+
+def load_pdf_with_edgeparse(path: str) -> list[Document]:
+    """Load a PDF and return LangChain Documents with metadata."""
+    raw = edgeparse.convert(path, format="json")
+    doc = json.loads(raw)
+
+    documents = []
+    for el in doc["elements"]:
+        if el["type"] not in ("header", "footer"):
+            documents.append(Document(
+                page_content=el["text"],
+                metadata={
+                    "source":   path,
+                    "page":     el["page_number"],
+                    "type":     el["type"],
+                    "bbox":     el["bounding_box"],
+                }
+            ))
+    return documents
+
+# Use with any LangChain retriever
+docs = load_pdf_with_edgeparse("report.pdf")
+```
+
+### RAG chain
+
+```python
+from langchain.vectorstores import Chroma
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.chains import RetrievalQA
+from langchain_anthropic import ChatAnthropic
+
+docs = load_pdf_with_edgeparse("report.pdf")
+
+vectorstore = Chroma.from_documents(docs, OpenAIEmbeddings())
+retriever = vectorstore.as_retriever(search_kwargs={"k": 5})
+
+chain = RetrievalQA.from_chain_type(
+    llm=ChatAnthropic(model="claude-opus-4-5"),
+    retriever=retriever,
+)
+result = chain.run("What are the key financial metrics?")
+```
+
+---
+
+## LlamaIndex
+
+### SimpleDirectoryReader replacement
+
+```python
+from llama_index.core import VectorStoreIndex
+from llama_index.core.schema import TextNode
+import edgeparse, json
+
+def edgeparse_nodes(paths: list[str]) -> list[TextNode]:
+    nodes = []
+    for path in paths:
+        raw = edgeparse.convert(path, format="json")
+        doc = json.loads(raw)
+        for el in doc["elements"]:
+            if el["text"].strip():
+                nodes.append(TextNode(
+                    text=el["text"],
+                    metadata={"source": path, "page": el["page_number"], "type": el["type"]},
+                ))
+    return nodes
+
+nodes = edgeparse_nodes(["report.pdf", "paper.pdf"])
+index = VectorStoreIndex(nodes)
+query_engine = index.as_query_engine()
+response = query_engine.query("Summarize the methodology section")
+print(response)
+```
+
+---
+
+## MCP (Model Context Protocol) tool
+
+Register EdgeParse as an MCP tool so Claude Desktop can call it:
+
+```python
+from mcp.server.models import InitializationOptions
+from mcp.server import NotificationOptions, Server
+from mcp import types
+import edgeparse
+
+server = Server("edgeparse-mcp")
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [types.Tool(
+        name="read_pdf",
+        description="Extract structured text from a PDF file. Returns Markdown.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "path":   {"type": "string", "description": "Path to the PDF file"},
+                "pages":  {"type": "string", "description": "Optional page range, e.g. '1-5'"},
+                "format": {"type": "string", "enum": ["markdown", "json", "text"], "default": "markdown"},
+            },
+            "required": ["path"],
+        },
+    )]
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+    if name == "read_pdf":
+        try:
+            result = edgeparse.convert(
+                arguments["path"],
+                format=arguments.get("format", "markdown"),
+                pages=arguments.get("pages"),
+            )
+            return [types.TextContent(type="text", text=result)]
+        except Exception as e:
+            return [types.TextContent(type="text", text=f"Error: {e}")]
+    raise ValueError(f"Unknown tool: {name}")
+```
+
+---
+
+## CrewAI agent tool
+
+```python
+from crewai_tools import BaseTool
+import edgeparse
+
+class PDFExtractorTool(BaseTool):
+    name: str = "PDF Extractor"
+    description: str = (
+        "Extract text, tables, and structure from a PDF file. "
+        "Input: file path. Output: Markdown text."
+    )
+
+    def _run(self, pdf_path: str, pages: str = None) -> str:
+        try:
+            return edgeparse.convert(
+                pdf_path,
+                format="markdown",
+                pages=pages,
+                table_method="cluster",
+            )
+        except Exception as e:
+            return f"Failed to extract PDF: {e}"
+
+# In your crew
+from crewai import Agent
+
+analyst = Agent(
+    role="Document Analyst",
+    goal="Extract and analyze information from PDF documents",
+    tools=[PDFExtractorTool()],
+)
+```
+
+---
+
+## OpenAI function calling
+
+```python
+import openai
+import edgeparse, json
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "read_pdf",
+        "description": "Extract text and tables from a PDF file",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path":   {"type": "string"},
+                "format": {"type": "string", "enum": ["markdown", "json", "text"]},
+                "pages":  {"type": "string"},
+            },
+            "required": ["path"],
+        },
+    }
+}]
+
+def handle_tool_call(tool_name, args):
+    if tool_name == "read_pdf":
+        return edgeparse.convert(
+            args["path"],
+            format=args.get("format", "markdown"),
+            pages=args.get("pages"),
+        )
+
+client = openai.OpenAI()
+messages = [{"role": "user", "content": "Summarize the report at /tmp/report.pdf"}]
+
+response = client.chat.completions.create(model="gpt-4o", messages=messages, tools=tools)
+
+if response.choices[0].message.tool_calls:
+    call = response.choices[0].message.tool_calls[0]
+    result = handle_tool_call(call.function.name, json.loads(call.function.arguments))
+    # Continue conversation with tool result...
+```
+
+---
+
+## Async batch processing
+
+For high-throughput pipelines, use async:
+
+```python
+import asyncio
+import edgeparse
+from pathlib import Path
+
+async def extract_pdf(path: str, semaphore: asyncio.Semaphore) -> tuple[str, str]:
+    async with semaphore:
+        # EdgeParse is CPU-bound; use executor to avoid blocking the event loop
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(
+            None, lambda: edgeparse.convert(path, format="markdown")
+        )
+        return path, result
+
+async def batch_extract(pdf_dir: str, max_concurrent: int = 8) -> dict[str, str]:
+    paths = [str(p) for p in Path(pdf_dir).glob("*.pdf")]
+    semaphore = asyncio.Semaphore(max_concurrent)
+    tasks = [extract_pdf(p, semaphore) for p in paths]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return {
+        path: result if isinstance(result, str) else f"ERROR: {result}"
+        for path, result in results
+    }
+
+# Run
+results = asyncio.run(batch_extract("documents/"))
+```
+
+---
+
+## Chunking strategy for RAG
+
+EdgeParse element boundaries make natural chunk boundaries:
+
+```python
+import edgeparse, json
+
+def chunk_for_rag(
+    pdf_path: str,
+    max_chunk_tokens: int = 512,
+    overlap_elements: int = 1,
+) -> list[dict]:
+    raw = edgeparse.convert(pdf_path, format="json")
+    doc = json.loads(raw)
+
+    chunks = []
+    current_chunk = []
+    current_len = 0
+
+    for el in doc["elements"]:
+        if el["type"] in ("header", "footer"):
+            continue
+
+        el_len = len(el["text"].split())
+
+        # Heading = natural chunk boundary
+        if el["type"] == "heading" and current_chunk:
+            chunks.append({
+                "text": "\n\n".join(e["text"] for e in current_chunk),
+                "page_start": current_chunk[0]["page_number"],
+                "page_end": current_chunk[-1]["page_number"],
+            })
+            current_chunk = current_chunk[-overlap_elements:]  # overlap
+            current_len = sum(len(e["text"].split()) for e in current_chunk)
+
+        # Size-based split
+        if current_len + el_len > max_chunk_tokens and current_chunk:
+            chunks.append({
+                "text": "\n\n".join(e["text"] for e in current_chunk),
+                "page_start": current_chunk[0]["page_number"],
+                "page_end": current_chunk[-1]["page_number"],
+            })
+            current_chunk = current_chunk[-overlap_elements:]
+            current_len = sum(len(e["text"].split()) for e in current_chunk)
+
+        current_chunk.append(el)
+        current_len += el_len
+
+    if current_chunk:
+        chunks.append({
+            "text": "\n\n".join(e["text"] for e in current_chunk),
+            "page_start": current_chunk[0]["page_number"],
+            "page_end": current_chunk[-1]["page_number"],
+        })
+
+    return chunks
+```

--- a/plugins/edgeparse/.claude-plugin/plugin.json
+++ b/plugins/edgeparse/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "edgeparse",
+  "version": "1.0.0",
+  "description": "Extract structured content from any PDF — headings, tables, paragraphs, lists, bounding boxes — deterministically, without ML dependencies or GPU requirements",
+  "author": {
+    "name": "Raphael Mansuy",
+    "url": "https://github.com/raphaelmansuy"
+  },
+  "homepage": "https://github.com/raphaelmansuy/edgeparse",
+  "repository": "https://github.com/raphaelmansuy/edgeparse",
+  "license": "Apache-2.0",
+  "keywords": ["pdf", "extraction", "parsing", "markdown", "rag"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/edgeparse/skills-lock.json
+++ b/plugins/edgeparse/skills-lock.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "skills": {
+    "edgeparse": {
+      "source": "raphaelmansuy/edgeparse",
+      "sourceType": "github"
+    }
+  }
+}

--- a/plugins/markitdown/skills/markitdown/SKILL.md
+++ b/plugins/markitdown/skills/markitdown/SKILL.md
@@ -40,7 +40,7 @@ Do NOT use MarkItDown for:
 
 - **Plain text files** (`.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`): Use Claude's native Read tool — it handles these perfectly and is faster.
 - **Source code files** (`.py`, `.js`, `.ts`, `.java`, etc.): Use the Read tool directly.
-- **PDF files when only basic reading is needed**: Claude's Read tool natively supports PDF. Only use MarkItDown for PDFs when you need specific Markdown formatting or when the PDF is complex.
+- **PDF files**: For PDF extraction, prefer **EdgeParse** (`edgeparse` plugin) — it is faster, preserves document structure (headings, tables, bounding boxes), and supports page ranges and borderless tables. Only fall back to MarkItDown for PDFs when EdgeParse is not installed.
 - **Images when the user wants visual analysis**: Use Claude's native image understanding instead of OCR-only text extraction.
 
 ## How to Use

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -449,6 +449,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/edgeparse": {
+      "release-type": "simple",
+      "component": "edgeparse",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

- Add EdgeParse as a built-in plugin providing Rust-native PDF extraction (Markdown/JSON/HTML/text output)
- Register EdgeParse in `.claude-plugin/marketplace.json` and `release-please-config.json`
- Add EdgeParse to the Built-in Plugins section in `README.md`
- Update MarkItDown skill to recommend EdgeParse for PDF extraction use cases

## Test plan

- [ ] Verify `plugins/edgeparse/.claude-plugin/plugin.json` is valid (`claude plugin validate plugins/edgeparse`)
- [ ] Confirm EdgeParse entry appears correctly in `.claude-plugin/marketplace.json`
- [ ] Confirm MarkItDown skill routes PDF tasks to EdgeParse

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `edgeparse` as a built-in plugin for fast, deterministic PDF extraction to Markdown/JSON/HTML/text. Improves PDF workflows by surfacing the plugin in the marketplace/docs and guiding users to use it for PDFs.

- **New Features**
  - Added `plugins/edgeparse` skill with API and integration docs, plugin manifest, and skills lock.
  - Registered `edgeparse` in `.claude-plugin/marketplace.json` and set up releases in `release-please-config.json`.
  - Updated README Built-in Plugins with install instructions; MarkItDown skill now recommends `edgeparse` for PDF tasks (page ranges, borderless tables, structured output).

<sup>Written for commit 50f8502c0e96671cf1354d3cd446210ee0eb8cb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

