### PR TITLE
feat(better-auth): add use-better-auth workflow skill

### DIFF
--- a/plugins/better-auth/.agents/skills/use-better-auth/SKILL.md
+++ b/plugins/better-auth/.agents/skills/use-better-auth/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: use-better-auth
+description: 'Answer questions about better-auth and help build authentication features. Use when developers: (1) ask about better-auth APIs like `betterAuth`, `auth.api.*`, `authClient.*`; (2) wire up sign-in / sign-up / sessions; (3) integrate framework adapters (Next.js, Nuxt, SvelteKit, Hono, Astro, Bun, Express); (4) add plugins (organization, two-factor, magic-link, passkey, oauth-proxy); (5) configure DB adapters (Prisma, Drizzle, Kysely, Mongoose). Triggers on: "better-auth", "betterAuth", "authClient", "sign in flow", "auth session", "social login", "magic link", "passkey", "organization plugin".'
+---
+
+## Prerequisites
+
+Before writing code, verify `better-auth` is in the project's lockfile (`bun.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, or `package.json`). If not installed, install with the project's package manager:
+
+```bash
+bun add better-auth    # or: pnpm add better-auth / npm i better-auth / yarn add better-auth
+```
+
+Verify the `ask` CLI is available (`which ask`). It is the primary tool for reading the exact version installed in this project. If `ask` is not installed, fall back to `node_modules/better-auth/` and the official site `https://better-auth.com/docs`.
+
+## Critical: Do Not Trust Internal Knowledge
+
+Everything known about better-auth from training data is suspect. The library's public API, plugin surface, framework adapters, and DB-adapter shapes shift between minor versions. Ship code against the current source, not memory.
+
+When working with better-auth:
+
+1. Resolve the installed version against the local checkout with `ask`
+2. Verify plugin names, adapter imports, and option shapes before generating code
+3. Run typecheck after changes to surface silent breakage early
+4. Never invent plugin names, adapter import paths, or function signatures — enumerate them first
+5. Surface deprecations or conflicts to the user rather than silently picking one pattern
+
+If documentation cannot be found to support an answer, state that explicitly.
+
+## Finding Documentation
+
+Resolve the source checkout once; reuse the path across reads:
+
+```bash
+SRC=$(ask src better-auth)           # checkout root
+DOCS=$(ask docs better-auth | head -n1)  # candidate docs dir
+```
+
+### Read the README and docs content
+
+```bash
+cat "$DOCS/README.md"
+ls "$SRC/docs/content/docs"
+cat "$SRC/docs/content/docs/installation.mdx"
+cat "$SRC/docs/content/docs/basic-usage.mdx"
+```
+
+### Enumerate plugins (authoritative list)
+
+```bash
+ls "$SRC/packages/better-auth/src/plugins"
+```
+
+### Enumerate framework integrations
+
+```bash
+ls "$SRC/packages/better-auth/src/integrations"
+ls "$SRC/docs/content/docs/integrations"
+```
+
+Note: the source-level `integrations/` directory only contains helper functions (Next.js cookies, SvelteKit handler, Node handler, etc.). Most frameworks (Hono, Astro, Express, Nuxt) mount the generic `auth.handler` directly — check `references/adapters.md` for the per-framework pattern.
+
+### Enumerate DB adapters
+
+```bash
+ls "$SRC/packages/better-auth/src/adapters"
+ls "$SRC/packages" | grep adapter
+```
+
+### Enumerate social providers
+
+```bash
+ls "$SRC/packages/core/src/social-providers"
+```
+
+### Grep for exported API
+
+```bash
+rg "^export " "$SRC/packages/better-auth/src/index.ts"
+rg "^export " "$SRC/packages/better-auth/src/client/index.ts"
+rg "^export (const|function) createAuthClient" "$SRC/packages/better-auth/src/client/"
+```
+
+### Fallback when `ask` is unavailable
+
+```bash
+SRC=./node_modules/better-auth
+ls $SRC/dist
+rg "betterAuth\\(" $SRC/dist
+```
+
+Use the official site `https://better-auth.com/docs` only to cross-reference — it tracks `main`, not the installed version.
+
+## Environment Variables
+
+Two env vars are resolved inside `create-context.ts` and `utils/url.ts`:
+
+- `BETTER_AUTH_SECRET` — required. At least 32 chars, high entropy. Generate with `openssl rand -base64 32` or `npx auth secret`. Also accepts `AUTH_SECRET`. For secret rotation without invalidating sessions, use `BETTER_AUTH_SECRETS` (plural, comma-separated).
+- `BETTER_AUTH_URL` — base URL of the app (e.g. `http://localhost:3000`). Public variants honored on clients: `NEXT_PUBLIC_BETTER_AUTH_URL`, `PUBLIC_BETTER_AUTH_URL`, `NUXT_PUBLIC_BETTER_AUTH_URL`.
+
+Missing or misconfigured values are the single most common source of runtime errors — see `references/common-errors.md`.
+
+## Server Setup (Canonical Pattern)
+
+Create `auth.ts` (project root, `lib/`, `utils/`, or a `src/`/`app/`/`server/`-nested equivalent) and export a named or default `auth`:
+
+```ts
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  database: /* DB adapter or Kysely dialect — see references/databases.md */,
+  emailAndPassword: {
+    enabled: true,
+  },
+  socialProviders: {
+    // github: { clientId: env.GITHUB_CLIENT_ID, clientSecret: env.GITHUB_CLIENT_SECRET },
+  },
+  plugins: [
+    // see references/plugins.md
+  ],
+});
+```
+
+The default export `betterAuth` lives in `packages/better-auth/src/auth/full.ts` and ships the full Kysely runtime. For environments where Kysely is not desired, import from `better-auth/minimal` and pass a custom adapter (e.g. `drizzleAdapter`) via `database`.
+
+## Client Setup (Canonical Pattern)
+
+Pick the framework-specific import path. Each one re-exports `createAuthClient` from `packages/better-auth/src/client/<framework>/index.ts`:
+
+```ts
+import { createAuthClient } from "better-auth/react";   // React
+import { createAuthClient } from "better-auth/vue";     // Vue / Nuxt
+import { createAuthClient } from "better-auth/svelte";  // Svelte / SvelteKit
+import { createAuthClient } from "better-auth/solid";   // Solid / Solid Start
+import { createAuthClient } from "better-auth/client";  // vanilla (framework-agnostic)
+
+export const authClient = createAuthClient({
+  baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL, // or equivalent per framework
+  plugins: [
+    // mirror any server-side plugins that expose a client plugin
+  ],
+});
+```
+
+Export the methods the app actually uses (`signIn`, `signUp`, `signOut`, `useSession`) from the client module rather than re-importing the whole `authClient` in every component.
+
+## Picking the Framework Adapter
+
+| Framework | Import | Mount |
+|-----------|--------|-------|
+| Next.js App Router | `better-auth/next-js` | `toNextJsHandler(auth)` at `app/api/auth/[...all]/route.ts` |
+| Next.js Pages Router | `better-auth/node` | `toNodeHandler(auth.handler)` + disable `bodyParser` |
+| SvelteKit | `better-auth/svelte-kit` | `svelteKitHandler({ event, resolve, auth, building })` in `hooks.server.ts` |
+| Solid Start | `better-auth/solid-start` | `toSolidStartHandler(auth)` |
+| TanStack Start | `better-auth/tanstack-start` | Mount `auth.handler`; use `tanstackStartCookies` plugin |
+| Nuxt / Nitro | (no source-level helper) | `auth.handler(toWebRequest(event))` in `server/api/auth/[...all].ts` |
+| Hono | (no source-level helper) | `auth.handler(c.req.raw)` at `/api/auth/*` |
+| Astro | (no source-level helper) | `auth.handler(ctx.request)` at `pages/api/auth/[...all].ts` |
+| Express | `better-auth/node` | `app.all("/api/auth/*", toNodeHandler(auth))` |
+| Bun | `better-auth/node` or native `Bun.serve` | Forward to `auth.handler` |
+
+Full wiring, cookie handling, and CORS gotchas per framework: `references/adapters.md`.
+
+## Picking Plugins
+
+Server plugins live under `packages/better-auth/src/plugins/`. Enumerate them before writing imports. Common picks:
+
+| Need | Plugin | Server import | Client import |
+|------|--------|---------------|---------------|
+| Multi-tenant / teams | `organization` | `better-auth/plugins/organization` | `better-auth/client/plugins` |
+| 2FA (TOTP / OTP / backup codes) | `two-factor` | `better-auth/plugins/two-factor` | same |
+| Passwordless magic link | `magic-link` | `better-auth/plugins/magic-link` | same |
+| WebAuthn / Passkeys | `passkey` (shipped in `@better-auth/passkey`) | `@better-auth/passkey` | `@better-auth/passkey/client` |
+| Dev-friendly OAuth over tunnels | `oauth-proxy` | `better-auth/plugins/oauth-proxy` | — |
+| JWT session tokens | `jwt` | `better-auth/plugins/jwt` | — |
+| OTP over email / SMS | `email-otp`, `phone-number` | `better-auth/plugins/email-otp` | same |
+| Admin / user management UI | `admin` | `better-auth/plugins/admin` | same |
+
+Full matrix with decision notes: `references/plugins.md`.
+
+## Picking the DB Adapter
+
+| Choice | Adapter | Import |
+|--------|---------|--------|
+| Prisma | `prismaAdapter(prisma, { provider })` | `better-auth/adapters/prisma` |
+| Drizzle | `drizzleAdapter(db, { provider })` | `better-auth/adapters/drizzle` |
+| Kysely | `kyselyAdapter(db, { type })` | `better-auth/adapters/kysely` |
+| MongoDB | `mongodbAdapter(client)` | `better-auth/adapters/mongodb` |
+| Memory (tests only) | `memoryAdapter(store)` | `better-auth/adapters/memory` |
+| Built-in Kysely dialect | pass dialect directly via `database` | — |
+
+After adding a plugin or changing the schema, regenerate:
+
+```bash
+npx auth generate     # dumps schema changes
+npx auth migrate      # applies them (Kysely built-in only)
+```
+
+Full init snippets and the schema-extension pattern: `references/databases.md`.
+
+## When Typecheck or Runtime Fails
+
+Before searching source code, grep `references/common-errors.md` for the failing symptom (missing secret, redirect loop, CORS, session not persisted, schema drift, edge-runtime incompatibility). Most runtime failures fall into one of six known categories with a canonical fix.
+
+If the symptom is not listed, resolve the source and grep the error string:
+
+```bash
+rg -n "error string fragment" "$SRC/packages/better-auth/src"
+```
+
+## References
+
+- [`references/adapters.md`](references/adapters.md) — framework-by-framework wiring (Next.js, Nuxt, SvelteKit, Hono, Astro, Express, Bun, TanStack Start, Solid Start)
+- [`references/plugins.md`](references/plugins.md) — every built-in plugin with when-to-use, server import, client import
+- [`references/databases.md`](references/databases.md) — Prisma / Drizzle / Kysely / Mongo init, schema generation, model extension
+- [`references/common-errors.md`](references/common-errors.md) — six concrete error → cause → fix entries

