### PR TITLE
feat(git-ai): add Git AI plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -576,6 +576,14 @@
       "keywords": ["pdf", "extraction", "parsing", "markdown", "rag"],
       "tags": ["skill", "document"],
       "source": "./plugins/edgeparse"
+    },
+    {
+      "name": "git-ai",
+      "description": "A Git extension for tracking the AI-generated code in your repos",
+      "category": "development",
+      "keywords": ["git-ai", "git", "ai", "code-tracking"],
+      "tags": ["tooling", "git"],
+      "source": "./plugins/git-ai"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ Extract structured content from any PDF — headings, tables, paragraphs, lists,
 
 **Install:** `/plugin install edgeparse@pleaseai` | **Source:** [plugins/edgeparse](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/edgeparse)
 
+#### Git AI
+A Git extension for tracking the AI-generated code in your repos.
+
+**Install:** `/plugin install git-ai@pleaseai` | **Source:** [plugins/git-ai](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/git-ai)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:

--- a/plugins/git-ai/.agents/skills/ask/SKILL.md
+++ b/plugins/git-ai/.agents/skills/ask/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: ask
+description: "Use this when you are exploring the codebase. It lets you ask the AI who wrote code questions about how things work and why they chose to build things the way they did. Think of it as asking the engineer who wrote the code for help understanding it."
+argument-hint: "[a question to the AI who authored the code you're looking at]"
+allowed-tools: ["Bash(git-ai:*)", "Read", "Glob", "Grep", "Task"]
+---
+
+# Ask Skill
+
+Answer questions about AI-written code by finding the original prompts and conversations that produced it, then **embodying the author agent's perspective** to answer.
+
+## Main Agent's Job (you)
+
+You do the prep work, then hand off to a **fast, tightly scoped subagent**:
+
+1. **Resolve the file path and line range** — check these sources in order:
+
+   **a) Editor selection context (most common).** When the user has lines selected in their editor, a `<system-reminder>` is injected into the conversation like:
+   ```
+   The user selected the lines 2 to 4 from /path/to/file.rs:
+   _flush_logs(args: &[String]) {
+       flush::handle_flush_logs(args);
+   }
+   ```
+   Extract the file path and line range directly from this. This is the primary way users will invoke `/ask` — they select code, then type something like "/ask why is this like that" without naming the file or lines.
+
+   **b) Explicit file/line references** — "on line 42", "lines 10-50 of src/main.rs" → use directly.
+
+   **c) Named symbol** — mentions a variable/function/class → Read the file, find where it's defined, extract line numbers.
+
+   **d) File without line specifics** → whole file (omit `--lines`).
+
+   **e) No file, no lines, no selection context, no identifiable code reference** → Do NOT attempt to guess or search. Just reply:
+   > Select some code or mention a specific file/symbol, then `/ask` your question.
+
+   Stop here. Do not spawn a subagent.
+
+2. **Spawn one subagent** with the template below. Use `max_turns: 4`.
+
+3. **Relay the answer** to the user. That's it.
+
+## Subagent Configuration
+
+```
+Task tool settings:
+  subagent_type: "general-purpose"
+  max_turns: 4
+```
+
+The subagent gets **only** `Bash` and `Read`. It does NOT get Glob, Grep, or Task. It runs at most 4 turns — this is a fast lookup, not a research project.
+
+## Choosing Between `blame --show-prompt` and `search`
+
+**If you want to read an entire file or range of lines AND the corresponding prompts behind them, use `git-ai blame --show-prompt`.** This is better than `search` for this use case — it gives you every line's authorship plus the full prompt JSON in one call.
+
+```
+# Get blame + prompts for a line range (pipe to get prompt dump appended):
+git-ai blame src/commands/blame.rs -L 23,54 --show-prompt | cat
+
+# Interactive (TTY) mode shows prompt hashes inline:
+# 7a4471d (cursor [abc123e] 2026-02-06 14:20:05 -0800   23)     code_here
+
+# Piped mode appends raw prompt messages after a --- separator:
+# ---
+# Prompt [abc123e]
+# [{"type":"user","text":"Write a function..."},{"type":"assistant","text":"Here is..."}]
+```
+
+Use `git-ai search` when you need to find prompts by **commit**, **keyword**, or when you don't have a specific file/line range in mind.
+
+## Subagent Prompt Template
+
+Fill in `{question}`, `{file_path}`, and `{start}-{end}` (omit LINES if not applicable):
+
+```
+You are answering a question about code by finding the original AI conversation
+that produced it. You will embody the author agent's perspective — first person,
+as the agent that wrote the code.
+
+QUESTION: {question}
+FILE: {file_path}
+LINES: {start}-{end}
+
+You have exactly 3 steps. Do them in order, then stop.
+
+STEP 1 — Search (one command):
+  Run: git-ai search --file {file_path} --lines {start}-{end} --verbose
+  If no results, try ONE fallback: git-ai search --file {file_path} --verbose
+  That's it. Do not run more than 2 git-ai commands total.
+
+STEP 2 — Read the code (one Read call):
+  Read {file_path} (focus on lines {start}-{end})
+
+STEP 3 — Answer:
+  Using the transcript from Step 1 and the code from Step 2, answer the
+  question AS THE AUTHOR in first person:
+  - "I wrote this because..."
+  - "The problem I was solving was..."
+  - "I chose X over Y because..."
+
+  Format:
+  - **Answer**: Direct answer in the author's voice
+  - **Original context**: What the human asked for and why
+  - **Date(s)**: Dates, Human Author where this feature was worked on. 
+
+  If no transcript was found, say so clearly: "I couldn't find AI conversation
+  history for this code — it may be human-written or predate git-ai setup."
+  In that case, analyze the code objectively (not first person).
+
+HARD CONSTRAINTS:
+- Do NOT use Glob, Grep, or Task tools. You only have Bash and Read.
+- Do NOT run more than 2 git-ai commands.
+- Do NOT read .claude/, .cursor/, .agents/, or any agent log directories.
+- Do NOT search JSONL transcripts or session logs directly.
+- All conversation data comes from `git-ai search` only.
+```
+
+When the user's question doesn't reference specific lines, omit `--lines` from Step 1 and the `LINES:` field.
+
+## Fallback Behavior
+
+When no prompt data is found:
+- The code might be human-written or predate git-ai
+- Answer from the code alone, clearly stating no AI history was found
+- Do NOT use first-person author voice in fallback — analyze objectively
+
+## Example Invocations
+
+**User selects lines 10-25 in editor, types: `/ask why is this like that`**
+Selection context is in system-reminder → extract file + lines 10-25, spawn subagent. This is the most common usage pattern.
+
+**`/ask why does this function use recursion instead of iteration?`**
+Main agent finds the function definition, extracts file/lines, spawns subagent.
+
+**`/ask what problem was being solved on lines 100-150 of src/main.rs?`**
+File and lines explicit — spawn subagent directly.
+
+**`/ask why was this approach chosen over using a HashMap?`**
+Main agent identifies relevant code from context, spawns subagent.
+

