### PR TITLE
chore: swap markitdown plugin for ask plugin in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,7 +63,7 @@
     "tsdown@pleaseai": false,
     "vueuse@pleaseai": true,
     "fetch@pleaseai": true,
-    "markitdown@pleaseai": true
+    "ask@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "passionfactory": {


### PR DESCRIPTION
## Summary

Replaces `markitdown@pleaseai` with `ask@pleaseai` in the `enabledPlugins` section of `.claude/settings.json`.

## Changes

- Removed `markitdown@pleaseai: true` from enabled plugins
- Added `ask@pleaseai: true` to enabled plugins

## Notes

This is a local Claude Code settings change only — no user-facing app code, CHANGELOG, or version files are affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swap enabled plugin in `.claude/settings.json`: `markitdown@pleaseai` -> `ask@pleaseai`. Settings-only; no user-facing changes.

<sup>Written for commit 681e700a7720aadf0a76db77477a73eaf2e1b9c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