--- a/plugins/better-auth/.agents/skills/use-better-auth/references/adapters.md
+++ b/plugins/better-auth/.agents/skills/use-better-auth/references/adapters.md
@@ -1,0 +1,290 @@
+# Framework Adapters
+
+Per-framework wiring for mounting `auth.handler` and instantiating the matching client. Verify every import path against `$(ask src better-auth)/packages/better-auth/src/integrations/` and `$(ask src better-auth)/docs/content/docs/integrations/` before pasting — exports are renamed between minor releases.
+
+Source-level helpers (shipped in `packages/better-auth/src/integrations/`):
+
+```
+next-js.ts   node.ts   solid-start.ts   svelte-kit.ts
+tanstack-start.ts   tanstack-start-solid.ts
+```
+
+All other frameworks (Nuxt, Hono, Astro, Fastify, Elysia, Express, Bun) mount the generic `auth.handler` directly — no source-level helper is required.
+
+---
+
+## Next.js — App Router
+
+File: `app/api/auth/[...all]/route.ts`
+
+```ts
+import { auth } from "@/lib/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+
+export const { GET, POST } = toNextJsHandler(auth);
+```
+
+Enable the cookie bridge so server components read fresh session data:
+
+```ts
+// lib/auth.ts
+import { betterAuth } from "better-auth";
+import { nextCookies } from "better-auth/next-js";
+
+export const auth = betterAuth({
+  plugins: [nextCookies()], // must be LAST in the plugin array
+});
+```
+
+Client:
+
+```ts
+// lib/auth-client.ts
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient();
+export const { signIn, signUp, signOut, useSession } = authClient;
+```
+
+## Next.js — Pages Router
+
+File: `pages/api/auth/[...all].ts`
+
+```ts
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "@/lib/auth";
+
+export const config = { api: { bodyParser: false } };
+
+export default toNodeHandler(auth.handler);
+```
+
+`bodyParser: false` is required — Next.js's default JSON parser will swallow the auth request body.
+
+---
+
+## Nuxt
+
+File: `server/api/auth/[...all].ts`
+
+```ts
+import { auth } from "~~/lib/auth";
+
+export default defineEventHandler((event) => {
+  return auth.handler(toWebRequest(event));
+});
+```
+
+Client (Nuxt uses the Vue client):
+
+```ts
+// lib/auth-client.ts
+import { createAuthClient } from "better-auth/vue";
+
+export const authClient = createAuthClient();
+export const { signIn, signUp, signOut, useSession } = authClient;
+```
+
+Call `authClient.useSession(useFetch)` from inside a page `setup()` — passing `useFetch` is what forwards cookies server-side during SSR.
+
+---
+
+## SvelteKit
+
+File: `src/hooks.server.ts`
+
+```ts
+import { auth } from "$lib/auth";
+import { svelteKitHandler } from "better-auth/svelte-kit";
+import { building } from "$app/environment";
+
+export async function handle({ event, resolve }) {
+  return svelteKitHandler({ event, resolve, auth, building });
+}
+```
+
+`svelteKitHandler` does **not** populate `event.locals.session` on its own. To expose the session inside `+layout.server.ts` / actions / endpoints, fetch it in `handle`:
+
+```ts
+const session = await auth.api.getSession({ headers: event.request.headers });
+if (session) {
+  event.locals.session = session.session;
+  event.locals.user = session.user;
+}
+```
+
+Enable the cookie plugin so form actions / server endpoints persist cookies:
+
+```ts
+import { sveltekitCookies } from "better-auth/svelte-kit";
+betterAuth({ plugins: [sveltekitCookies()] });
+```
+
+Client:
+
+```ts
+import { createAuthClient } from "better-auth/svelte";
+export const authClient = createAuthClient();
+```
+
+---
+
+## TanStack Start
+
+File: `src/routes/api/auth/$.ts`
+
+```ts
+import { auth } from "@/lib/auth";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/auth/$")({
+  server: {
+    handlers: {
+      GET:  async ({ request }: { request: Request }) => auth.handler(request),
+      POST: async ({ request }: { request: Request }) => auth.handler(request),
+    },
+  },
+});
+```
+
+Add the cookie plugin (must be the **last** plugin):
+
+```ts
+// React variant
+import { tanstackStartCookies } from "better-auth/tanstack-start";
+// Solid variant
+import { tanstackStartCookies } from "better-auth/tanstack-start-solid";
+
+betterAuth({ plugins: [tanstackStartCookies()] });
+```
+
+Prefer the `authClient` for sign-in flows over calling `auth.api.*` from server functions — the client handles cookie propagation via the plugin.
+
+---
+
+## Solid Start
+
+File: `src/routes/api/auth/[...auth].ts`
+
+```ts
+import { auth } from "~/lib/auth";
+import { toSolidStartHandler } from "better-auth/solid-start";
+
+export const { GET, POST } = toSolidStartHandler(auth);
+```
+
+Client:
+
+```ts
+import { createAuthClient } from "better-auth/solid";
+export const authClient = createAuthClient();
+```
+
+---
+
+## Hono
+
+```ts
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { auth } from "./auth";
+
+const app = new Hono();
+
+app.use(
+  "/api/auth/*",
+  cors({
+    origin: "http://localhost:3001",
+    allowHeaders: ["Content-Type", "Authorization"],
+    allowMethods: ["POST", "GET", "OPTIONS"],
+    exposeHeaders: ["Content-Length"],
+    maxAge: 600,
+    credentials: true, // required so cookies survive cross-origin
+  }),
+);
+
+app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+```
+
+Without `credentials: true` on CORS **and** `credentials: "include"` on the client fetch, the session cookie will not round-trip.
+
+---
+
+## Astro
+
+File: `src/pages/api/auth/[...all].ts`
+
+```ts
+import type { APIRoute } from "astro";
+import { auth } from "~/auth";
+
+export const ALL: APIRoute = async (ctx) => {
+  // For rate-limiting: ctx.request.headers.set("x-forwarded-for", ctx.clientAddress);
+  return auth.handler(ctx.request);
+};
+```
+
+Client: pick the import that matches the island framework — `better-auth/react`, `better-auth/vue`, `better-auth/svelte`, `better-auth/solid`, or `better-auth/client` for vanilla.
+
+---
+
+## Express
+
+```ts
+import express from "express";
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "./auth";
+
+const app = express();
+
+// Express 4:
+app.all("/api/auth/*", toNodeHandler(auth));
+// Express 5:
+// app.all("/api/auth/*splat", toNodeHandler(auth));
+
+// Mount express.json() AFTER auth — never before, or the client will hang on "pending".
+app.use(express.json());
+```
+
+CommonJS is not supported — set `"type": "module"` in `package.json`, or use a tsconfig `"module"` setting that emits ESM.
+
+---
+
+## Bun
+
+```ts
+import { auth } from "./auth";
+
+Bun.serve({
+  port: 3000,
+  fetch: (req) => {
+    if (new URL(req.url).pathname.startsWith("/api/auth")) return auth.handler(req);
+    return new Response("OK");
+  },
+});
+```
+
+Bun's fetch signature matches the Web `Request` / `Response` shape `auth.handler` expects — no adapter needed.
+
+---
+
+## Nitro (standalone)
+
+Nitro uses the same pattern as Nuxt:
+
+```ts
+// routes/api/auth/[...all].ts
+import { auth } from "~/lib/auth";
+
+export default defineEventHandler((event) => auth.handler(toWebRequest(event)));
+```
+
+---
+
+## CORS & cookie invariants (every framework)
+
+- Server response `Access-Control-Allow-Origin` must be the specific origin — not `*` — when `credentials: "include"` is used client-side.
+- Set cookies with `sameSite: "lax"` (or `"none"` + `secure: true` for cross-site) via `advanced.defaultCookieAttributes` in `betterAuth({})`.
+- Behind a reverse proxy, trust the forwarded host headers so callback URLs resolve correctly (`trustedOrigins` option).
+
+See `references/common-errors.md` for concrete cookie/CORS misconfig symptoms.