--- a/plugins/git-ai/.agents/skills/git-ai-search/SKILL.md
+++ b/plugins/git-ai/.agents/skills/git-ai-search/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: git-ai-search
+description: "Search and restore AI conversation context from git history"
+argument-hint: "[search query or workflow]"
+allowed-tools: ["Bash(git-ai:*)", "Read", "Glob", "Grep"]
+---
+
+# Git AI Search Skill
+
+Search and restore AI conversation context from git history using `git-ai search` and `git-ai continue`.
+
+## Overview
+
+Git AI tracks AI-generated code and the conversations that produced it. This skill helps you:
+- **Search** - Find AI prompt sessions by commit, file, pattern, or author
+- **Continue** - Restore AI session context to continue work where someone left off
+- **Show** - View the full transcript of a specific prompt
+
+### When to Use Each Command
+
+| You want to... | Use... |
+|---------------|--------|
+| See what AI context exists for a commit | `git-ai search --commit <sha>` |
+| See AI context for specific lines | `git-ai search --file <path> --lines <range>` |
+| Read the full AI conversation | `git-ai search --commit <sha> --verbose` |
+| Get machine-readable output | `git-ai search --json` |
+| Find prompts mentioning a topic | `git-ai search --pattern "keyword"` |
+| Continue someone's AI session | `git-ai continue --commit <sha>` |
+| Continue working on a code region | `git-ai continue --file <path> --lines <range>` |
+| Launch Claude with restored context | `git-ai continue --commit <sha> --launch` |
+| View a specific prompt transcript | `git-ai show-prompt <id>` |
+
+## Workflow Patterns
+
+### 1. Investigate a Commit
+
+Understand what AI assistance was used in a specific commit:
+
+```bash
+# See a summary of AI sessions in the commit
+git-ai search --commit abc1234
+
+# View the full conversations
+git-ai search --commit abc1234 --verbose
+
+# Get JSON for programmatic processing
+git-ai search --commit abc1234 --json | jq '.prompts | keys[]'
+```
+
+### 2. Understand a Code Region
+
+Find what AI sessions contributed to specific lines:
+
+```bash
+# Search by file
+git-ai search --file src/main.rs
+
+# Search specific lines
+git-ai search --file src/main.rs --lines 100-150
+
+# Multiple line ranges
+git-ai search --file src/main.rs --lines 50-75 --lines 200-250
+```
+
+### 3. Continue Someone's Work
+
+Pick up where a teammate left off:
+
+```bash
+# See what they were working on
+git-ai search --commit abc1234 --verbose
+
+# Restore context and continue in your shell
+git-ai continue --commit abc1234
+
+# Or launch directly into Claude Code
+git-ai continue --commit abc1234 --launch
+
+# Or copy context to clipboard to paste elsewhere
+git-ai continue --commit abc1234 --clipboard
+```
+
+### 4. Review a Pull Request
+
+Understand AI involvement in a PR:
+
+```bash
+# Get all commits in the PR
+COMMITS=$(gh pr view 123 --json commits -q '.commits[].oid')
+
+# Search each commit
+for sha in $COMMITS; do
+  echo "=== $sha ==="
+  git-ai search --commit $sha
+done
+
+# Or search the full range
+BASE=$(gh pr view 123 --json baseRefOid -q '.baseRefOid')
+HEAD=$(gh pr view 123 --json headRefOid -q '.headRefOid')
+git-ai search --commit $BASE..$HEAD
+```
+
+### 5. Audit AI Involvement in a File
+
+See all AI sessions that touched a file:
+
+```bash
+# Full file history
+git-ai search --file src/auth/login.rs
+
+# Filter by author
+git-ai search --file src/auth/login.rs --author "Alice"
+
+# Filter by tool
+git-ai search --file src/auth/login.rs --tool claude
+```
+
+### 6. Search by Topic
+
+Find prompts discussing specific topics:
+
+```bash
+# Search prompt content
+git-ai search --pattern "authentication"
+git-ai search --pattern "error handling"
+
+# Combine with filters
+git-ai search --pattern "refactor" --tool cursor
+```
+
+### 7. Pipe to Other Tools
+
+Integrate with scripts and workflows:
+
+```bash
+# Get prompt IDs only
+git-ai search --commit abc1234 --porcelain
+
+# Count matches
+git-ai search --file src/main.rs --count
+
+# JSON for processing
+git-ai search --commit abc1234 --json | jq '.prompts[] | {tool, model, author: .human_author}'
+
+# Find commits with AI-authored code
+git log --oneline | while read sha msg; do
+  count=$(git-ai search --commit $sha --count 2>/dev/null || echo "0")
+  if [ "$count" != "0" ]; then
+    echo "$sha ($count sessions): $msg"
+  fi
+done
+```
+
+## Command Reference
+
+### git-ai search
+
+Search for AI prompt sessions by various criteria.
+
+```
+git-ai search [OPTIONS]
+```
+
+**Context Source (pick one):**
+- `--commit <rev>` - Search a specific commit (or range with `sha1..sha2`)
+- `--file <path>` - Search by file path
+- `--lines <range>` - Filter to line range (requires --file, repeatable)
+- `--pattern <text>` - Full-text search in prompt content
+- `--prompt-id <id>` - Look up specific prompt by ID
+
+**Filters (combinable):**
+- `--author <name>` - Filter by human author (substring match)
+- `--tool <name>` - Filter by tool (claude, cursor, etc.)
+- `--since <date>` - Only prompts after date
+- `--until <date>` - Only prompts before date
+
+**Output Format (pick one):**
+- (default) - Human-readable summary
+- `--json` - Full JSON output
+- `--verbose` - Detailed output with full transcripts
+- `--porcelain` - Machine-readable prompt IDs only
+- `--count` - Just the count of matching prompts
+
+### git-ai continue
+
+Restore AI session context for continuation.
+
+```
+git-ai continue [OPTIONS]
+```
+
+**Context Source (pick one, or none for TUI):**
+- `--commit <rev>` - Continue from a commit
+- `--file <path>` - Continue from a file
+- `--lines <range>` - Limit to line range (with --file)
+- `--prompt-id <id>` - Continue specific prompt
+
+**Agent Selection:**
+- `--agent <name>` - Target agent (claude, cursor; default: claude)
+- `--tool <name>` - Alias for --agent
+
+**Output Mode (pick one):**
+- (default) - Print formatted context to stdout
+- `--launch` - Spawn agent CLI with context
+- `--clipboard` - Copy context to clipboard
+- `--json` - Output as structured JSON
+
+**Options:**
+- `--max-messages <n>` - Limit messages per prompt (default: 50)
+
+### git-ai show-prompt
+
+Display the full transcript of a specific prompt.
+
+```
+git-ai show-prompt <prompt_id> [OPTIONS]
+```
+
+- `--json` - Output as JSON
+- `--raw` - Show raw internal format
+
+## Output Formats
+
+### Default Output
+
+Human-readable summary:
+
+```
+Found 2 AI prompt session(s) for commit abc1234
+
+[1] Prompt a1b2c3d4 (claude / claude-sonnet-4)
+    Author: Alice
+    Files: src/main.rs:10-50
+
+[2] Prompt e5f6g7h8 (cursor / gpt-4)
+    Author: Bob
+    Files: src/lib.rs:100-150, src/utils.rs:20-30
+```
+
+### --json Output
+
+Full structured data for programmatic use:
+
+```json
+{
+  "source": {
+    "sha": "abc1234",
+    "author": "Alice",
+    "date": "2025-01-15",
+    "message": "Add authentication"
+  },
+  "prompts": [
+    {
+      "id": "a1b2c3d4",
+      "tool": "claude",
+      "model": "claude-sonnet-4",
+      "author": "Alice",
+      "messages": [...]
+    }
+  ]
+}
+```
+
+### --verbose Output
+
+Full conversations inline:
+
+```
+=== Session 1: Prompt a1b2c3d4 ===
+Tool: claude (claude-sonnet-4)
+Author: Alice
+
+**User**:
+Help me implement user authentication...
+
+**Assistant**:
+I'll help you implement authentication. Here's my approach...
+```
+
+### --porcelain Output
+
+One prompt ID per line (for scripting):
+
+```
+a1b2c3d4
+e5f6g7h8
+```
+
+### --count Output
+
+Just the number:
+
+```
+2
+```
+
+## Tips
+
+### Combining Filters
+
+Filters use AND semantics - prompts must match ALL specified filters:
+
+```bash
+# Claude prompts by Alice in the last 7 days
+git-ai search --commit HEAD~10..HEAD --tool claude --author "Alice" --since 7d
+```
+
+### Using with Git Commands
+
+Combine with git log to explore history:
+
+```bash
+# Find commits with high AI involvement
+git log --oneline --since="1 week ago" | while read sha msg; do
+  git-ai search --commit $sha --count 2>/dev/null
+done
+
+# Search AI context for files changed in a commit
+git diff-tree --no-commit-id --name-only -r abc1234 | while read file; do
+  git-ai search --file "$file"
+done
+```
+
+### Restoring Context for Different Agents
+
+The `--agent` flag controls context formatting:
+
+```bash
+# For Claude Code
+git-ai continue --commit abc1234 --agent claude --launch
+
+# For other tools, copy to clipboard
+git-ai continue --commit abc1234 --clipboard
+```
+
+### Inspecting Specific Prompts
+
+If search returns many results, drill down:
+
+```bash
+# Get the IDs
+git-ai search --commit abc1234 --porcelain
+
+# View a specific one
+git-ai show-prompt a1b2c3d4
+```
+
+### Performance Tips
+
+- Use `--commit` for fastest results (direct note lookup)
+- `--file` requires blame computation (slower for large files)
+- `--pattern` searches the database (fast substring match)
+- Add `--count` first to check result size before verbose output
+
+## Examples
+
+### Quick checks
+
+```bash
+# Any AI in this commit?
+git-ai search --commit HEAD --count
+
+# What tools were used?
+git-ai search --commit abc1234 --json | jq '.prompts[].tool' | sort -u
+
+# Who used AI in this file?
+git-ai search --file src/main.rs --json | jq '.prompts[].author' | sort -u
+```
+
+### Detailed exploration
+
+```bash
+# Full context of the most recent AI session
+git-ai search --commit HEAD --verbose | head -100
+
+# Continue the exact session that wrote these lines
+git-ai continue --file src/main.rs --lines 50-100 --launch
+```
+
+### Integration with CI/CD
+
+```bash
+# In a PR check, report AI involvement
+PROMPT_COUNT=$(git-ai search --commit $PR_HEAD --count 2>/dev/null || echo "0")
+if [ "$PROMPT_COUNT" -gt 0 ]; then
+  echo "This PR includes $PROMPT_COUNT AI-assisted session(s)"
+  git-ai search --commit $PR_HEAD
+fi
+```

