### PR TITLE
chore: rename language-server-please marketplace to code-intelligence

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,10 +31,10 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
-    "typescript-lsp@language-server-please": true,
-    "graphql-lsp@language-server-please": false,
-    "vue-lsp@language-server-please": true,
-    "eslint-lsp@language-server-please": true,
+    "typescript-lsp@code-intelligence": true,
+    "graphql-lsp@code-intelligence": false,
+    "vue-lsp@code-intelligence": true,
+    "eslint-lsp@code-intelligence": true,
     "skill-creator@claude-plugins-official": true,
     "backend@passionfactory": false,
     "bun@passionfactory": true,
@@ -72,7 +72,7 @@
         "repo": "chatbot-pf/engineering-standards"
       }
     },
-    "language-server-please": {
+    "code-intelligence": {
       "source": {
         "source": "github",
         "repo": "chatbot-pf/code-please"


### PR DESCRIPTION
## Summary

Rename the plugin marketplace identifier from `language-server-please` to `code-intelligence` in `.claude/settings.json`.

## Changes

- `enabledPlugins` keys updated: `typescript-lsp`, `graphql-lsp`, `vue-lsp`, `eslint-lsp` — suffix changed from `@language-server-please` to `@code-intelligence`
- `marketplaces` key renamed: `language-server-please` → `code-intelligence`

## Notes

- The upstream repository source (`chatbot-pf/code-please`) is **unchanged**
- This is a config-only rename with no functional behavior change
- No migration of plugin state is required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the marketplace identifier in `.claude/settings.json` from `language-server-please` to `code-intelligence` for consistency. Updated `enabledPlugins` entries for `typescript-lsp`, `graphql-lsp`, `vue-lsp`, and `eslint-lsp` to use `@code-intelligence`; no behavior change or migration required.

<sup>Written for commit bf5f1ff9459ecf002c3dcc8f9fb1f6eff64cdf4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