--- a/plugins/better-auth/.agents/skills/use-better-auth/references/common-errors.md
+++ b/plugins/better-auth/.agents/skills/use-better-auth/references/common-errors.md
@@ -1,0 +1,201 @@
+# Common Errors
+
+Six concrete failure modes that account for the majority of runtime problems. Each entry lists the symptom, the root cause (traced to the file it originates in), and the canonical fix.
+
+When a symptom is not listed here, resolve the source and grep the error string:
+
+```bash
+rg -n "error string fragment" "$(ask src better-auth)/packages/better-auth/src"
+```
+
+---
+
+## 1. Missing or weak `BETTER_AUTH_SECRET`
+
+**Symptom** — one of:
+
+- Warning at startup: `BETTER_AUTH_SECRET is missing. Set it in your environment or pass secret to betterAuth({ secret })`
+- Warning: `You are using the default secret. Please set BETTER_AUTH_SECRET in your environment variables or pass secret in your auth config.`
+- Warning: `your BETTER_AUTH_SECRET should be at least 32 characters long for adequate security`
+- In production: all sessions invalidate on every restart.
+
+**Cause** — `packages/better-auth/src/context/create-context.ts` falls back to a default secret when `options.secret || env.BETTER_AUTH_SECRET || env.AUTH_SECRET` is empty. The default changes between process lifetimes, which is why cookies signed before a restart fail to verify afterwards.
+
+**Fix** — set a strong secret:
+
+```bash
+# .env
+BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+```
+
+Or generate with the built-in CLI:
+
+```bash
+npx auth secret
+```
+
+For rotation without invalidating existing sessions, use the plural form:
+
+```bash
+BETTER_AUTH_SECRETS=new-secret,previous-secret,older-secret
+```
+
+---
+
+## 2. Wrong `baseURL` — redirect loops, broken callbacks
+
+**Symptom** — OAuth callback 404s, `Base URL could not be determined` warning, social sign-in redirects back to the sign-in page, or cookies are scoped to the wrong domain.
+
+**Cause** — `packages/better-auth/src/utils/url.ts` resolves `baseURL` from (in order) `options.baseURL`, `env.BETTER_AUTH_URL`, `env.NEXT_PUBLIC_BETTER_AUTH_URL`, `env.PUBLIC_BETTER_AUTH_URL`, `env.NUXT_PUBLIC_BETTER_AUTH_URL`, then the incoming request headers. When none match the real origin (HTTPS vs HTTP, missing port, behind a proxy), callback URLs get generated with the wrong host.
+
+**Fix** — set `BETTER_AUTH_URL` to the real origin per environment:
+
+```bash
+# .env.development
+BETTER_AUTH_URL=http://localhost:3000
+
+# .env.production
+BETTER_AUTH_URL=https://app.example.com
+```
+
+Behind a reverse proxy, also add the proxied origins to `trustedOrigins`:
+
+```ts
+betterAuth({
+  baseURL: process.env.BETTER_AUTH_URL,
+  trustedOrigins: ["https://app.example.com", "https://preview.example.com"],
+});
+```
+
+For preview deployments (Vercel previews, tunnels) that can't have a stable public URL, use the `oauth-proxy` plugin to route the OAuth callback through a fixed production URL.
+
+---
+
+## 3. CORS / credentials — cookies never round-trip cross-origin
+
+**Symptom** — `authClient.signIn.email(...)` returns a user but `authClient.useSession()` on the next page reports `null`. Request shows `200 OK` and a `Set-Cookie` header, but the browser does not store it. Only happens when the client and server are on different origins (e.g. `localhost:5173` calling `localhost:3000`).
+
+**Cause** — a cross-origin response with `Access-Control-Allow-Origin: *` cannot set cookies, and a client fetch without `credentials: "include"` never sends them.
+
+**Fix** — three things must line up:
+
+1. Server CORS allows the specific origin and sets `Access-Control-Allow-Credentials: true`.
+   ```ts
+   // Hono example
+   app.use("/api/auth/*", cors({
+     origin: "http://localhost:5173",  // NOT "*"
+     credentials: true,
+     allowMethods: ["GET", "POST", "OPTIONS"],
+     allowHeaders: ["Content-Type", "Authorization"],
+   }));
+   ```
+2. The client sends credentials — `createAuthClient` does this by default, but custom `fetchOptions` must preserve `credentials: "include"`.
+3. Cookies have the right `sameSite`. Same-site can rely on `"lax"`; cross-site requires `"none"` + `secure: true`.
+   ```ts
+   betterAuth({
+     advanced: {
+       defaultCookieAttributes: { sameSite: "none", secure: true, partitioned: true },
+     },
+   });
+   ```
+
+---
+
+## 4. Session cookie not set in production (sameSite / secure mismatch)
+
+**Symptom** — local development works, production sign-in succeeds but the session cookie is missing from the browser. DevTools shows `Set-Cookie` was blocked with reason `secure`, `samesite`, or `this set-cookie was blocked because it had the "secure" attribute but was not received over a secure connection`.
+
+**Cause** — browsers silently drop cookies that have `secure: true` on HTTP origins, or `sameSite: "none"` without `secure: true`. When the production app sits behind a proxy that terminates TLS but forwards HTTP, the server sees HTTP and emits inconsistent cookie flags.
+
+**Fix** —
+
+- Ensure the production origin really is HTTPS end-to-end, or that `trustProxy` / forwarded headers are honored.
+- Set consistent cookie attributes:
+  ```ts
+  betterAuth({
+    advanced: {
+      defaultCookieAttributes: {
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",            // same-site apps
+        httpOnly: true,
+      },
+    },
+  });
+  ```
+- For cross-subdomain sessions (`app.example.com` + `api.example.com`), pin the cookie domain: `defaultCookieAttributes.domain: ".example.com"`.
+
+---
+
+## 5. Schema drift — runtime errors after enabling a plugin
+
+**Symptom** — SQL errors like `column "two_factor_enabled" does not exist`, `no such table: organization`, `P2022: The column ... does not exist in the current database`, or a silent 500 on `/get-session` after adding a plugin.
+
+**Cause** — plugins frequently add columns or whole tables (`organization`, `two-factor`, `passkey`, `username`, `phone-number`, `email-otp`, `admin`). Without regenerating the schema, the DB is missing the columns the plugin reads.
+
+**Fix** — regenerate after every plugin change:
+
+```bash
+npx auth generate    # updates schema snippets for the configured adapter
+npx auth migrate     # applies (built-in Kysely only)
+```
+
+With Prisma:
+
+```bash
+npx auth generate
+npx prisma migrate dev
+```
+
+With Drizzle:
+
+```bash
+npx auth generate
+pnpm drizzle-kit generate
+pnpm drizzle-kit migrate
+```
+
+Mongo needs no migration, but the `admin` / `organization` plugins still expect new collections — writes create them lazily, reads before the first write return `null`.
+
+---
+
+## 6. Edge-runtime incompatibility
+
+**Symptom** — dev server works, but `vercel build` or `wrangler deploy` fails with `Module not found: Can't resolve 'pg-native'`, `crypto.randomUUID is not a function`, `unsupported module 'fs'`, or the app deploys but `/api/auth/*` 500s with `Cannot find module`.
+
+**Cause** — the default Kysely dialect loads Node-native drivers (`pg`, `mysql2`, `better-sqlite3`, `node:crypto` in some paths) that aren't available in V8 / Workers / edge runtimes. Also, `betterAuth` from `better-auth` (the full build) ships Kysely — the minimal build skips it.
+
+**Fix** —
+
+- Use the minimal build plus an edge-safe adapter:
+  ```ts
+  import { betterAuth } from "better-auth/minimal";
+  import { drizzleAdapter } from "better-auth/adapters/drizzle";
+  import { drizzle } from "drizzle-orm/libsql";  // or d1, planetscale-serverless, neon-http
+  ```
+- Confirm every adapter / DB driver advertises edge support. `pg` does not — use `@neondatabase/serverless` or `postgres` (postgres.js) with HTTP transport instead.
+- Move the auth handler out of the edge runtime when a Node-only driver is unavoidable:
+  ```ts
+  export const runtime = "nodejs"; // Next.js route handler
+  ```
+- When crypto APIs diverge (Node vs V8), audit `packages/better-auth/src/crypto/` for the helpers used and confirm they fall back to `globalThis.crypto.subtle`.
+
+---
+
+## Escalation
+
+If a failure does not match any entry above:
+
+```bash
+SRC=$(ask src better-auth)
+
+# Search for the error message
+rg -n "exact error string" "$SRC/packages"
+
+# Check create-context.ts for startup validations
+rg -n "throw|logger.(warn|error)" "$SRC/packages/better-auth/src/context/create-context.ts"
+
+# Check error-codes files for the stable error code emitted by the API
+rg -rn "error-codes.ts" "$SRC/packages/better-auth/src/plugins"
+```
+
+Every plugin ships an `error-codes.ts` file — grep those to map an API response's `error.code` to the originating plugin.