--- a/plugins/git-ai/.agents/skills/prompt-analysis/SKILL.md
+++ b/plugins/git-ai/.agents/skills/prompt-analysis/SKILL.md
@@ -1,0 +1,587 @@
+---
+name: prompt-analysis
+description: "Analyze AI prompting patterns and acceptance rates"
+argument-hint: "[question about prompts]"
+allowed-tools: ["Bash(git-ai:*)", "Read", "Glob", "Grep", "Task"]
+---
+
+# Prompt Analysis Skill
+
+Analyze AI prompting patterns using the local `prompts.db` SQLite database.
+
+## What is Git AI?
+
+Git AI is a tool that tracks AI-generated code and prompts in git. It stores:
+- Every AI conversation (prompts and responses)
+- Which lines of code came from AI vs human edits
+- Acceptance rates (how much AI code was kept vs modified)
+- Associated commits and authors
+
+This skill queries that data to help users understand their AI coding patterns.
+
+## Initialization
+
+First, determine scope from the user's question:
+
+| User mentions | Flags to use |
+|---------------|--------------|
+| "my prompts" or nothing specified | (default - current user, current repo) |
+| "team", "everyone", "all authors" | `--all-authors` |
+| specific person's name | `--author "<name>"` |
+| specific time range | `--since <days>` (default: 30) |
+
+Discovery is notes-only — `git-ai prompts` always operates on the current repository (the working directory must be inside a git repo). To analyze multiple repos, run the command separately in each.
+
+Run initialization:
+```bash
+git-ai prompts [flags]
+```
+
+This creates/updates `prompts.db` in the current directory.
+
+## Schema Reference
+
+The `prompts` table contains:
+- `seq_id` - Auto-increment ID for iteration
+- `id` - Unique prompt identifier
+- `tool` - Tool used (e.g., "claude-code", "cursor")
+- `model` - Model name (e.g., "claude-sonnet-4-20250514")
+- `human_author` - Git user who created the prompt
+- `commit_sha` - Associated commit (if any)
+- `total_additions`, `total_deletions` - Lines of code changed
+- `accepted_lines`, `overridden_lines` - Lines kept vs modified by human
+- `accepted_rate` - Ratio: accepted / (accepted + overridden)
+- `messages` - JSON array of the conversation
+- `start_time`, `last_time` - Unix timestamps
+
+## Analysis Approaches
+
+### For aggregate questions (metrics, comparisons)
+
+Use direct SQL queries:
+```bash
+git-ai prompts exec "SELECT model, AVG(accepted_rate), COUNT(*) FROM prompts GROUP BY model"
+```
+
+### For per-prompt analysis (categorization, content analysis)
+
+When questions require examining each prompt's content (messages JSON), use subagents:
+
+1. **Add analysis columns** to the schema:
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN work_type TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN analysis_notes TEXT"
+```
+
+2. **Reset the iteration pointer**:
+```bash
+git-ai prompts reset
+```
+
+3. **Iterate with subagents** - Launch parallel subagents using Task tool with `subagent_type: "general-purpose"`. Each subagent:
+   - Runs `git-ai prompts next` to get one prompt as JSON
+   - Analyzes the `messages` content
+   - Updates the database: `git-ai prompts exec "UPDATE prompts SET work_type='...' WHERE id='...'"`
+
+4. **Final synthesis** - Query the enriched data:
+```bash
+git-ai prompts exec "SELECT work_type, COUNT(*), AVG(accepted_rate) FROM prompts GROUP BY work_type"
+```
+
+## Subagent Pattern for Iteration
+
+When processing prompts individually, spawn multiple subagents in parallel. Each subagent prompt should include:
+
+```
+Run `git-ai prompts next` to get the next prompt.
+
+Analyze the messages JSON to determine: [specific analysis task]
+
+Then update the database:
+git-ai prompts exec "UPDATE prompts SET [column]='[value]' WHERE id='[prompt_id]'"
+
+Return your analysis result.
+```
+
+Spawn 3-5 subagents at a time, check results, spawn more until `git-ai prompts next` returns "No more prompts."
+
+**IMPORTANT:** The `git-ai prompts next` command returns ALL the data needed for analysis as JSON, including:
+- The full `messages` array with the complete conversation (human prompts and AI responses)
+- Metadata like `model`, `tool`, `accepted_rate`, `accepted_lines`, etc.
+
+Subagents should NOT run additional commands like `git show` or `git log` - everything needed is in the JSON output from `git-ai prompts next`. Instruct subagents explicitly:
+
+```
+IMPORTANT: All data you need is in the JSON output from `git-ai prompts next`.
+Do NOT run git commands. Analyze the `messages` field in the JSON directly.
+```
+
+## Iterator Examples
+
+### Example 1: Categorize prompts by work type
+
+**User asks:** "Categorize my prompts by work type (bug fix, feature, refactor, docs)"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN work_type TEXT"
+git-ai prompts reset
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+Read the messages JSON and categorize this prompt into ONE of:
+- "bug_fix" - fixing broken behavior, errors, or regressions
+- "feature" - adding new functionality
+- "refactor" - restructuring code without changing behavior
+- "docs" - documentation, comments, READMEs
+- "test" - adding or modifying tests
+- "config" - configuration, build, CI/CD changes
+- "other" - doesn't fit above categories
+
+Update the database:
+git-ai prompts exec "UPDATE prompts SET work_type='<category>' WHERE id='<prompt_id>'"
+
+Return: the prompt id, your categorization, and a one-sentence reason.
+```
+
+**Synthesis query:**
+```sql
+SELECT work_type, COUNT(*) as count,
+       ROUND(AVG(accepted_rate), 3) as avg_acceptance,
+       SUM(accepted_lines) as total_lines
+FROM prompts
+WHERE work_type IS NOT NULL
+GROUP BY work_type
+ORDER BY count DESC
+```
+
+### Example 2: Analyze why prompts had low acceptance
+
+**User asks:** "Why do some of my prompts have low acceptance rates?"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN low_acceptance_reason TEXT"
+git-ai prompts exec "UPDATE pointers SET current_seq_id = (SELECT MIN(seq_id) - 1 FROM prompts WHERE accepted_rate < 0.5 AND accepted_rate IS NOT NULL)"
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+This prompt had a low acceptance rate (human modified most of the AI's code).
+Analyze the messages JSON and identify the likely reason:
+- "vague_request" - the prompt was unclear or underspecified
+- "wrong_approach" - AI took a fundamentally wrong approach
+- "style_mismatch" - code worked but didn't match project conventions
+- "partial_solution" - AI only solved part of the problem
+- "overengineered" - AI added unnecessary complexity
+- "context_missing" - AI lacked necessary context about the codebase
+- "other" - explain briefly
+
+Update the database:
+git-ai prompts exec "UPDATE prompts SET low_acceptance_reason='<reason>' WHERE id='<prompt_id>'"
+
+Return: prompt id, the reason, and specific evidence from the conversation.
+```
+
+### Example 3: Identify prompts that could be turned into reusable patterns
+
+**User asks:** "Which of my prompts solved problems I might face again?"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN reusable_pattern TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN pattern_description TEXT"
+git-ai prompts reset
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+Analyze whether this prompt represents a reusable pattern worth saving:
+- Look for: common coding tasks, useful abstractions, clever solutions
+- Skip: one-off fixes, highly context-specific changes, trivial edits
+
+If reusable, set reusable_pattern to a short name (e.g., "api_error_handling", "form_validation", "test_mocking")
+and pattern_description to a one-sentence description of what it does.
+
+If not reusable, set both to NULL.
+
+git-ai prompts exec "UPDATE prompts SET reusable_pattern='<name>', pattern_description='<desc>' WHERE id='<prompt_id>'"
+
+Return: prompt id and whether you marked it as reusable (with the pattern name if yes).
+```
+
+### Example 4: Score prompt quality/clarity
+
+**User asks:** "How clear are my prompts? Which ones could I have written better?"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN clarity_score INTEGER"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN clarity_feedback TEXT"
+git-ai prompts reset
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+Score the HUMAN's prompt clarity from 1-5:
+5 = Crystal clear: specific goal, context provided, constraints stated
+4 = Good: clear intent, minor ambiguities
+3 = Adequate: understandable but missing helpful context
+2 = Vague: required AI to make significant assumptions
+1 = Unclear: AI had to guess what was wanted
+
+Also provide brief feedback on how the prompt could be improved.
+
+git-ai prompts exec "UPDATE prompts SET clarity_score=<1-5>, clarity_feedback='<feedback>' WHERE id='<prompt_id>'"
+
+Return: prompt id, score, and your feedback.
+```
+
+**Synthesis query:**
+```sql
+SELECT clarity_score, COUNT(*) as count,
+       ROUND(AVG(accepted_rate), 3) as avg_acceptance
+FROM prompts
+WHERE clarity_score IS NOT NULL
+GROUP BY clarity_score
+ORDER BY clarity_score DESC
+```
+
+### Example 5: Correlate prompting techniques with acceptance rate
+
+**User asks:** "Correlate my prompting techniques with acceptance rate"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN technique TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN technique_notes TEXT"
+git-ai prompts reset
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+Analyze the HUMAN's prompting technique in the messages. Identify which techniques were used:
+- "example_driven" - provided examples of desired output or behavior
+- "step_by_step" - broke down the request into steps or phases
+- "context_heavy" - provided extensive background/context about the codebase
+- "minimal" - terse, brief request with little context
+- "iterative" - built up solution through back-and-forth refinement
+- "constraint_focused" - emphasized what NOT to do or specific requirements
+- "reference_based" - pointed to existing code/files to follow as patterns
+- "multiple" - combined several techniques (list them in notes)
+
+Also note any specific effective or ineffective patterns in technique_notes.
+
+git-ai prompts exec "UPDATE prompts SET technique='<technique>', technique_notes='<notes>' WHERE id='<prompt_id>'"
+
+Return: prompt id, technique identified, the acceptance_rate, and your observations.
+```
+
+**Synthesis query:**
+```sql
+SELECT technique,
+       COUNT(*) as count,
+       ROUND(AVG(accepted_rate), 3) as avg_acceptance,
+       ROUND(MIN(accepted_rate), 3) as min_acceptance,
+       ROUND(MAX(accepted_rate), 3) as max_acceptance
+FROM prompts
+WHERE technique IS NOT NULL AND accepted_rate IS NOT NULL
+GROUP BY technique
+ORDER BY avg_acceptance DESC
+```
+
+### Example 6: Qualitative analysis of failed prompts
+
+**User asks:** "Do a qualitative analysis of failed prompts (0 accepted)"
+
+**Definition of "failed prompts":**
+- `accepted_lines IS NULL` - conversation happened but no code was committed
+- `accepted_lines = 0` - code was generated but human rejected/rewrote all of it
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN failure_analysis TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN failure_category TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN improvement_suggestion TEXT"
+-- Set pointer to iterate only over failed prompts
+git-ai prompts exec "DELETE FROM pointers WHERE name='default'"
+git-ai prompts exec "INSERT INTO pointers (name, current_seq_id) VALUES ('default', (SELECT MIN(seq_id) - 1 FROM prompts WHERE accepted_lines IS NULL OR accepted_lines = 0))"
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+This prompt resulted in 0% acceptance - the human rejected or completely rewrote all AI-generated code.
+
+Perform a qualitative analysis by reading the full conversation in messages JSON:
+
+1. **What was requested?** Summarize the human's goal.
+2. **What did the AI produce?** Summarize what code/solution was generated.
+3. **Why did it fail?** Categorize into:
+   - "misunderstood_intent" - AI solved the wrong problem
+   - "poor_code_quality" - bugs, errors, or broken code
+   - "wrong_technology" - used wrong framework/library/approach
+   - "incomplete" - only partially addressed the request
+   - "style_violation" - worked but violated project conventions
+   - "overcomplicated" - solution far more complex than needed
+   - "security_issue" - introduced vulnerabilities
+   - "abandoned" - user changed direction mid-conversation
+
+4. **How could the prompt be improved?** Specific, actionable suggestion.
+
+git-ai prompts exec "UPDATE prompts SET failure_category='<category>', failure_analysis='<analysis>', improvement_suggestion='<suggestion>' WHERE id='<prompt_id>'"
+
+Return a detailed analysis including: prompt id, what was requested, what went wrong, and how to prompt better next time.
+```
+
+**Synthesis:**
+```sql
+SELECT failure_category,
+       COUNT(*) as count,
+       GROUP_CONCAT(id, ', ') as prompt_ids
+FROM prompts
+WHERE failure_category IS NOT NULL
+GROUP BY failure_category
+ORDER BY count DESC
+```
+
+Then review individual `failure_analysis` and `improvement_suggestion` values to compile lessons learned.
+
+### Example 7: Grade prompts according to best practices
+
+**User asks:** "Grade my prompts according to best practices"
+
+**Setup:**
+```bash
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN grade TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN grade_breakdown TEXT"
+git-ai prompts exec "ALTER TABLE prompts ADD COLUMN grade_feedback TEXT"
+git-ai prompts reset
+```
+
+**Subagent prompt:**
+```
+Run `git-ai prompts next` to get the next prompt as JSON.
+
+IMPORTANT: All data you need is in this JSON output. Do NOT run git commands.
+Analyze the `messages` field directly.
+
+Grade the HUMAN's prompt against these best practices for AI-assisted coding:
+
+**Grading Criteria (each worth 0-2 points):**
+
+1. **Specificity (0-2)**: Does the prompt clearly state what needs to be done?
+   - 0: Vague or ambiguous ("fix this", "make it better")
+   - 1: General direction but missing details ("add validation")
+   - 2: Specific outcome described ("add email validation that checks format and shows inline error")
+
+2. **Context (0-2)**: Does the prompt provide necessary background?
+   - 0: No context, assumes AI knows everything
+   - 1: Some context but missing key details
+   - 2: Relevant files, constraints, or project patterns mentioned
+
+3. **Scope (0-2)**: Is the request appropriately sized?
+   - 0: Too broad ("rewrite the app") or impossibly vague
+   - 1: Large but manageable, could be broken down
+   - 2: Focused, single-responsibility task
+
+4. **Constraints (0-2)**: Are requirements and boundaries specified?
+   - 0: No constraints given when they'd be helpful
+   - 1: Some constraints but missing important ones
+   - 2: Clear about what to do AND what not to do
+
+5. **Testability (0-2)**: Can success be verified?
+   - 0: No way to know if the result is correct
+   - 1: Implicit success criteria
+   - 2: Explicit expected behavior or acceptance criteria
+
+**Calculate total (0-10) and assign grade:**
+- A (9-10): Excellent prompt, follows best practices
+- B (7-8): Good prompt, minor improvements possible
+- C (5-6): Adequate prompt, notable gaps
+- D (3-4): Poor prompt, significant issues
+- F (0-2): Ineffective prompt, needs major revision
+
+Store breakdown as JSON: {"specificity": X, "context": X, "scope": X, "constraints": X, "testability": X}
+
+git-ai prompts exec "UPDATE prompts SET grade='<A-F>', grade_breakdown='<json>', grade_feedback='<specific feedback>' WHERE id='<prompt_id>'"
+
+Return: prompt id, grade, total score, and one key improvement suggestion.
+```
+
+**Synthesis query:**
+```sql
+SELECT grade,
+       COUNT(*) as count,
+       ROUND(AVG(accepted_rate), 3) as avg_acceptance,
+       SUM(accepted_lines) as total_lines_accepted
+FROM prompts
+WHERE grade IS NOT NULL AND accepted_rate IS NOT NULL
+GROUP BY grade
+ORDER BY grade
+```
+
+**Correlation analysis:**
+```sql
+-- See if grade correlates with acceptance rate
+SELECT
+    grade,
+    ROUND(AVG(accepted_rate), 3) as avg_acceptance,
+    COUNT(*) as n
+FROM prompts
+WHERE grade IS NOT NULL AND accepted_rate IS NOT NULL
+GROUP BY grade
+ORDER BY
+    CASE grade
+        WHEN 'A' THEN 1
+        WHEN 'B' THEN 2
+        WHEN 'C' THEN 3
+        WHEN 'D' THEN 4
+        WHEN 'F' THEN 5
+    END
+```
+
+## Example Queries
+
+**Acceptance rate by model:**
+```sql
+SELECT model,
+       ROUND(AVG(accepted_rate), 3) as avg_rate,
+       SUM(accepted_lines) as total_accepted,
+       COUNT(*) as prompt_count
+FROM prompts
+GROUP BY model
+ORDER BY avg_rate DESC
+```
+
+**Most productive prompts (high acceptance + high LoC):**
+```sql
+SELECT id, tool, model, accepted_lines, accepted_rate,
+       (last_time - start_time) as duration_secs
+FROM prompts
+WHERE accepted_rate > 0.8 AND accepted_lines > 50
+ORDER BY accepted_lines DESC
+LIMIT 10
+```
+
+**Prompts by time of day:**
+```sql
+SELECT
+  CASE
+    WHEN (start_time % 86400) / 3600 < 12 THEN 'morning'
+    WHEN (start_time % 86400) / 3600 < 17 THEN 'afternoon'
+    ELSE 'evening'
+  END as time_of_day,
+  COUNT(*) as count,
+  AVG(accepted_rate) as avg_rate
+FROM prompts
+GROUP BY time_of_day
+```
+
+## Cleanup
+
+The `prompts.db` file is ephemeral. Delete it anytime to start fresh:
+```bash
+rm prompts.db
+```
+
+## Troubleshooting
+
+**If there are 0 prompts in the database:**
+Git AI may not be set up correctly in this repository. Direct the user to:
+- Check https://usegitai.com/docs/cli for setup instructions
+- Verify `git-ai` is installed and configured
+- Ensure they have made commits with AI assistance after setup
+
+**Important: Git AI only tracks data going forward.**
+Git AI cannot retroactively categorize or track prompts from before it was installed. Only commits made after Git AI setup will have prompt data. If the user recently installed Git AI, they may have limited data until they accumulate more AI-assisted commits.
+
+## Footguns and Data Caveats
+
+**Not all prompts have stats or commits:**
+- `commit_sha` is NULL when the prompt conversation happened but no code was ever committed
+- `accepted_lines`, `overridden_lines`, `accepted_rate` may be NULL or 0 for uncommitted work
+- `total_additions`, `total_deletions` may be NULL for the same reason
+
+**Why this happens:**
+- User had a conversation but didn't accept the code
+- User accepted code but never committed it
+- User is still working (code not yet committed)
+
+**Definition of "failed prompts":**
+When analyzing failed or unsuccessful prompts, use this definition:
+- `accepted_lines IS NULL` - conversation happened but no code was committed
+- `accepted_lines = 0` - code was generated but human rejected/rewrote all of it
+
+Query: `WHERE accepted_lines IS NULL OR accepted_lines = 0`
+
+**Handle in queries:**
+```sql
+-- Exclude uncommitted prompts from acceptance rate analysis
+SELECT model, AVG(accepted_rate)
+FROM prompts
+WHERE commit_sha IS NOT NULL AND accepted_rate IS NOT NULL
+GROUP BY model
+
+-- Find prompts with conversation but no committed code
+SELECT id, tool, start_time
+FROM prompts
+WHERE commit_sha IS NULL
+```
+
+## Important Notes
+
+- The `messages` column contains JSON - parse it to read conversation content
+- Use subagents for any analysis requiring reading message content
+- SQLite is a scratchpad - add columns freely for analysis
+- Default scope is conservative (current user, current repo, 30 days)
+- Expand scope only when user explicitly mentions team/all repos
+
+## Permissions Setup
+
+To avoid being prompted for every `git-ai` command, add to project or user settings:
+
+**Project:** `.claude/settings.json`
+**User:** `~/.claude/settings.json`
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git-ai:*)"
+    ]
+  }
+}
+```
+
+This is especially important for subagent iteration, as subagents don't inherit skill-level permissions.

--- a/plugins/git-ai/.claude-plugin/plugin.json
+++ b/plugins/git-ai/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "git-ai",
+  "version": "1.0.0",
+  "description": "A Git extension for tracking the AI-generated code in your repos",
+  "license": "Apache-2.0",
+  "keywords": ["git-ai", "git", "ai", "code-tracking"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/git-ai/skills-lock.json
+++ b/plugins/git-ai/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "ask": {
+      "source": "git-ai-project/git-ai",
+      "sourceType": "github",
+      "computedHash": "4078ed1606c491e95cfd892a701ab01d4f842fda2a2a14322f3989a776b75a85"
+    },
+    "git-ai-search": {
+      "source": "git-ai-project/git-ai",
+      "sourceType": "github",
+      "computedHash": "7d940c8210fb8823036486e68db9541f011f166fb897dd55a623c765827b980b"
+    },
+    "prompt-analysis": {
+      "source": "git-ai-project/git-ai",
+      "sourceType": "github",
+      "computedHash": "2836b2e21be407f19a239b9a316f15974d95b67716aa9271332cb40280c3e99a"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -460,6 +460,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/git-ai": {
+      "release-type": "simple",
+      "component": "git-ai",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

- Add Git AI plugin to the Claude Code plugin marketplace
- Install three skills via skills.sh: `ask`, `git-ai-search`, and `prompt-analysis`
- Update `.claude-plugin/marketplace.json` with the new plugin entry
- Update `README.md` with Git AI section under Built-in Plugins
- Update `release-please-config.json` with `plugins/git-ai` package

## Test plan

- [ ] Verify marketplace.json entry is valid (`claude plugin validate .claude-plugin/marketplace.json`)
- [ ] Confirm plugin installs correctly via `/plugin install git-ai@pleaseai`
- [ ] Check that all three skills (ask, git-ai-search, prompt-analysis) are accessible after installation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `git-ai` to the plugin marketplace to track AI-authored code and restore original prompt context in repos. Includes three skills (`ask`, `git-ai-search`, `prompt-analysis`) with docs and release setup.

- **New Features**
  - Registered in `.claude-plugin/marketplace.json` and added README install: `/plugin install git-ai@pleaseai`.
  - Added skills and docs under `plugins/git-ai/.agents/skills/`, plus manifest at `plugins/git-ai/.claude-plugin/plugin.json` and `skills-lock.json`.
  - Registered `plugins/git-ai` in `release-please-config.json` for versioning.

<sup>Written for commit dc14b931b350f21267d1d98b96d1654784d02efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

