### PR TITLE
feat(graphite): add SessionStart hook to detect .graphite_repo_config

### DIFF
--- a/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [Mastra skill review (PR #161)](pr161-mastra-skill.md) — cubic found no issues after correctness fixes were applied
 - [Graphite commands review (PR #170)](pr170-graphite-commands.md) — cubic P1 flagging `gt create` positional arg was a false positive (CLI confirms `gt create [name]` is valid)
+- [Graphite session-start hook review (PR #171)](pr171-graphite-session-start-hook.md) — cubic clean pass (0 issues); full diff vs main reviewed with `-b` flag

--- a/.claude/agent-memory/review-review-cubic-reviewer/pr171-graphite-session-start-hook.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/pr171-graphite-session-start-hook.md
@@ -1,0 +1,16 @@
+---
+name: Graphite session-start hook review (PR #171)
+description: cubic review of graphite SessionStart hook feature — clean pass with 0 issues
+metadata:
+  type: project
+---
+
+PR #171 (branch: feat/graphite-session-start-hook) — cubic review during /review:apply Step 5.
+
+Two gemini-code-assist[bot] threads were already addressed before the cubic run (one alternative-applied, one skipped). Working tree had one uncommitted edit to `plugins/graphite/hooks/graphite-context.sh` (comment-only clarification of JSON-vs-plain-stdout fallback behavior).
+
+cubic ran with `-b` (vs main) + `-j` flags covering the full diff.
+
+**Result: 0 issues (clean pass).** Review state saved at commit 6416349.
+
+**How to apply:** The graphite plugin's hook approach (shell script with JSON/plain-stdout fallback) is cubic-clean. No recurring patterns to watch for here.

--- a/plugins/graphite/README.md
+++ b/plugins/graphite/README.md
@@ -77,6 +77,8 @@ The skill loads automatically when the user mentions Graphite, `gt`, stacked PRs
 - Handle worktrees: run stack commands from each owning worktree
 - Avoid `git rebase` on tracked branches (corrupts Graphite metadata)
 
+A `SessionStart` hook also detects `.graphite_repo_config` inside the git common dir (worktree-safe via `git rev-parse --git-common-dir`) and injects a short notice so Claude reaches for `gt` from the first turn — even before any keyword in the conversation triggers the skill. If the `gt` CLI is missing, the hook surfaces the install command instead.
+
 ## Links
 
 - [Graphite docs](https://graphite.com/docs)

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SessionStart hook: inject Graphite context when the repo uses Graphite.
+#
+# Detection rule: `.graphite_repo_config` exists inside the git common dir
+# (the real .git directory, resolved via `git rev-parse --git-common-dir`
+# so this also works inside `git worktree` checkouts and subdirectories).
+
+set -euo pipefail
+
+# Not a git repo, or git not installed → nothing to do.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -z "$GIT_COMMON_DIR" ]; then
+  exit 0
+fi
+
+# Resolve to absolute path (git may return a relative path like ".git").
+if [ -d "$GIT_COMMON_DIR" ]; then
+  GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+fi
+
+CONFIG_FILE="$GIT_COMMON_DIR/.graphite_repo_config"
+if [ ! -f "$CONFIG_FILE" ]; then
+  exit 0
+fi
+
+# Detect whether the `gt` CLI is on PATH so we can tailor the guidance.
+if command -v gt >/dev/null 2>&1; then
+  GT_NOTE="\`gt\` CLI is available on PATH."
+else
+  GT_NOTE="\`gt\` CLI is **not installed**. Install it before driving Graphite: \`brew install withgraphite/tap/graphite\` or \`npm i -g @withgraphite/graphite-cli\`, then \`gt auth\`."
+fi
+
+# Keep the injected context short — the \`graphite\` skill covers the full
+# mental model and command reference. This hook just flags the repo type
+# at session start so Claude reaches for \`gt\` (not raw \`git\`) immediately.
+CONTEXT=$(cat <<EOF
+This repository is configured for **Graphite stacked PRs** (\`.graphite_repo_config\` detected at \`$CONFIG_FILE\`).
+
+- Prefer \`gt\` over raw \`git\` for branch creation, rebasing, and pushes. Plain \`git\` is still fine for staging, diffing, logs, and inspection.
+- Never run \`git rebase\` on a tracked branch — it wipes Graphite metadata. Use \`gt modify\`, \`gt restack\`, or \`gt move\` instead.
+- The \`graphite\` skill in this plugin has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
+
+$GT_NOTE
+EOF
+)
+
+# Emit as SessionStart additionalContext (JSON form, same convention as the
+# repo-level hooks/context.sh). Fall back to plain stdout if jq is missing.
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg context "$CONTEXT" '{
+    "hookSpecificOutput": {
+      "hookEventName": "SessionStart",
+      "additionalContext": $context
+    }
+  }'
+else
+  printf '%s\n' "$CONTEXT"
+fi

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -38,7 +38,7 @@ This repository is configured for **Graphite stacked PRs** (\`.graphite_repo_con
 
 - Prefer \`gt\` over raw \`git\` for branch creation, rebasing, and pushes. Plain \`git\` is still fine for staging, diffing, logs, and inspection.
 - Never run \`git rebase\` on a tracked branch — it wipes Graphite metadata. Use \`gt modify\`, \`gt restack\`, or \`gt move\` instead.
-- The \`graphite:graphite\` skill has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
+- The \`graphite:graphite\` skill (background, auto-activating) carries the full workflow — golden path, conflict resolution, worktrees, multi-trunk. It will load itself once stacked-PR work appears in context.
 
 $GT_NOTE
 EOF

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -38,7 +38,7 @@ This repository is configured for **Graphite stacked PRs** (\`.graphite_repo_con
 
 - Prefer \`gt\` over raw \`git\` for branch creation, rebasing, and pushes. Plain \`git\` is still fine for staging, diffing, logs, and inspection.
 - Never run \`git rebase\` on a tracked branch — it wipes Graphite metadata. Use \`gt modify\`, \`gt restack\`, or \`gt move\` instead.
-- The \`graphite\` skill has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
+- The \`graphite:graphite\` skill has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
 
 $GT_NOTE
 EOF

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -38,7 +38,7 @@ This repository is configured for **Graphite stacked PRs** (\`.graphite_repo_con
 
 - Prefer \`gt\` over raw \`git\` for branch creation, rebasing, and pushes. Plain \`git\` is still fine for staging, diffing, logs, and inspection.
 - Never run \`git rebase\` on a tracked branch — it wipes Graphite metadata. Use \`gt modify\`, \`gt restack\`, or \`gt move\` instead.
-- The \`graphite\` skill in this plugin has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
+- The \`graphite\` skill has the full workflow (golden path, conflict resolution, worktrees, multi-trunk). Load it via the Skill tool when stacked-PR work begins.
 
 $GT_NOTE
 EOF

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -44,8 +44,13 @@ $GT_NOTE
 EOF
 )
 
-# Emit as SessionStart additionalContext (JSON form, same convention as the
-# repo-level hooks/context.sh). Fall back to plain stdout if jq is missing.
+# Emit as SessionStart additionalContext. Claude Code accepts BOTH forms:
+#   - JSON `{hookSpecificOutput: {hookEventName, additionalContext}}` (preferred,
+#     same convention as the repo-level hooks/context.sh)
+#   - Plain stdout (treated verbatim as additionalContext)
+# We prefer JSON when `jq` is available and fall back to plain stdout otherwise
+# — both are valid hook outputs, this is graceful degradation, not a contract
+# violation.
 if command -v jq >/dev/null 2>&1; then
   jq -n --arg context "$CONTEXT" '{
     "hookSpecificOutput": {

--- a/plugins/graphite/hooks/hooks.json
+++ b/plugins/graphite/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Inject Graphite context at session start when .git/.graphite_repo_config is present",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/graphite-context.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook to the `graphite` plugin that detects whether the current repo uses Graphite and injects a brief notice so Claude reaches for `gt` from the first turn — without waiting for a skill keyword to appear in the conversation.

## Why a Hook (not skill alone)

The existing graphite skill only activates when the user mentions Graphite-related keywords (`gt`, "stacked PRs", etc.). A `SessionStart` hook fires unconditionally, so Claude is primed to use `gt` even in sessions where Graphite is never explicitly mentioned.

## Files Touched

- `plugins/graphite/hooks/hooks.json` (new) — registers the `SessionStart` hook with a 5 s timeout, referencing `${CLAUDE_PLUGIN_ROOT}`
- `plugins/graphite/hooks/graphite-context.sh` (new, executable) — detects `.graphite_repo_config` via `git rev-parse --git-common-dir` (worktree-safe), outputs JSON `hookSpecificOutput.additionalContext`; falls back to plain stdout when `jq` is missing; surfaces `gt` install instructions when the CLI is absent
- `plugins/graphite/README.md` (modified) — one paragraph added under "How it works" documenting the hook

## Validation

- `claude plugin validate plugins/graphite` passes
- `graphite-context.sh` manually tested across 4 scenarios: non-git dir, git repo without `.graphite_repo_config`, git repo with it, and a subdirectory of that repo — all behaved correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `SessionStart` hook to the `graphite` plugin that detects `.graphite_repo_config` and injects a short note so Claude prefers `gt` from the first turn. The hook text uses the fully-qualified `graphite:graphite` name, explains it auto-activates (no Skill tool), and shows install steps if `gt` is missing.

- **New Features**
  - Registers the hook in `plugins/graphite/hooks/hooks.json` (5s timeout) to run `graphite-context.sh`.
  - `graphite-context.sh` outputs JSON to `hookSpecificOutput.additionalContext` with a plain stdout fallback; comments now explicitly document this dual-mode behavior.
  - Updates hook text and `plugins/graphite/README.md`: drop “in this plugin,” use `graphite:graphite`, and remove the incorrect “Load via Skill tool” instruction.

<sup>Written for commit 75d33761117e50f2f121c865bda354d4b603983f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