--- a/plugins/better-auth/.agents/skills/use-better-auth/references/databases.md
+++ b/plugins/better-auth/.agents/skills/use-better-auth/references/databases.md
@@ -1,0 +1,188 @@
+# Database Adapters
+
+Verified against `$(ask src better-auth)/packages/better-auth/src/adapters/` and `$(ask src better-auth)/docs/content/docs/adapters/`. Confirm the current list before writing imports:
+
+```bash
+SRC=$(ask src better-auth)
+ls "$SRC/packages/better-auth/src/adapters"      # drizzle-adapter, kysely-adapter, memory-adapter, mongodb-adapter, prisma-adapter
+ls "$SRC/packages" | grep adapter                 # authoritative package list
+```
+
+Two routes are supported:
+
+1. **Built-in Kysely dialect** — pass a raw database pool / driver directly via `database:`. Only for SQLite / Postgres / MySQL / MSSQL. No external package required. Migrations run with `npx auth migrate`.
+2. **External ORM adapter** — wrap an ORM instance (Prisma / Drizzle / Mongo) in the matching `Adapter` function. Migrations are owned by the ORM; better-auth only generates the schema snippet.
+
+## Option 1 — Built-in Kysely (zero-ORM)
+
+### Postgres
+
+```ts
+import { betterAuth } from "better-auth";
+import { Pool } from "pg";
+
+export const auth = betterAuth({
+  database: new Pool({ connectionString: process.env.DATABASE_URL }),
+});
+```
+
+### MySQL / MSSQL
+
+Follow the same pattern with `mysql2/promise` or `tedious`. See `docs/content/docs/adapters/{mysql,mssql}.mdx` for the exact dialect import.
+
+### SQLite
+
+```ts
+import Database from "better-sqlite3";
+
+export const auth = betterAuth({
+  database: new Database("database.sqlite"),
+});
+```
+
+Also supports `libsql`, `node:sqlite` (Node 22+ native), and `bun:sqlite` — see the SQLite adapter doc for the dialect shim per driver.
+
+Apply migrations after config changes:
+
+```bash
+npx auth migrate
+```
+
+## Option 2 — Prisma
+
+```ts
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export const auth = betterAuth({
+  database: prismaAdapter(prisma, { provider: "sqlite" }), // "postgresql" | "mysql" | "mongodb" | ...
+});
+```
+
+**Prisma 7 caveat**: if `schema.prisma` sets a custom `output` path, import `PrismaClient` from that path, not `@prisma/client`. The adapter cannot introspect a mis-aimed client.
+
+### Schema flow
+
+Prisma owns migrations. Better-auth generates the schema snippet:
+
+```bash
+npx auth generate       # writes / updates prisma schema fragments
+npx prisma migrate dev  # prisma owns the actual migration
+```
+
+## Option 3 — Drizzle
+
+```ts
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { db } from "./database";
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, { provider: "pg" }), // "pg" | "mysql" | "sqlite"
+});
+```
+
+Provider values are `pg` / `mysql` / `sqlite` — different from Prisma's `postgresql`. The generator remaps automatically; match whichever value appears in the Drizzle config.
+
+### Schema flow
+
+```bash
+npx auth generate                # writes / updates drizzle schema files
+pnpm drizzle-kit generate        # drizzle owns the migration step
+pnpm drizzle-kit migrate
+```
+
+## Option 4 — Kysely
+
+```ts
+import { kyselyAdapter } from "better-auth/adapters/kysely";
+
+export const auth = betterAuth({
+  database: kyselyAdapter(db, { type: "postgres" }),
+});
+```
+
+Useful when an existing Kysely instance is already shared across the app. Otherwise the built-in Kysely dialect in Option 1 is simpler.
+
+## Option 5 — MongoDB
+
+```ts
+import { betterAuth } from "better-auth";
+import { MongoClient } from "mongodb";
+import { mongodbAdapter } from "better-auth/adapters/mongodb";
+
+const client = new MongoClient("mongodb://localhost:27017/app");
+const db = client.db();
+
+export const auth = betterAuth({
+  database: mongodbAdapter(db, { client }), // client is optional but required for transactions
+});
+```
+
+MongoDB does not have a migration step — collections are created lazily. Since v1.4.0, the adapter supports joins via `experimental.joins: true`, which speeds up `/get-session` and `/get-full-organization` by 2–3×.
+
+## Option 6 — Memory (tests only)
+
+```ts
+import { memoryAdapter } from "better-auth/adapters/memory";
+
+const store = {};
+export const auth = betterAuth({ database: memoryAdapter(store) });
+```
+
+Never for production — the store is process-local and cleared on restart. Useful as a Vitest fixture.
+
+## Schema generation cheatsheet
+
+```bash
+npx auth generate       # diff / write schema for configured adapter
+npx auth migrate        # apply (built-in Kysely only)
+```
+
+Every time a plugin is added or removed, rerun `generate`. Common symptoms of skipping this step: `column "twoFactorEnabled" does not exist`, `no such table: organization`, `P2022: The column ... does not exist` — see `references/common-errors.md`.
+
+## Extending the user / session / account models
+
+Add columns through the `user` / `session` / `account` options on `betterAuth({...})`:
+
+```ts
+betterAuth({
+  user: {
+    additionalFields: {
+      displayName: { type: "string", required: false },
+      role: { type: "string", defaultValue: "member" },
+    },
+  },
+});
+```
+
+Propagate the extra fields to the client SDK's types with the `inferAdditionalFields` helper:
+
+```ts
+// auth-client.ts
+import { createAuthClient } from "better-auth/react";
+import { inferAdditionalFields } from "better-auth/client/plugins";
+import type { auth } from "./auth";
+
+export const authClient = createAuthClient({
+  plugins: [inferAdditionalFields<typeof auth>()],
+});
+```
+
+Without `inferAdditionalFields`, `authClient.useSession()` will type the user as the built-in shape and the extra columns will be silently dropped from intellisense.
+
+## Picking between built-in Kysely and an ORM adapter
+
+| Situation | Pick |
+|-----------|------|
+| Greenfield app, no ORM yet | Built-in Kysely (simplest) |
+| App already uses Prisma | `prismaAdapter` |
+| App already uses Drizzle | `drizzleAdapter` |
+| App uses Mongo | `mongodbAdapter` |
+| Cloudflare / edge runtime | Drizzle + `better-sqlite3` replacement (e.g. `libsql`, `d1`) — Kysely built-in `pg`/`mysql2` are Node-only |
+| High-volume reads on sessions / orgs | Mongo with `experimental.joins` or SQL with proper indexes |
+
+Edge-runtime compatibility is the most common source of silent failures. See `references/common-errors.md` ("edge runtime").

