### PR TITLE
ci: add Graphite CI optimizer gate and explicit PR triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,8 +16,44 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  # Graphite CI optimizer gate. On PRs, asks the Graphite API whether this
+  # PR's position in its stack means CI can be skipped (e.g., it's a mid-stack
+  # PR that will be retested when the top of the stack runs). On pushes to
+  # main, the optimizer is bypassed so post-merge CI always runs.
+  # Docs: https://graphite.com/docs/stacking-and-ci
+  optimize_ci:
+    name: Optimize CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      skip: ${{ steps.graphite.outputs.skip || steps.bypass.outputs.skip }}
+    steps:
+      - name: Bypass optimizer on push events
+        id: bypass
+        if: github.event_name != 'pull_request'
+        run: echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Graphite token is configured
+        if: github.event_name == 'pull_request'
+        env:
+          TOKEN: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::GRAPHITE_CI_OPTIMIZER_TOKEN secret is not set. Add it under Settings → Secrets and variables → Actions, or remove the optimize_ci job."
+            exit 1
+          fi
+
+      - name: Graphite CI optimizer
+        id: graphite
+        if: github.event_name == 'pull_request'
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   lint:
     name: Lint
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -54,6 +91,8 @@ jobs:
 
   build:
     name: Build
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -79,6 +118,8 @@ jobs:
 
   typecheck:
     name: Type Check
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -104,6 +145,8 @@ jobs:
 
   test:
     name: Test
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## What

1. **Explicit `pull_request` trigger types**: Set to `[opened, synchronize, reopened]`, deliberately excluding `edited`. Graphite edits PR descriptions when performing downstack merges — without this exclusion, those edits would retrigger CI on all open PRs in the stack.

2. **`optimize_ci` gate job**: Uses `withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689` (v0.0.9, SHA-pinned). On `pull_request` events, this job calls the Graphite API to determine whether CI can safely be skipped for mid-stack PRs that will be re-tested when the top of the stack runs.

3. **Gated downstream jobs**: `lint`, `build`, `typecheck`, and `test` now declare `needs: optimize_ci` and `if: needs.optimize_ci.outputs.skip == 'false'`. On `push` to main the optimizer is bypassed (the bypass step unconditionally outputs `skip=false`), so post-merge CI always runs in full.

4. **Fails loudly on missing secret**: On `pull_request` events, a pre-flight step checks for `GRAPHITE_CI_OPTIMIZER_TOKEN`. If the secret is absent it emits `::error::` and exits 1, making the failure visible rather than silently passing or skipping.

## Why

Graphite stacks re-run CI on every PR in the stack when any one PR is updated. The CI optimizer eliminates redundant runs for mid-stack PRs, significantly reducing CI minutes and queue time. See the Graphite docs for the full rationale.

## Follow-up TODOs (must be done manually)

These steps cannot be automated from this PR and must be completed by a maintainer before the optimizer is functional:

- [ ] **Add `GRAPHITE_CI_OPTIMIZER_TOKEN` repo secret** — obtain the token from [app.graphite.dev](https://app.graphite.dev) under Settings → CI optimizer, then add it under _Settings → Secrets and variables → Actions_. Without it, every PR CI run will fail at the `optimize_ci` gate.
- [ ] **Mark required status checks** — add `Optimize CI`, `Lint`, `Build`, `Type Check`, and `Test` as required status checks in branch protection for `main`.
- [ ] **Adjust branch protection on `main`** — per Graphite guidelines, disable: _Dismiss stale approvals_, _Require approval of most recent push_, and _Require merge queue_ (Graphite manages its own merge queue).
- [ ] **Repo push settings** — disable _Limit how many branches and tags can be updated in a single push_ under repository settings.

## References

- https://graphite.com/docs/github-configuration-guidelines
- https://graphite.com/docs/stacking-and-ci

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Graphite CI optimizer gate and explicit PR triggers to skip redundant CI on stacked PRs while always running full CI on merges to main. Also fails fast if the optimizer token is missing.

- **New Features**
  - Set `pull_request` types to `[opened, synchronize, reopened]` to avoid retriggers from PR description edits.
  - Added `optimize_ci` job using `withgraphite/graphite-ci-action@v0.0.9` to decide when to skip; bypassed on `push` to main.
  - Gated `lint`, `build`, `typecheck`, and `test` on `needs: optimize_ci` with `skip == 'false'`.
  - Pre-flight check for `GRAPHITE_CI_OPTIMIZER_TOKEN`; emits error and fails if missing.

- **Migration**
  - Add `GRAPHITE_CI_OPTIMIZER_TOKEN` repo secret from Graphite (Settings → CI optimizer).
  - Mark required checks: Optimize CI, Lint, Build, Type Check, Test.
  - Update branch protection on `main`: disable Dismiss stale approvals, Require approval of most recent push, and Require merge queue.
  - Disable “Limit how many branches and tags can be updated in a single push” in repo settings.

<sup>Written for commit c893b2e13624964f42361b72957b9c00200aefc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

