### PR TITLE
feat: add graphite plugin for stacked-PR workflows with gt CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -586,6 +586,14 @@
       "source": "./plugins/git-ai"
     },
     {
+      "name": "graphite",
+      "description": "Stacked PR workflow with the Graphite CLI (gt) — create stacks, submit, sync, restack, split/squash/fold, track branches, and collaborate on shared stacks",
+      "category": "development",
+      "keywords": ["graphite", "gt", "stacked-prs", "stacking", "git", "github", "pull-request", "code-review"],
+      "tags": ["tooling", "git", "github"],
+      "source": "./plugins/graphite"
+    },
+    {
       "name": "workflow",
       "description": "Workflow SDK: Build durable, reliable, and observable apps and AI Agents in TypeScript",
       "category": "development",

--- a/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
@@ -1,3 +1,4 @@
 # Agent Memory — review-review-cubic-reviewer
 
 - [Mastra skill review (PR #161)](pr161-mastra-skill.md) — cubic found no issues after correctness fixes were applied
+- [Graphite commands review (PR #170)](pr170-graphite-commands.md) — cubic P1 flagging `gt create` positional arg was a false positive (CLI confirms `gt create [name]` is valid)

--- a/.claude/agent-memory/review-review-cubic-reviewer/pr170-graphite-commands.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/pr170-graphite-commands.md
@@ -1,0 +1,19 @@
+---
+name: Graphite commands review (PR #170)
+description: cubic review of 4 markdown docs in plugins/graphite/commands/ — 1 false positive flagged about gt create positional arg
+metadata:
+  type: project
+---
+
+PR #170 (graphite plugin) — review-fix pass after gemini + cubic bot feedback on first push. Four markdown files changed: create.md, fold.md, modify.md, squash.md.
+
+cubic found 1 issue (P1):
+- `plugins/graphite/commands/create.md:15` — "Incorrect `gt create` invocation for single-token input": cubic claimed there is no positional branch-name argument for `gt create`.
+
+**Verdict: false positive.** `gt create --help` confirms the CLI signature is `gt create [name]` where `[name]` is an optional positional branch-name argument. The doc's `gt create -am "<message>" $ARGUMENTS` is valid syntax when `$ARGUMENTS` is a single branch-name token.
+
+No fixes were applied. Review state saved at commit bea558f.
+
+**Why:** cubic hallucinated a constraint ("branch names are derived from message only") that conflicts with the actual CLI help text.
+
+**How to apply:** When cubic flags `gt` CLI invocations as invalid, verify against `gt <subcommand> --help` before accepting the issue. cubic has a pattern of not knowing the full `gt` CLI surface.

--- a/plugins/graphite/.claude-plugin/plugin.json
+++ b/plugins/graphite/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "graphite",
+  "version": "1.0.0",
+  "description": "Stacked PR workflow with the Graphite CLI (gt) — create stacks, submit, sync, restack, split/squash/fold, track existing branches, and collaborate on shared stacks",
+  "author": {
+    "name": "Passion Factory",
+    "email": "support@passionfactory.ai",
+    "url": "https://github.com/pleaseai"
+  },
+  "homepage": "https://graphite.com/docs",
+  "repository": "https://github.com/pleaseai/claude-code-plugins",
+  "license": "MIT",
+  "keywords": [
+    "graphite",
+    "gt",
+    "stacked-prs",
+    "stacking",
+    "git",
+    "github",
+    "pull-request",
+    "code-review"
+  ]
+}

--- a/plugins/graphite/README.md
+++ b/plugins/graphite/README.md
@@ -1,0 +1,85 @@
+# graphite
+
+Stacked pull-request workflow with the Graphite CLI (`gt`). Teaches Claude to drive `gt` for creating, syncing, restacking, and submitting branch stacks.
+
+## Overview
+
+[Graphite](https://graphite.com) is a developer-tool layer on top of `git` and GitHub that makes **stacks of small PRs** ergonomic. A stack is a sequence of branches where each builds on its parent and lands as its own PR. This plugin makes Claude aware of the stack model so it uses `gt` instead of raw `git` for branch creation, rebasing, and pushes.
+
+The plugin includes:
+
+- A **skill** (`graphite`) that activates whenever stacked-PR or `gt` work comes up. It documents the mental model, the golden path, conflict-resolution patterns, worktree handling, and multi-trunk setups.
+- **15 slash commands** covering basic workflows (`create`, `submit`, `sync`, `log`, `checkout`, `modify`) and advanced operations (`restack`, `absorb`, `split`, `squash`, `fold`, `track`, `reorder`, `move`, `get`).
+
+## Prerequisites
+
+Install and authenticate the Graphite CLI first — this plugin drives the CLI, it does not install it.
+
+```sh
+# macOS
+brew install withgraphite/tap/graphite
+
+# Other platforms / npm
+npm install -g @withgraphite/graphite-cli
+
+# Authenticate (one time)
+gt auth
+```
+
+Then in your repo:
+
+```sh
+gt init   # select trunk branch (usually main)
+```
+
+## Installation
+
+```sh
+claude
+/plugin marketplace add pleaseai/claude-code-plugins
+/plugin install graphite@pleaseai
+```
+
+## Commands
+
+### Basic
+
+| Command | Purpose |
+|---------|---------|
+| `/graphite:create` | Create a new stacked branch from the current working-tree changes |
+| `/graphite:submit` | Push the stack and create/update PRs |
+| `/graphite:sync` | Pull trunk, prune merged branches, restack |
+| `/graphite:log` | Show the stack (`gt ls` / `gt log`) |
+| `/graphite:checkout` | Move between branches (up/down/top/bottom/name) |
+| `/graphite:modify` | Amend or add a commit on the current branch (auto-restacks upstack) |
+
+### Advanced
+
+| Command | Purpose |
+|---------|---------|
+| `/graphite:restack` | Repair branches after parent SHA changes; drive conflict resolution |
+| `/graphite:absorb` | Distribute working-tree changes across the right downstack branches |
+| `/graphite:split` | Break the current branch into multiple branches by commit/file/hunk |
+| `/graphite:squash` | Squash a multi-commit branch into one |
+| `/graphite:fold` | Combine the current branch into its parent |
+| `/graphite:track` | Bring an externally-created git branch under Graphite |
+| `/graphite:reorder` | Interactively reorder branches in the stack |
+| `/graphite:move` | Rebase the current branch (and dependents) onto a new parent |
+| `/graphite:get` | Fetch a teammate's stack to collaborate |
+
+## How it works
+
+The skill loads automatically when the user mentions Graphite, `gt`, stacked PRs, or works in a repo containing `.git/.graphite_repo_config`. It teaches Claude to:
+
+- Prefer `gt` over raw `git` for branch operations on tracked branches
+- Run `gt ls` before any destructive operation to confirm stack shape
+- Resolve restack conflicts via `gt add .` → `gt continue -a` (not `git rebase --continue`)
+- Handle worktrees: run stack commands from each owning worktree
+- Avoid `git rebase` on tracked branches (corrupts Graphite metadata)
+
+## Links
+
+- [Graphite docs](https://graphite.com/docs)
+- [CLI quick start](https://graphite.com/docs/cli-quick-start)
+- [Command cheatsheet](https://graphite.com/docs/cheatsheet)
+- [Command reference](https://graphite.com/docs/command-reference)

--- a/plugins/graphite/commands/absorb.md
+++ b/plugins/graphite/commands/absorb.md
@@ -1,0 +1,28 @@
+---
+description: Distribute working-tree changes to the right downstack branches (gt absorb)
+allowed-tools: Bash, Read
+argument-hint: [-a (stage all) | -p (patch mode) | -d (dry run)]
+---
+
+When the working tree contains hunks that logically belong to **several different downstack branches**, `gt absorb` figures out which branch each hunk should amend into and applies them. User input: `$ARGUMENTS`.
+
+## When to prefer absorb over modify
+
+- The diff fixes things touched by multiple ancestors (e.g. typo in branch A and unrelated bug in branch B).
+- You want to land review feedback that spans multiple PRs at once.
+- For changes that all belong on the current branch, use `/graphite:modify` instead — it's simpler.
+
+## Steps
+
+1. Run `git status --short` so the user sees the working-tree state.
+2. Run `gt ls` to show which branches are candidates downstack.
+3. Run a dry run first: `gt absorb -a -d` (or `gt absorb -p -d` for hunk selection). Show the user the proposed branch-per-hunk assignment.
+4. If the user approves, run without `-d` to apply. Each affected branch is amended, then everything upstack is auto-restacked.
+5. Resolve any restack conflicts the usual way: `gt add .` → `gt continue -a`, or `gt abort`.
+6. Run `gt ls` and consider `gt submit --stack -u` to update PRs.
+
+## Key flags
+
+- `-a, --all` — consider all modified files (default is staged only)
+- `-p, --patch` — interactive hunk selection
+- `-d, --dry-run` — show the plan without amending

--- a/plugins/graphite/commands/checkout.md
+++ b/plugins/graphite/commands/checkout.md
@@ -1,0 +1,29 @@
+---
+description: Switch branches in the stack (gt checkout / up / down / top / bottom)
+allowed-tools: Bash, Read
+argument-hint: [branch | up | down | top | bottom | trunk]
+---
+
+Move to a different branch in the Graphite stack. User input: `$ARGUMENTS`.
+
+## Dispatch by argument
+
+- `up` or empty + "next up" intent → `gt up` (alias `gt u`); accept a trailing number for steps (`gt up 2`).
+- `down` → `gt down` (`gt d`); same step semantics.
+- `top` → `gt top` (`gt t`).
+- `bottom` → `gt bottom` (`gt b`).
+- `trunk` or `main` → `gt checkout --trunk` (`gt co -t`).
+- A branch name → `gt checkout <name>` (`gt co <name>`).
+- Empty / no argument → `gt checkout` (interactive picker — only run if the session supports interactive prompts; otherwise show `gt ls` and ask the user to pick).
+
+## Steps
+
+1. If the working tree is dirty, run `git status --short` and confirm with the user — checkout will fail or carry the changes.
+2. Run `gt ls` to show context.
+3. Run the dispatched command.
+4. Confirm with `gt ls` (the new current branch is marked `◉`).
+
+## Notes
+
+- When `gt up` or `gt top` hits a branch with multiple children, it prompts to disambiguate. In non-interactive contexts, pass the specific branch name instead.
+- `gt checkout -s <branch>` switches to a branch and pulls its whole stack — useful when navigating to a teammate's stack after `gt get`.

--- a/plugins/graphite/commands/create.md
+++ b/plugins/graphite/commands/create.md
@@ -1,0 +1,26 @@
+---
+description: Create a new stacked branch from the current changes (gt create)
+allowed-tools: Bash, Read, Grep
+argument-hint: [branch-name or commit message]
+---
+
+Create a new Graphite-tracked branch on top of the current branch, carrying the working-tree changes as a single commit. User input: `$ARGUMENTS`.
+
+## Steps
+
+1. Run `git status --short` to confirm there are changes to commit. If the tree is clean, ask the user whether they meant to run `gt create --onto <branch>` (create empty branch on top of another).
+2. Run `gt ls` to show the current stack so the user can confirm where the new branch lands.
+3. Build the command:
+   - If `$ARGUMENTS` looks like a commit message (contains spaces or `:`), use `gt create -am "$ARGUMENTS"` — Graphite derives the branch name from the message.
+   - If `$ARGUMENTS` is a single token, treat it as a branch name: `gt create -am "..." $ARGUMENTS`. Ask the user for a commit message if one wasn't provided.
+   - If `$ARGUMENTS` is empty, ask the user for a commit message (or branch name) before proceeding.
+4. Run the command and report the new branch and updated `gt ls`.
+
+## Key flags
+
+- `-a, --all` — stage every modified file (default for this command)
+- `-m, --message <msg>` — commit message (and source of the auto-generated branch name)
+- `-p, --patch` — interactive hunk staging instead of `-a`
+- `--insert` — insert this branch between the current branch and its children, restacking dependents
+- `--onto <branch>` — create on top of a different branch (useful with worktrees)
+- `--ai` — let Graphite suggest a branch name / message

--- a/plugins/graphite/commands/create.md
+++ b/plugins/graphite/commands/create.md
@@ -12,7 +12,7 @@ Create a new Graphite-tracked branch on top of the current branch, carrying the 
 2. Run `gt ls` to show the current stack so the user can confirm where the new branch lands.
 3. Build the command:
    - If `$ARGUMENTS` looks like a commit message (contains spaces or `:`), use `gt create -am "$ARGUMENTS"` — Graphite derives the branch name from the message.
-   - If `$ARGUMENTS` is a single token, treat it as a branch name: `gt create -am "..." $ARGUMENTS`. Ask the user for a commit message if one wasn't provided.
+   - If `$ARGUMENTS` is a single token, treat it as a branch name. Ask the user for a commit message, then run: `gt create -am "<message>" $ARGUMENTS`.
    - If `$ARGUMENTS` is empty, ask the user for a commit message (or branch name) before proceeding.
 4. Run the command and report the new branch and updated `gt ls`.
 

--- a/plugins/graphite/commands/fold.md
+++ b/plugins/graphite/commands/fold.md
@@ -1,0 +1,26 @@
+---
+description: Combine the current branch into its parent (gt fold)
+allowed-tools: Bash, Read
+argument-hint: [--keep | --close]
+---
+
+Merge the current branch's commits into its parent branch. Children of the current branch become children of the parent. User input: `$ARGUMENTS`.
+
+## When to use
+
+- Two adjacent branches turned out to be the same logical change and shouldn't be separate PRs.
+- A small follow-up branch is ready to be rolled into the change it depends on.
+
+## Steps
+
+1. Run `gt ls` and confirm with the user **which** parent the current branch will fold into. Ask for confirmation before folding — this is destructive on the PR (the child branch's PR will be closed unless `--keep` is used).
+2. Run `gt fold`. By default the resulting branch keeps the **parent's** name.
+   - `gt fold --keep` (`-k`) — keep the child's name instead, retiring the parent's name.
+   - `gt fold --close` (`-c`) — also close the now-redundant PR.
+3. Auto-restack runs for upstack branches. Resolve conflicts as usual.
+4. `gt submit -u` to update the surviving PR.
+
+## Notes
+
+- The folded branch now contains **both** sets of commits. Consider running `/graphite:squash` afterwards to keep the Graphite "one commit per branch" style.
+- If you want the *opposite* — break a branch apart — use `/graphite:split`.

--- a/plugins/graphite/commands/fold.md
+++ b/plugins/graphite/commands/fold.md
@@ -13,12 +13,12 @@ Merge the current branch's commits into its parent branch. Children of the curre
 
 ## Steps
 
-1. Run `gt ls` and confirm with the user **which** parent the current branch will fold into. Ask for confirmation before folding — this is destructive on the PR (the child branch's PR will be closed unless `--keep` is used).
+1. Run `gt ls` and confirm the parent branch with the user. Ask for confirmation before folding — this is destructive on the PR for the disappearing branch name (close it manually or pass `--close`).
 2. Run `gt fold`. By default the resulting branch keeps the **parent's** name.
    - `gt fold --keep` (`-k`) — keep the child's name instead, retiring the parent's name.
    - `gt fold --close` (`-c`) — also close the now-redundant PR.
 3. Auto-restack runs for upstack branches. Resolve conflicts as usual.
-4. `gt submit -u` to update the surviving PR.
+4. `gt submit --stack -u` to push the surviving branch and the restacked upstack branches to their PRs.
 
 ## Notes
 

--- a/plugins/graphite/commands/get.md
+++ b/plugins/graphite/commands/get.md
@@ -1,0 +1,34 @@
+---
+description: Fetch a teammate's stack locally and start collaborating (gt get)
+allowed-tools: Bash, Read
+argument-hint: <branch-name> [--unfrozen | --force]
+---
+
+Pull a teammate's branch (and its full stack) into the local repo so you can review, extend, or build on top. User input: `$ARGUMENTS`.
+
+## Steps
+
+1. Confirm the working tree is clean (`git status --short`). If not, ask the user to commit or stash first.
+2. Run `gt get <branch>`. Graphite fetches the branch and every ancestor up to trunk, tracking each one.
+3. Branches arrive **frozen by default** — local edits are blocked until they're unfrozen. To start contributing immediately, run with `--unfrozen`.
+4. Run `gt ls` to show the user the new stack alongside any existing local stacks.
+
+## After fetching
+
+To extend a teammate's stack:
+```bash
+gt co <their-branch>             # navigate to it
+gt unfreeze <their-branch>       # if you'll modify it; otherwise skip
+# make changes
+gt create -am "your addition"    # stack your branch on top
+gt submit                        # opens your own PR
+```
+
+To just review without editing, leave the branch frozen — `gt sync` will still keep it current with the remote.
+
+## Key flags
+
+- `-d, --downstack` — fetch only this branch's ancestors (default is full stack)
+- `-u, --remote-upstack` — also fetch children pushed by the teammate
+- `--unfrozen` — bring in unfrozen so local edits are immediately allowed
+- `-f, --force` — overwrite any local copies of the same branch

--- a/plugins/graphite/commands/log.md
+++ b/plugins/graphite/commands/log.md
@@ -1,0 +1,25 @@
+---
+description: Show the Graphite stack (gt log / gt ls)
+allowed-tools: Bash
+argument-hint: [--all | --stack | short]
+---
+
+Display the current Graphite stack structure. User input: `$ARGUMENTS`.
+
+## Decide form
+
+- `gt ls` (alias for `gt log short`) — compact tree, fastest, good default for orientation.
+- `gt log` — full information per branch (PR status, last commit, worktree path).
+- `gt log -a` / `gt log --all` — show every stack in the repo, not just the current one.
+- `gt log -s` / `gt log --stack` — limit to the current stack.
+
+If `$ARGUMENTS` is empty, run `gt ls`. Otherwise pass the args through.
+
+## Reading the output
+
+- `◉` (filled circle) marks the current branch.
+- A worktree path next to a branch means it's checked out in another worktree — do not modify it from here.
+- `needs restack` next to a branch means its parent has moved; run `/graphite:restack` before submitting.
+- PR numbers and statuses (open, draft, merged) appear at the end of each line in `gt log`.
+
+Just run the command and show the output to the user — do not interpret unless asked.

--- a/plugins/graphite/commands/modify.md
+++ b/plugins/graphite/commands/modify.md
@@ -15,9 +15,10 @@ Apply working-tree changes to the current branch and automatically restack every
   ```
 - **New commit** — adds a new commit on the same branch.
   ```
-  gt modify -cam "fix tests"
-  gt modify -c              # use already-staged changes
+  gt modify -cam "fix tests"        # stage all + new commit with message
+  gt modify -cm "fix tests"         # already-staged changes + new commit with message
   ```
+  Always pass `-m "<message>"` — `gt modify -c` alone opens `$EDITOR` for the message, which hangs in a non-interactive shell.
 - **Into a downstack branch** — amend changes into an ancestor branch, then restack upward.
   ```
   gt modify --into <ancestor-branch>

--- a/plugins/graphite/commands/modify.md
+++ b/plugins/graphite/commands/modify.md
@@ -1,0 +1,48 @@
+---
+description: Amend or add a commit on the current branch and auto-restack upstack (gt modify)
+allowed-tools: Bash, Read
+argument-hint: [-c for new commit | -m "message" | --into <branch>]
+---
+
+Apply working-tree changes to the current branch and automatically restack every upstack descendant. User input: `$ARGUMENTS`.
+
+## Modes
+
+- **Amend** (default) — folds staged changes into the existing commit. PR keeps the same identity; force-push needed on next submit.
+  ```
+  gt modify -a              # stage all + amend
+  gt modify                 # amend already-staged changes
+  ```
+- **New commit** — adds a new commit on the same branch.
+  ```
+  gt modify -cam "fix tests"
+  gt modify -c              # use already-staged changes
+  ```
+- **Into a downstack branch** — amend changes into an ancestor branch, then restack upward.
+  ```
+  gt modify --into <ancestor-branch>
+  ```
+
+## Steps
+
+1. Run `git status --short` and `gt ls` so the user sees what is staged and where it will land.
+2. Pick the mode from `$ARGUMENTS`. If ambiguous (multi-commit branch already exists), ask the user: amend or new commit? Amend keeps the branch single-commit (preferred Graphite style); new commit makes it a multi-commit branch that may need `gt squash` later.
+3. Run the chosen `gt modify` command.
+4. If the auto-restack hits conflicts:
+   - Resolve in the editor.
+   - `gt add .` to mark resolved.
+   - `gt continue -a` to finish the restack chain.
+   - `gt abort` to back out cleanly.
+5. Run `gt ls` to confirm the new state.
+
+## Key flags
+
+- `-a, --all` — stage all modified files before amending
+- `-c, --commit` — create a new commit instead of amending
+- `-m, --message <msg>` — commit message (for `-c` or to reword on amend)
+- `-p, --patch` — interactive hunk staging
+- `--into <branch>` — amend into a downstack branch in one step
+
+## When to use `gt absorb` instead
+
+If the working-tree changes belong to **multiple** downstack branches (e.g. you fixed several bugs across the stack), use `gt absorb -a` — Graphite picks the right branch per hunk.

--- a/plugins/graphite/commands/move.md
+++ b/plugins/graphite/commands/move.md
@@ -1,0 +1,28 @@
+---
+description: Rebase the current branch (and its dependents) onto a new parent (gt move)
+allowed-tools: Bash, Read
+argument-hint: [--onto <branch> | --only]
+---
+
+Re-parent the current branch onto a different branch and bring its descendants along. User input: `$ARGUMENTS`.
+
+## Steps
+
+1. Run `gt ls` to show the current shape.
+2. Determine the target parent:
+   - If `$ARGUMENTS` includes `--onto <branch>` or just a branch name, use that.
+   - Otherwise, run `gt move` to open the interactive parent picker. If the session is non-interactive, ask the user for the target branch.
+3. Run `gt move --onto <target-branch>`.
+4. Graphite rebases the current branch onto the target and restacks everything upstack of it. Resolve conflicts the usual way: `gt add .` → `gt continue -a`, or `gt abort`.
+5. Run `gt ls` to confirm the new structure.
+
+## Key flags
+
+- `-o, --onto <branch>` — target parent (skips interactive picker)
+- `--only` — move just this branch; do not bring children along
+
+## When to use vs reorder
+
+- Single branch + clear new parent → `gt move --onto`.
+- Multiple branches need shuffling → `/graphite:reorder` (editor-based).
+- Just inserting a new branch → `/graphite:create` with `--insert`.

--- a/plugins/graphite/commands/reorder.md
+++ b/plugins/graphite/commands/reorder.md
@@ -1,0 +1,26 @@
+---
+description: Interactively reorder branches in the current stack (gt reorder)
+allowed-tools: Bash, Read
+argument-hint: [--stack]
+---
+
+Reshuffle the order of branches in the current stack via an editor-based picker. User input: `$ARGUMENTS`.
+
+## How it works
+
+`gt reorder` opens `$EDITOR` with the current branch and its ancestors (downstack), one branch per line. Rearrange the lines to set the new order. You can also delete lines (removes the branch from the stack) or add lines (must reference branches Graphite already knows about).
+
+## Steps
+
+1. Run `gt ls` to show the user the stack today.
+2. Ask which form they want:
+   - `gt reorder` — just the downstack of the current branch.
+   - `gt reorder --stack` — the entire stack (trunk → tip).
+3. Run the command. Graphite will open the editor; if the session is non-interactive, suggest using `/graphite:move --onto <branch>` to reposition one branch at a time instead.
+4. On save, Graphite performs the restacks. Resolve any conflicts as usual: `gt add .` → `gt continue -a`, or `gt abort`.
+5. Run `gt ls` to confirm.
+
+## When to prefer alternatives
+
+- Moving a **single branch** to a new parent → `/graphite:move` with `--onto <branch>`.
+- Inserting a **new branch** mid-stack → `gt create --insert -am "..."` (covered by `/graphite:create`).

--- a/plugins/graphite/commands/restack.md
+++ b/plugins/graphite/commands/restack.md
@@ -1,0 +1,35 @@
+---
+description: Rebase branches onto current parents and resolve restack conflicts (gt restack)
+allowed-tools: Bash, Read, Edit
+argument-hint: [--upstack | --downstack | --only]
+---
+
+Repair the stack when branches point at stale parent commits. User input: `$ARGUMENTS`.
+
+## When restack is needed
+
+- `gt sync` reported "could not restack" for one or more branches.
+- A PR was squash-merged on GitHub — children still reference the pre-squash SHA.
+- A manual `git rebase` was run on a tracked branch (avoid this in general).
+- `gt ls` shows `needs restack` next to a branch.
+
+## Steps
+
+1. Run `gt ls` to identify branches marked `needs restack`.
+2. If a specific branch was named in conflict output, `gt co <branch>` first.
+3. Run the appropriate scope:
+   - `gt restack` — restack the current stack on its current parents.
+   - `gt restack -u` / `--upstack` — only branches above the current one.
+   - `gt restack -d` / `--downstack` — only branches below the current one.
+   - `gt restack -o` / `--only` — current branch only, leave neighbors.
+4. On conflict during the rebase:
+   - Resolve conflicts in editor (markers `<<<<<<<` / `=======` / `>>>>>>>`).
+   - `gt add .` to mark resolved (wraps `git add`).
+   - `gt continue -a` to finish the restack chain.
+   - Or `gt abort` to back out — safe to do.
+5. After clean restack, run `gt ls` to confirm and consider `gt submit --stack -u` to update the PRs.
+
+## Notes
+
+- `gt restack` is idempotent — running it on an already-clean stack is a no-op.
+- Across worktrees: run `gt restack` from **each** worktree that owns branches in the stack (Graphite 1.8.4+).

--- a/plugins/graphite/commands/split.md
+++ b/plugins/graphite/commands/split.md
@@ -1,0 +1,29 @@
+---
+description: Break the current branch into multiple branches (gt split)
+allowed-tools: Bash, Read
+argument-hint: [--by-commit | --by-file "<pathspec>" | --by-hunk]
+---
+
+Divide the current branch into a stack of smaller branches. User input: `$ARGUMENTS`.
+
+## Modes
+
+- `gt split --by-commit` (`-c`) — split along existing commit boundaries. Each commit becomes its own branch. Only useful on a multi-commit branch.
+- `gt split --by-file "<pathspec>"` (`-f`) — peel off files matching the pathspec onto a new branch. Repeat `-f` for multiple patterns: `gt split -f "*.json" -f "*.yaml"`.
+- `gt split --by-hunk` (`-h`) — interactive `git add --patch`-style hunk selection.
+
+## Steps
+
+1. Run `gt ls` and `git log --oneline <trunk>..` so the user sees what's on the branch today.
+2. Decide the mode:
+   - Multiple commits already, clean per-commit grouping → `--by-commit`.
+   - Mixed files, easy to separate by path → `--by-file`.
+   - Same files but distinct concerns → `--by-hunk`.
+3. Run `gt split <mode>`.
+4. **Preserve the original branch name on one of the pieces** if it already has a PR — GitHub PR branch names are immutable. Tell the user when this matters; Graphite usually prompts.
+5. After the split, run `gt ls` and consider `gt submit --stack` to open PRs for the new branches.
+
+## Notes
+
+- After splitting, the auto-restack runs for everything above the split point. Resolve conflicts the usual way.
+- If the user wants the *opposite* (combine branches), use `/graphite:fold` (into parent) or `/graphite:squash` (commits within one branch).

--- a/plugins/graphite/commands/squash.md
+++ b/plugins/graphite/commands/squash.md
@@ -17,7 +17,7 @@ Collapse a multi-commit branch into a single commit. User input: `$ARGUMENTS`.
 2. Run `gt squash` — Graphite opens `$EDITOR` with all the commit messages concatenated so you can craft a final message.
    - `gt squash -m "<message>"` skips the editor with a preset message.
    - `gt squash -n` / `--no-edit` reuses the first commit's message untouched.
-3. Auto-restack runs for everything upstack. Resolve conflicts the usual way: `gt add .` → `gt continue -a`.
+3. `gt squash` rewrites the branch's SHA. Upstack children now point at the old SHA — run `gt restack` to bring them onto the new commit. If `gt restack` hits conflicts, resolve in editor → `gt add .` → `gt continue -a`.
 4. `gt submit -u` (or `gt submit --stack -u`) to force-push the updated branch to the PR.
 
 ## Notes

--- a/plugins/graphite/commands/squash.md
+++ b/plugins/graphite/commands/squash.md
@@ -1,0 +1,26 @@
+---
+description: Squash all commits on the current branch into one (gt squash)
+allowed-tools: Bash, Read
+argument-hint: [-m "message" | --no-edit | --edit]
+---
+
+Collapse a multi-commit branch into a single commit. User input: `$ARGUMENTS`.
+
+## When to use
+
+- A branch accumulated several `gt modify -c` commits during review and should land as one logical change.
+- After a `gt fold`, to keep the combined branch single-commit.
+
+## Steps
+
+1. Run `git log --oneline <parent>..HEAD` to show the commits about to be squashed.
+2. Run `gt squash` — Graphite opens `$EDITOR` with all the commit messages concatenated so you can craft a final message.
+   - `gt squash -m "<message>"` skips the editor with a preset message.
+   - `gt squash -n` / `--no-edit` reuses the first commit's message untouched.
+3. Auto-restack runs for everything upstack. Resolve conflicts the usual way: `gt add .` → `gt continue -a`.
+4. `gt submit -u` (or `gt submit --stack -u`) to force-push the updated branch to the PR.
+
+## Notes
+
+- Squashing rewrites the SHA → force-push is required. Graphite uses `--force-with-lease` so concurrent updates from teammates are rejected, not overwritten.
+- The branch name is unchanged, so the PR stays the same.

--- a/plugins/graphite/commands/submit.md
+++ b/plugins/graphite/commands/submit.md
@@ -1,0 +1,33 @@
+---
+description: Push the current stack and create/update PRs (gt submit)
+allowed-tools: Bash, Read
+argument-hint: [--stack | --update-only | reviewers]
+---
+
+Submit the current Graphite stack to the remote and open or update pull requests. User input: `$ARGUMENTS`.
+
+## Decide scope
+
+- Default `gt submit` pushes the current branch and everything **downstack** from it.
+- `gt submit --stack` (alias `gt ss`) pushes the entire stack rooted at trunk.
+- `gt submit --stack --update-only` (`gt ss -u`) updates PRs only — won't open new ones.
+
+If the user didn't specify scope and the stack has more than one branch, ask whether they want `--stack` or just the current branch + downstack.
+
+## Steps
+
+1. Run `gt ls` and show the user which branches will be submitted.
+2. Run `git status --short` to confirm there are no uncommitted changes. If there are, ask whether to `gt modify -a` them in first, stash, or abort.
+3. Run `gt sync --no-pull` or `gt restack` if `gt ls` shows any branch as `needs restack` — do not submit a stale stack.
+4. Run the appropriate `gt submit` command. Pass `-c` / `--confirm` to skip interactive prompts only if the user asked for non-interactive.
+5. Report each created/updated PR URL from the output.
+
+## Key flags
+
+- `--stack` — submit every branch in the stack (not just current + downstack)
+- `--update-only`, `-u` — update existing PRs, never create new ones
+- `--draft` — open as draft
+- `-c, --confirm` — skip the interactive prompts
+- `-e, --edit` — open `$EDITOR` for each PR description
+- `-f, --force` — force-push (use with care; Graphite already uses `--force-with-lease` by default)
+- `--ai` — Graphite drafts the PR title/body

--- a/plugins/graphite/commands/sync.md
+++ b/plugins/graphite/commands/sync.md
@@ -1,0 +1,28 @@
+---
+description: Pull trunk, delete merged branches, restack the stack (gt sync)
+allowed-tools: Bash, Read
+argument-hint: [--all | --force]
+---
+
+Sync the local repository with `origin`. `gt sync` pulls trunk, prompts to delete branches that have been merged into trunk, and restacks the remaining stack onto the new trunk tip. User input: `$ARGUMENTS`.
+
+## Steps
+
+1. Run `git status --short` to ensure the working tree is clean. If not, ask whether to commit/stash before syncing.
+2. Run `gt ls` to capture the stack shape before sync.
+3. Run `gt sync $ARGUMENTS` (respecting any flags the user passed).
+4. If the output reports conflicts on specific branches:
+   - List the conflicted branches to the user.
+   - For each, `gt co <branch>` → `gt restack` → resolve in editor → `gt add .` → `gt continue -a`.
+   - If a restack should be aborted, run `gt abort` and report.
+5. Run `gt ls` again so the user sees the new state and which merged branches were pruned.
+
+## Key flags
+
+- `-a, --all` — sync every trunk (when multiple trunks are configured)
+- `-d, --delete-all` — delete merged branches without prompting
+- `-f, --force` — accept all destructive prompts
+
+## When to use vs `git pull`
+
+Always prefer `gt sync` in a Graphite-tracked repo. Plain `git pull` won't restack downstream branches and can leave stacks pointing at the old trunk tip, which then requires a manual `gt restack`.

--- a/plugins/graphite/commands/track.md
+++ b/plugins/graphite/commands/track.md
@@ -1,0 +1,33 @@
+---
+description: Track existing git branches with Graphite (gt track / untrack)
+allowed-tools: Bash, Read
+argument-hint: [branch | --force | --untrack <branch>]
+---
+
+Bring branches that were created outside Graphite under `gt`'s control by recording their parent. User input: `$ARGUMENTS`.
+
+## When you need this
+
+- The branch was created with raw `git checkout -b` and Graphite doesn't know its parent.
+- A teammate pushed branches you fetched via `git fetch` (not `gt get`).
+- `gt` metadata was corrupted and needs to be re-established.
+
+## Steps
+
+1. Run `git branch --show-current` to confirm the branch under cursor.
+2. If `$ARGUMENTS` starts with `--untrack` or is `-u`, run `gt untrack <branch>` and stop.
+3. Otherwise:
+   - For the **current** branch: `gt track` (will prompt for parent if ambiguous).
+   - For a specific branch: `gt track <branch>`.
+   - To auto-pick the nearest ancestor as parent without prompting: `gt track --force`.
+4. To track an entire external stack, check out its **tip** and run `gt track` — it walks up until it hits an already-tracked branch.
+
+## Important warnings
+
+- **Don't** use raw `git rebase` on tracked branches afterwards — it can remove the base commit Graphite uses to identify the branch's start. If you must rebase, use `gt modify --interactive` or `gt restack`.
+- If `gt track` complains about diverged parent, run `git rebase <parent>` **once** to align the branch on its parent, then `gt track` again.
+
+## Key flags
+
+- `-p, --parent <branch>` — set parent explicitly (skip the prompt)
+- `-f, --force` — pick the nearest ancestor as parent automatically (useful for multi-branch tracking)

--- a/plugins/graphite/skills/graphite/SKILL.md
+++ b/plugins/graphite/skills/graphite/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: graphite
+description: Drive the Graphite CLI (`gt`) for stacked pull-request workflows. Use when the user works with stacked PRs, mentions Graphite, gt, "the stack", or wants to create/submit/sync/restack/split/squash/fold branches. Triggers on `gt` commands, "stack of PRs", "stacked diffs", "trunk-based", `.graphite_repo_config`, branches prefixed by a Graphite user (e.g. `lms--`, `pp--`).
+tools: Bash, Read, Grep, Glob, Edit
+user-invocable: false
+---
+
+# Graphite CLI (`gt`) — Stacked PR Workflow
+
+Graphite is a CLI on top of git that makes **stacks of small PRs** ergonomic. A stack is a sequence of branches where each builds on its parent; each branch maps to one PR. The CLI is invoked as `gt` (not `graphite`).
+
+When the user is in a Graphite repo (`.git/.graphite_repo_config` present) or mentions stacked PRs / `gt` / Graphite, prefer `gt` over raw `git` for branch creation, rebasing, and pushes. Plain git still works for staging, diffing, logs, and inspection.
+
+## Core mental model
+
+- **One commit per branch.** Stack additional changes by creating new branches on top, not new commits on the same branch.
+- **Trunk is `main`** (or whatever `gt init` selected). Stacks are rooted on trunk.
+- **`gt` knows the parent of every tracked branch.** It uses that metadata to restack automatically when ancestors change.
+- **Do not use raw `git rebase` to move tracked branches.** It can wipe Graphite metadata. Use `gt modify`, `gt restack`, or `gt move` instead.
+
+## The golden path: create → submit
+
+```bash
+# Make changes, then:
+gt create -am "feat: add activity feed API"   # stage all, commit, new branch
+# More changes for the next layer:
+gt create -am "feat: render feed in UI"       # creates branch on top of previous
+gt submit --stack                              # push all branches, open PRs
+```
+
+- `gt create [name]` creates a branch from the current HEAD with the staged changes already committed. With `-a` it stages all changes; with `-m "..."` it sets the commit message; combined `-am "..."` is the common form.
+- `gt c` is the alias for `gt create`.
+- `gt submit` pushes the current branch and downstack; `gt submit --stack` (alias `gt ss`) pushes every branch in the current stack and opens/updates PRs for each.
+
+## Viewing the stack
+
+```bash
+gt log         # full tree with branches, PRs, worktree paths
+gt ls          # compact view (alias for `gt log short`)
+```
+
+The filled circle (◉) marks the current branch. Always run `gt ls` before any restack/move operation to confirm parent relationships.
+
+## Navigating the stack
+
+| Goal | Command | Alias |
+|------|---------|-------|
+| Move up one branch | `gt up` | `gt u` |
+| Move down one branch | `gt down` | `gt d` |
+| Top of stack | `gt top` | `gt t` |
+| Bottom of stack | `gt bottom` | `gt b` |
+| Specific branch (interactive) | `gt checkout` | `gt co` |
+| Jump to trunk | `gt checkout --trunk` | `gt co -t` |
+| Show parent | `gt parent` | — |
+| Show children | `gt children` | — |
+
+`gt up` and `gt top` prompt for disambiguation when a branch has multiple children.
+
+## Editing a mid-stack branch
+
+```bash
+gt co some_mid_branch       # check out the branch
+# edit files
+gt modify -a                # amend the existing commit; upstack restacks automatically
+# OR add a new commit on this branch:
+gt modify -cam "fix tests"
+```
+
+- `gt modify` (alias `gt m`) amends the current branch's commit and **automatically restacks every upstack descendant**. No need to run `gt restack` manually after a clean modify.
+- Use `-c` / `--commit` to add a new commit instead of amending.
+- Use `--into <branch>` to amend staged changes into a downstack branch in one step.
+- For changes that should land in multiple downstack branches simultaneously, use `gt absorb -a` (Graphite picks the right branch per hunk).
+
+### When restack hits a conflict
+
+```
+# resolve conflicts in editor
+gt add .                     # mark resolved (gt add wraps git add)
+gt continue -a               # finish the restack
+# or
+gt abort                     # bail out safely
+```
+
+## Syncing with the remote
+
+```bash
+gt sync
+```
+
+This single command:
+1. Pulls trunk from `origin`,
+2. Detects merged branches and prompts to delete them,
+3. Restacks the remaining branches onto the new trunk tip.
+
+If a restack conflicts, `gt sync` exits with a list of branches to fix. Check each out and run `gt restack`, then resolve as above.
+
+Prefer `gt sync` over `git pull` whenever the working repo has tracked Graphite branches — `git pull` won't restack the stack.
+
+## Submitting / updating PRs
+
+```bash
+gt submit               # current branch + downstack
+gt submit --stack       # entire current stack (alias: gt ss)
+gt submit --stack -u    # update PRs only, don't create new ones (gt ss -u)
+```
+
+`gt submit` interactively asks whether to open a draft PR and whether to edit the description. To skip prompts, pass `-c` / `--confirm`. To open the editor unconditionally, pass `-e` / `--edit`.
+
+## Manual restack
+
+You only need this when:
+- `gt sync` reported conflicts on a branch, or
+- A parent advanced (squash-merge on GitHub) and children still point at the old SHA, or
+- After a `git rebase` you ran by hand on a tracked branch (avoid this).
+
+```bash
+gt restack              # restack current stack on top of current parents
+gt restack -u           # only upstack from current branch
+gt restack -d           # only downstack
+gt restack -o           # only this branch (no children/parents)
+```
+
+## Reorganizing the stack
+
+| Operation | Command | Notes |
+|-----------|---------|-------|
+| Move current branch to a new parent | `gt move --onto <branch>` | Restacks dependents automatically |
+| Interactive reorder | `gt reorder` | Opens editor with branch list; rearrange lines |
+| Insert a new branch mid-stack | `gt create --all --insert -m "..."` | Other branches restack onto it |
+| Fold branch into its parent | `gt fold` | `--keep` keeps the child's name |
+| Squash a multi-commit branch into one | `gt squash` | Opens editor for the new message; `-m "..."` to skip |
+| Split a branch | `gt split --by-commit` / `--by-file "*.json"` / `--by-hunk` | Three modes |
+| Delete a branch but keep the changes | `gt pop` | |
+| Delete a branch entirely | `gt delete [-f]` | `-c` also closes the PR |
+
+When splitting a branch that already has a PR, **keep the original branch name** for one of the pieces — GitHub PR branch names are immutable, so any renamed piece becomes a new PR.
+
+## Tracking existing git branches
+
+If a branch was created with raw `git checkout -b`, Graphite doesn't know its parent yet:
+
+```bash
+gt track                    # prompts to pick a parent (or the only candidate)
+gt track <branch>           # track a specific branch
+gt track --force            # auto-pick nearest ancestor as parent
+gt untrack <branch>         # stop tracking
+```
+
+Run `gt track` from the **tip** of an external stack to track multiple branches at once (walks up until it hits an already-tracked branch).
+
+## Collaborating on someone else's stack
+
+```bash
+gt get <branch>             # fetch their stack locally
+# branches arrive frozen by default — no accidental edits
+gt unfreeze <branch>        # to extend their work
+gt create -am "my addition" # stack your branch on top
+gt submit                   # push and open your own PR(s)
+```
+
+`gt freeze` / `gt unfreeze` toggle the lock manually. `gt info` shows freeze status.
+
+## Worktrees
+
+`gt log` displays a worktree path next to any branch checked out elsewhere. Rules of thumb:
+
+- `gt sync`, `gt get`, `gt restack` must be run **from each worktree** that owns branches in the stack.
+- To start a branch on top of a branch that's checked out in another worktree, use `gt create --onto <branch>` from the current worktree.
+- `gt undo` is per-worktree.
+
+## Multiple trunks
+
+Repos that maintain release branches alongside `main` can register both as trunks:
+
+```bash
+gt trunk --add release-v10
+gt trunk --all
+gt sync --all              # sync every trunk and its stacks
+gt log short --all         # show stacks across all trunks
+```
+
+Branches are auto-associated with whichever trunk they were created off of.
+
+## Recovery
+
+- `gt undo` reverses the most recent Graphite mutation (per worktree).
+- Conflicts during any restack-style operation: `gt add .` → `gt continue -a`, or `gt abort` to back out.
+
+## Operating principles for Claude
+
+- Before any restack, move, fold, squash, or split, run `gt ls` and show the output so the user sees the current shape.
+- Never run `git rebase`, `git reset --hard`, or `git push --force` on a tracked branch without explicit confirmation — use the `gt` equivalent (`gt modify`, `gt restack`, `gt move`, `gt submit --force`).
+- After resolving a restack conflict, prefer `gt continue` over running `git rebase --continue` directly.
+- When the user asks for a "new branch on top of X," default to `gt create -am "..."` from X — don't construct branch names manually unless asked; `gt` derives them from the commit message.
+- For multi-commit work, ask whether to keep multiple commits (`gt modify -c`) or amend (`gt modify`) — the answer determines whether the next `gt submit` updates the same PR or needs `gt squash` first.
+- If `.git/.graphite_repo_config` is missing, treat the repo as un-initialized and propose `gt init` before any other `gt` command.


### PR DESCRIPTION
## Summary

Adds a built-in plugin (`plugins/graphite/`) that teaches Claude to drive the Graphite CLI (`gt`) for stacked pull request workflows. Also registers the plugin in the marketplace so it is installable via `/plugin install graphite@pleaseai`.

## Changes

- `plugins/graphite/.claude-plugin/plugin.json` — plugin manifest (validated with `claude plugin validate`)
- `plugins/graphite/skills/graphite/SKILL.md` — ambient skill that activates on mentions of `gt`, graphite, stacked PRs, or repos containing `.graphite_repo_config`
- `plugins/graphite/commands/` — 15 slash commands: `create`, `submit`, `sync`, `log`, `checkout`, `modify` (basic), `restack`, `absorb`, `split`, `squash`, `fold`, `track`, `reorder`, `move`, `get` (advanced)
- `plugins/graphite/README.md` — install instructions, command index, links to graphite.com docs
- `.claude-plugin/marketplace.json` — new `graphite` entry added alongside `git-ai`

## Test Plan

- [ ] `claude plugin validate plugins/graphite` passes without errors
- [ ] Manual install via `/plugin install graphite@pleaseai` succeeds
- [ ] All 15 commands appear under the `/graphite:*` namespace after install
- [ ] Skill activates when user mentions `gt`, `graphite`, or stacked PRs in a repo with `.graphite_repo_config`

## Related Issues

No linked issue — plugin was directly requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in `graphite` plugin that drives the Graphite CLI (`gt`) for stacked PR workflows. Registers it in the marketplace and ships 15 `/graphite:*` commands plus an ambient skill; docs refined for safer non-interactive use and correct guidance.

- **New Features**
  - Marketplace entry in `.claude-plugin/marketplace.json` for `graphite`.
  - Plugin manifest at `plugins/graphite/.claude-plugin/plugin.json`.
  - Ambient skill that triggers on `gt`, Graphite, stacked PRs, or repos with `.graphite_repo_config`.
  - 15 commands for create/submit/sync/log/checkout/modify and advanced restack/absorb/split/squash/fold/track/reorder/move/get.
  - `plugins/graphite/README.md` with install and docs links.
  - Docs updates: handle single-token `gt create` names, use `gt submit --stack -u` after `fold`, warn that `gt modify -c` opens an editor (use `-cm "msg"`), and clarify `gt squash` requires a follow-up `gt restack`.

- **Migration**
  - Install Graphite CLI (`brew install withgraphite/tap/graphite` or `npm i -g @withgraphite/graphite-cli`), then `gt auth` and `gt init`.
  - Install the plugin: `/plugin marketplace add pleaseai/claude-code-plugins` → `/plugin install graphite@pleaseai`.
  - Verify commands under `/graphite:*`; the skill auto-activates in a Graphite repo.

<sup>Written for commit 3781ee2110fce9935dbcf0880e1ec050da9ef546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