--- a/plugins/better-auth/.agents/skills/use-better-auth/references/plugins.md
+++ b/plugins/better-auth/.agents/skills/use-better-auth/references/plugins.md
@@ -1,0 +1,235 @@
+# Built-in Plugins
+
+Every row below was verified against `$(ask src better-auth)/packages/better-auth/src/plugins/` and each plugin's `index.ts` exports. Re-run this before trusting any import path for the version in use:
+
+```bash
+SRC=$(ask src better-auth)
+ls "$SRC/packages/better-auth/src/plugins"
+rg "^export (const|function) " "$SRC/packages/better-auth/src/plugins/*/index.ts"
+```
+
+Plugins live in the main `better-auth` package unless marked otherwise. Each server plugin is added to `betterAuth({ plugins: [...] })`; each matching client plugin is added to `createAuthClient({ plugins: [...] })` so the client SDK surfaces the new endpoints with types.
+
+## Multi-tenant / teams
+
+### `organization`
+
+Server: `import { organization } from "better-auth/plugins/organization"`
+Client: `import { organizationClient } from "better-auth/client/plugins"`
+
+Adds orgs, members, roles, invitations, and team-scoped sessions. Ships a companion access-control module (`access` — see below) for defining role statements.
+
+Use when the app has multiple tenants, workspaces, or teams. Skip for single-tenant apps with a flat user list.
+
+## Authentication factors
+
+### `two-factor`
+
+Server: `import { twoFactor } from "better-auth/plugins/two-factor"`
+Client: `import { twoFactorClient } from "better-auth/client/plugins"`
+
+TOTP + backup codes + optional OTP. Adds `/two-factor/*` endpoints.
+
+### `passkey` *(separate package `@better-auth/passkey`)*
+
+Server: `import { passkey } from "@better-auth/passkey"`
+Client: `import { passkeyClient } from "@better-auth/passkey/client"`
+
+WebAuthn passkey registration and sign-in. Not in `better-auth/plugins/` — it ships as its own package. Confirm with `ls $(ask src better-auth)/packages/passkey`.
+
+### `magic-link`
+
+Server: `import { magicLink } from "better-auth/plugins/magic-link"`
+Client: `import { magicLinkClient } from "better-auth/client/plugins"`
+
+Passwordless email links. Requires providing `sendMagicLink({ email, url, token })` — mail delivery is owned by the caller.
+
+### `email-otp`
+
+Server: `import { emailOTP } from "better-auth/plugins/email-otp"`
+Client: `import { emailOTPClient } from "better-auth/client/plugins"`
+
+Email OTP for verification / sign-in / password reset. Requires a `sendVerificationOTP` callback.
+
+### `phone-number`
+
+Server: `import { phoneNumber } from "better-auth/plugins/phone-number"`
+Client: `import { phoneNumberClient } from "better-auth/client/plugins"`
+
+Phone + OTP sign-in. Requires a `sendOTP` callback — pair with Twilio, Vonage, etc.
+
+### `siwe`
+
+Server: `import { siwe } from "better-auth/plugins/siwe"`
+Client: `import { siweClient } from "better-auth/client/plugins"`
+
+Sign-In With Ethereum (EIP-4361). Needs `getNonce` / `verifyMessage` callbacks.
+
+### `one-tap`
+
+Server: `import { oneTap } from "better-auth/plugins/one-tap"`
+Client: `import { oneTapClient } from "better-auth/client/plugins"`
+
+Google One Tap sign-in.
+
+### `anonymous`
+
+Server: `import { anonymous } from "better-auth/plugins/anonymous"`
+Client: `import { anonymousClient } from "better-auth/client/plugins"`
+
+Creates throw-away users before sign-up; upgrades them to real accounts on credential linking.
+
+### `username`
+
+Server: `import { username } from "better-auth/plugins/username"`
+Client: `import { usernameClient } from "better-auth/client/plugins"`
+
+Adds username field + username-based sign-in alongside email.
+
+## OAuth / OIDC
+
+### `generic-oauth`
+
+Server: `import { genericOAuth } from "better-auth/plugins/generic-oauth"`
+Client: `import { genericOAuthClient } from "better-auth/client/plugins"`
+
+Catch-all for OAuth 2 / OIDC providers not in `social-providers/`. Ships pre-built configs for Auth0, Slack, and more under `plugins/generic-oauth/providers/` — enumerate with `ls $(ask src better-auth)/packages/better-auth/src/plugins/generic-oauth/providers`.
+
+### `oauth-proxy`
+
+Server: `import { oAuthProxy } from "better-auth/plugins/oauth-proxy"`
+
+Proxies OAuth callbacks through a stable production URL so preview deployments (Vercel previews, tunnels, etc.) can complete OAuth flows that require a fixed redirect URI. Reads `productionURL` or falls back to `BETTER_AUTH_URL`.
+
+### `oidc-provider`
+
+Server: `import { oidcProvider } from "better-auth/plugins/oidc-provider"`
+
+Turns better-auth into an OIDC **provider** (the app hands out tokens to other apps). The inverse of social-providers.
+
+## Sessions / tokens
+
+### `jwt`
+
+Server: `import { jwt } from "better-auth/plugins/jwt"`
+
+Issues signed JWTs alongside the session cookie — useful when other services need to verify sessions without a round-trip.
+
+### `bearer`
+
+Server: `import { bearer } from "better-auth/plugins/bearer"`
+
+Accepts `Authorization: Bearer <token>` in addition to cookies. Wire it up for API clients and mobile apps that can't carry cookies.
+
+### `multi-session`
+
+Server: `import { multiSession } from "better-auth/plugins/multi-session"`
+Client: `import { multiSessionClient } from "better-auth/client/plugins"`
+
+Lets a browser keep several concurrent sessions (switch between accounts without signing out).
+
+### `custom-session`
+
+Server: `import { customSession } from "better-auth/plugins/custom-session"`
+Client: `import { customSessionClient } from "better-auth/client/plugins"`
+
+Extend the shape returned by `useSession()` / `getSession()` — commonly used to embed the current `organization` on the session object.
+
+### `one-time-token`
+
+Server: `import { oneTimeToken } from "better-auth/plugins/one-time-token"`
+Client: `import { oneTimeTokenClient } from "better-auth/client/plugins"`
+
+Short-lived single-use tokens (e.g. for invite links or password-less device linking).
+
+### `device-authorization`
+
+Server: `import { deviceAuthorization } from "better-auth/plugins/device-authorization"`
+Client: `import { deviceAuthorizationClient } from "better-auth/client/plugins"`
+
+RFC 8628 device flow — pair a TV / CLI with a browser session.
+
+### `last-login-method`
+
+Server: `import { lastLoginMethod } from "better-auth/plugins/last-login-method"`
+Client: `import { lastLoginMethodClient } from "better-auth/client/plugins"`
+
+Remembers the last auth method per user and exposes it so the UI can highlight it on the sign-in form.
+
+## Admin / governance
+
+### `admin`
+
+Server: `import { admin } from "better-auth/plugins/admin"`
+Client: `import { adminClient } from "better-auth/client/plugins"`
+
+Role-based user management: list, ban, impersonate, set role. Pair with `access` for fine-grained statements.
+
+### `access`
+
+`import { createAccessControl, role } from "better-auth/plugins/access"`
+
+Not a plugin itself — the access-control primitive used by `organization` and `admin` to define role statements (resource × action).
+
+### `additional-fields`
+
+Client-only type helper: `import { inferAdditionalFields } from "better-auth/client/plugins"`
+
+Propagates extra columns added to the user / session / account tables through the client SDK's types.
+
+### `haveibeenpwned`
+
+Server: `import { haveIBeenPwned } from "better-auth/plugins/haveibeenpwned"`
+
+Rejects sign-ups / password changes when the password appears in the HIBP k-anonymity API.
+
+### `captcha`
+
+Server: `import { captcha } from "better-auth/plugins/captcha"`
+
+Gates sensitive endpoints behind Turnstile / hCaptcha / reCAPTCHA / Arkose verification.
+
+## Tooling
+
+### `open-api`
+
+Server: `import { openAPI } from "better-auth/plugins/open-api"`
+
+Exposes an OpenAPI 3 schema for every mounted endpoint (including plugin endpoints) — useful for client-SDK codegen.
+
+### `mcp`
+
+Server: `import { mcp } from "better-auth/plugins/mcp"`
+
+Model Context Protocol integration — lets an MCP client authenticate against better-auth. Ships MCP-specific adapters: `mcpAuthHono`, `mcpAuthOfficial`, `mcpAuthMcpUse`.
+
+## Decision matrix
+
+| User-visible need | Pick |
+|-------------------|------|
+| Teams, orgs, workspaces | `organization` (+ `customSession` to surface active org) |
+| TOTP / backup codes | `two-factor` |
+| Passkeys / WebAuthn | `@better-auth/passkey` |
+| Email magic link | `magic-link` |
+| Email or SMS OTP | `email-otp`, `phone-number` |
+| Remember Ethereum wallet | `siwe` |
+| Admin panel for user management | `admin` (+ `access`) |
+| API clients / mobile (no cookies) | `bearer` |
+| Preview deploys / tunnels break OAuth | `oauth-proxy` |
+| App acts as IdP | `oidc-provider` |
+| Other services need signed claims | `jwt` |
+| User switches between accounts | `multi-session` |
+| Pwned-password blocklist | `haveibeenpwned` |
+| Bot protection on sensitive endpoints | `captcha` |
+| Auto-generated SDK / docs | `open-api` |
+
+## Schema impact
+
+Most plugins add columns or tables. After enabling one, regenerate the schema:
+
+```bash
+npx auth generate    # prints schema diff / writes files
+npx auth migrate     # applies (Kysely built-in only)
+```
+
+Forgetting this step is the top cause of `no such column` / `invalid input syntax` errors at runtime. See `references/common-errors.md` ("schema drift").

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Better Auth authentication framework skills for JavaScript/TypeScript projects",
   "author": {
     "name": "Better Auth",

--- a/plugins/better-auth/CHANGELOG.md
+++ b/plugins/better-auth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0] - 2026-04-23
+
+
+### Features
+
+* **better-auth:** add hand-written `use-better-auth` skill for grounding agent work in the installed version via the `ask` CLI, mirroring Vercel's `use-ai-sdk` workflow skill
+
 ## [1.1.0](https://github.com/pleaseai/claude-code-plugins/compare/better-auth-v1.0.0...better-auth-v1.1.0) (2026-03-19)
 
 


