### PR TITLE
chore(release-please): register bun plugin in release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -48,5 +48,6 @@
   "plugins/workflow": "1.0.0",
   "plugins/portless": "1.0.0",
   "plugins/zod": "1.0.0",
-  "plugins/graphite": "1.0.0"
+  "plugins/graphite": "1.0.0",
+  "plugins/bun": "1.0.0"
 }

--- a/plugins/bun/plugin.json
+++ b/plugins/bun/plugin.json
@@ -1,3 +1,4 @@
 {
-  "name": "bun"
+  "name": "bun",
+  "version": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -515,6 +515,27 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/bun": {
+      "release-type": "simple",
+      "component": "bun",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

Register `plugins/bun` with release-please so that conventional commits scoped to `bun` drive automated version bumps and changelog generation.

## Changes

- `.release-please-manifest.json`: added `"plugins/bun": "1.0.0"` (initial version pin)
- `release-please-config.json`: added `plugins/bun` package config with:
  - `release-type: simple`
  - `component: bun`
  - Three `extra-files` entries to keep versions in sync on release:
    - `plugins/bun/.claude-plugin/plugin.json`
    - `plugins/bun/.codex-plugin/plugin.json`
    - `plugins/bun/plugin.json` (root)

## Why

Without this registration, `feat(bun):` and `fix(bun):` commits are ignored by release-please. With it, the release-please GitHub Action will open a release PR for the bun plugin whenever relevant commits land on `main`, and will update the version field in all three manifest files automatically.

## Notes

- This is a tooling/config-only change — no runtime code or plugin manifests are modified.
- The `plugins/bun/` directory and its manifests already exist; this simply wires them into the release pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register `plugins/bun` with release-please so `feat(bun):` and `fix(bun):` commits trigger automated version bumps and changelog entries. Adds `plugins/bun` to `.release-please-manifest.json` (1.0.0), configures version sync across `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `plugin.json`, and sets `version: 1.0.0` in `plugins/bun/plugin.json` to enable bumps.

<sup>Written for commit f0a16696be14af9ff7684830dbdd8b074b629ab2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

