### PR TITLE
chore(release): add graphite plugin to release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -47,5 +47,6 @@
   "plugins/git-ai": "1.0.0",
   "plugins/workflow": "1.0.0",
   "plugins/portless": "1.0.0",
-  "plugins/zod": "1.0.0"
+  "plugins/zod": "1.0.0",
+  "plugins/graphite": "1.0.0"
 }

--- a/plugins/graphite/.claude-plugin/plugin.json
+++ b/plugins/graphite/.claude-plugin/plugin.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "description": "Stacked PR workflow with the Graphite CLI (gt) — create stacks, submit, sync, restack, split/squash/fold, track existing branches, and collaborate on shared stacks",
   "author": {
-    "name": "Passion Factory",
-    "email": "support@passionfactory.ai",
-    "url": "https://github.com/pleaseai"
+    "name": "Graphite",
+    "url": "https://github.com/withgraphite"
   },
   "homepage": "https://graphite.com/docs",
   "repository": "https://github.com/pleaseai/claude-code-plugins",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -504,6 +504,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/graphite": {
+      "release-type": "simple",
+      "component": "graphite",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

The graphite plugin exists at `plugins/graphite/` with a `.claude-plugin/plugin.json` at v1.0.0, but was missing from the release-please tooling. This adds both the package config entry and the manifest entry so release-please can track and manage version bumps for the graphite plugin going forward.

## Changes

- `release-please-config.json`: Added `plugins/graphite` entry with `release-type: simple` and `extra-files` pointing to `.claude-plugin/plugin.json` (jsonpath `$.version`)
- `.release-please-manifest.json`: Added `"plugins/graphite": "1.0.0"` to match the current version in the plugin manifest

## Test Plan

- [ ] Verify release-please dry-run picks up the graphite package correctly
- [ ] Confirm no regressions to other package entries in the config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `plugins/graphite` to release-please so the Graphite plugin is tracked and versioned automatically. Updated `release-please-config.json` (release type `simple`, extra file `.claude-plugin/plugin.json` via `$.version`) and `.release-please-manifest.json` (`plugins/graphite: 1.0.0`), and corrected plugin author metadata to credit Graphite.

<sup>Written for commit ee2bd2f3879c801455f7babbace8805cc34e7dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