### PR DESCRIPTION
## Summary

Adds a hand-written `use-better-auth` workflow skill to the `better-auth` plugin, mirroring the structure and intent of Vercel's `use-ai-sdk` skill.

## What was added and where

- **New skill**: `plugins/better-auth/.agents/skills/use-better-auth/SKILL.md` (216 lines, imperative voice, no second-person)
- **Reference docs** (4 files under `.../references/`):
  - `adapters.md` — supported framework adapters
  - `plugins.md` — built-in plugin catalogue
  - `databases.md` — supported database adapters
  - `common-errors.md` — common error patterns and fixes
- **Version bump**: `plugins/better-auth/.claude-plugin/plugin.json` 1.1.0 → 1.2.0
- **Changelog**: 1.2.0 entry prepended to `plugins/better-auth/CHANGELOG.md`

## Why hand-written instead of vendor-synced

This skill is a **meta-skill** that teaches agents _how to work_ with better-auth, not end-user best-practices that belong upstream in the `better-auth` source repository. Specifically:

- It mirrors the `use-ai-sdk` pattern from the Vercel plugin: ground every code-generation step in the **installed** package version by querying `$(ask src better-auth)` rather than trusting training-data knowledge that may be months behind the latest release.
- Vendor-synced skills (those with `SYNC.md`) are generated from upstream Gemini CLI extensions. There is no upstream source for this grounding skill — it was authored here intentionally.
- Placing it in `.agents/skills/` (not `skills/`) keeps it out of the auto-sync pipeline and avoids accidental overwrites on the next `bun run skills:sync`.

## Verification

- `claude plugin validate plugins/better-auth` passes with version 1.2.0.
- Plugin, adapter, and integration names in the reference files were spot-checked against `$(ask src better-auth)` source tree (e.g. `betterAuth`, `prismaAdapter`, `twoFactor`, `admin`).
- SKILL.md body is written in imperative mood with no second-person ("you") references, consistent with skill authoring standards.
- `skills-lock.json` was intentionally left untouched — it is managed exclusively by `bunx skills add` / vendor sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hand-written `use-better-auth` workflow skill to the `better-auth` plugin to ground auth work in the installed package version via the `ask` CLI. Mirrors the `use-ai-sdk` pattern to provide accurate, version-aware guidance.

- **New Features**
  - Added `plugins/better-auth/.agents/skills/use-better-auth/SKILL.md` that queries local `better-auth` source to avoid stale APIs.
  - Included `references/` for adapters, plugins, databases, and common errors sourced from the repo.
  - Placed the skill under `.agents/skills/` to stay out of the vendor sync pipeline.

- **Dependencies**
  - Bumped plugin version to 1.2.0 and updated `CHANGELOG.md`.

<sup>Written for commit 404540dafcecf236e9b4da22694274a97ec251c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

