### PR TITLE
feat(graphite): also activate context hook via .please/config.yml opt-in

### DIFF
--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # SessionStart hook: inject Graphite context when the repo uses Graphite.
 #
-# Detection rule: `.graphite_repo_config` exists inside the git common dir
-# (the real .git directory, resolved via `git rev-parse --git-common-dir`
-# so this also works inside `git worktree` checkouts and subdirectories).
+# Detection rules (either triggers injection):
+#   1. `.graphite_repo_config` exists inside the git common dir
+#      (the real .git directory, resolved via `git rev-parse --git-common-dir`
+#      so this also works inside `git worktree` checkouts and subdirectories).
+#   2. `.please/config.yml` at the repo root sets `graphite.enabled: true`
+#      — lets a project opt in before `gt init` has been run.
 
 set -euo pipefail
 
@@ -18,9 +21,44 @@ if [ -d "$GIT_COMMON_DIR" ]; then
   GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
 fi
 
-CONFIG_FILE="$GIT_COMMON_DIR/.graphite_repo_config"
-if [ ! -f "$CONFIG_FILE" ]; then
+GRAPHITE_CONFIG_FILE="$GIT_COMMON_DIR/.graphite_repo_config"
+HAS_GRAPHITE_CONFIG=0
+if [ -f "$GRAPHITE_CONFIG_FILE" ]; then
+  HAS_GRAPHITE_CONFIG=1
+fi
+
+# Check `.please/config.yml` for `graphite.enabled: true` at the repo root.
+# Parsed with awk to avoid a hard dependency on `yq` — matches the top-level
+# `graphite:` key followed by an indented `enabled: true` before any other
+# top-level key appears.
+PLEASE_CONFIG_FILE=""
+HAS_PLEASE_OPT_IN=0
+GIT_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$GIT_TOPLEVEL" ] && [ -f "$GIT_TOPLEVEL/.please/config.yml" ]; then
+  PLEASE_CONFIG_FILE="$GIT_TOPLEVEL/.please/config.yml"
+  if awk '
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+    /^[^[:space:]#]/                { in_graphite=0 }
+    in_graphite && /^[[:space:]]+enabled:[[:space:]]*true([[:space:]]|#|$)/ {
+      found=1; exit
+    }
+    END { exit !found }
+  ' "$PLEASE_CONFIG_FILE"; then
+    HAS_PLEASE_OPT_IN=1
+  fi
+fi
+
+if [ "$HAS_GRAPHITE_CONFIG" -eq 0 ] && [ "$HAS_PLEASE_OPT_IN" -eq 0 ]; then
   exit 0
+fi
+
+# Build a short, accurate detection note for the injected context.
+if [ "$HAS_GRAPHITE_CONFIG" -eq 1 ] && [ "$HAS_PLEASE_OPT_IN" -eq 1 ]; then
+  DETECTION_NOTE="\`.graphite_repo_config\` detected at \`$GRAPHITE_CONFIG_FILE\`; also opted in via \`graphite.enabled: true\` in \`$PLEASE_CONFIG_FILE\`"
+elif [ "$HAS_GRAPHITE_CONFIG" -eq 1 ]; then
+  DETECTION_NOTE="\`.graphite_repo_config\` detected at \`$GRAPHITE_CONFIG_FILE\`"
+else
+  DETECTION_NOTE="opted in via \`graphite.enabled: true\` in \`$PLEASE_CONFIG_FILE\` (run \`gt init\` if not already initialized)"
 fi
 
 # Detect whether the `gt` CLI is on PATH so we can tailor the guidance.
@@ -34,7 +72,7 @@ fi
 # mental model and command reference. This hook just flags the repo type
 # at session start so Claude reaches for \`gt\` (not raw \`git\`) immediately.
 CONTEXT=$(cat <<EOF
-This repository is configured for **Graphite stacked PRs** (\`.graphite_repo_config\` detected at \`$CONFIG_FILE\`).
+This repository is configured for **Graphite stacked PRs** ($DETECTION_NOTE).
 
 - Prefer \`gt\` over raw \`git\` for branch creation, rebasing, and pushes. Plain \`git\` is still fine for staging, diffing, logs, and inspection.
 - Never run \`git rebase\` on a tracked branch — it wipes Graphite metadata. Use \`gt modify\`, \`gt restack\`, or \`gt move\` instead.

--- a/plugins/graphite/hooks/graphite-context.sh
+++ b/plugins/graphite/hooks/graphite-context.sh
@@ -37,10 +37,15 @@ GIT_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -n "$GIT_TOPLEVEL" ] && [ -f "$GIT_TOPLEVEL/.please/config.yml" ]; then
   PLEASE_CONFIG_FILE="$GIT_TOPLEVEL/.please/config.yml"
   if awk '
-    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-    /^[^[:space:]#]/                { in_graphite=0 }
-    in_graphite && /^[[:space:]]+enabled:[[:space:]]*true([[:space:]]|#|$)/ {
-      found=1; exit
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; child_indent=0; next }
+    /^[^[:space:]#]/                { in_graphite=0; child_indent=0 }
+    in_graphite && /^[[:space:]]*($|#)/ { next }
+    in_graphite {
+      match($0, /^[[:space:]]*/)
+      indent=RLENGTH
+      if (child_indent==0) child_indent=indent
+      if (indent == child_indent && $0 ~ /^[[:space:]]+enabled:[[:space:]]*true([[:space:]]|#|$)/) { found=1; exit }
+      if (indent < child_indent) { in_graphite=0; child_indent=0 }
     }
     END { exit !found }
   ' "$PLEASE_CONFIG_FILE"; then


### PR DESCRIPTION
## Summary

The Graphite SessionStart hook previously only injected context when `.graphite_repo_config` was present in the git common dir (i.e. after `gt init` had been run). It now **also** activates when `.please/config.yml` at the repo root contains:

```yaml
graphite:
  enabled: true
```

This lets a project opt into the Graphite context/skill before running `gt init` — useful for repos that have decided to adopt Graphite but haven't initialized yet.

## Changes

- Added a second detection path in `plugins/graphite/hooks/graphite-context.sh`
- YAML parsing via `awk` (no `yq` dependency required)
- Detection note dynamically reflects which trigger fired (Graphite config file, please opt-in, or both)

## Test Plan

Manually tested 9 cases:

- [ ] No opt-in → no injection
- [ ] `graphite.enabled: true` in please config → injection
- [ ] `graphite.enabled: false` → no injection
- [ ] `.graphite_repo_config` alone → injection
- [ ] Both triggers → combined note
- [ ] Look-alike key `graphite_other:` → correctly rejected
- [ ] Inline comment `enabled: true # opt in` → injection
- [ ] `graphite:` block without `enabled` key → no injection
- [ ] `enabled: true` under an unrelated parent → not matched

## Related Issues

No linked issue — direct enhancement to a manually-maintained built-in plugin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a second activation path for the Graphite SessionStart hook: repos can now opt in via `.please/config.yml` with `graphite.enabled: true`, not just via `.graphite_repo_config`. This lets teams get Graphite context before running `gt init`.

- **New Features**
  - Detects `graphite.enabled: true` in `.please/config.yml` at the repo root.
  - Parses YAML with `awk` (no `yq` dependency).
  - Detection note reflects whether `.graphite_repo_config`, the please opt-in, or both triggered.

- **Bug Fixes**
  - Tightened the `awk` YAML check to only match `enabled: true` as a direct child of top-level `graphite:`, preventing false positives from nested keys.

<sup>Written for commit 7a0af4560b5b0e774bfa720693760135c85c79c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

