### PR TITLE
feat(graphite): add merge queue label workflow with mode-aware dispatch

### DIFF
--- a/.please/config.yml
+++ b/.please/config.yml
@@ -19,3 +19,13 @@ review:
   gemini:
     enabled: true
     default-flags: "--sandbox"
+
+# Graphite stacked-PR workflow (consumed by the graphite plugin)
+graphite:
+  enabled: true
+  merge-queue:
+    # Which merge-queue mode this repo uses. One of:
+    #   graphite | github-native | external | none
+    # When unset, the plugin assumes `none` and uses the direct-merge path.
+    mode: graphite
+    label: "merge-queue"   # used only when mode: graphite (must match Graphite settings)

--- a/plugins/graphite/README.md
+++ b/plugins/graphite/README.md
@@ -10,7 +10,8 @@ The plugin includes:
 
 - A **skill** (`graphite`) that activates whenever stacked-PR or `gt` work comes up. It documents the mental model, the golden path, conflict-resolution patterns, worktree handling, and multi-trunk setups.
 - A **setup skill** (`graphite-setup`) that activates when configuring a repo for Graphite — GitHub branch protection, merge queue choice (Graphite / GitHub native / external), CI triggers, ignoring `graphite-base/*` branches, and stack-aware CI Optimizations.
-- **15 slash commands** covering basic workflows (`create`, `submit`, `sync`, `log`, `checkout`, `modify`) and advanced operations (`restack`, `absorb`, `split`, `squash`, `fold`, `track`, `reorder`, `move`, `get`).
+- A **merge-queue skill** (`graphite-merge-queue`) that handles runtime operation of Graphite's queue — label-based enqueueing, stack cascade rules, dequeueing, and reading the configured label from `.please/config.yml`.
+- **16 slash commands** covering basic workflows (`create`, `submit`, `sync`, `log`, `checkout`, `modify`), advanced operations (`restack`, `absorb`, `split`, `squash`, `fold`, `track`, `reorder`, `move`, `get`), and merge-queue operation (`merge-queue`).
 
 ## Prerequisites
 
@@ -67,6 +68,28 @@ claude
 | `/graphite:reorder` | Interactively reorder branches in the stack |
 | `/graphite:move` | Rebase the current branch (and dependents) onto a new parent |
 | `/graphite:get` | Fetch a teammate's stack to collaborate |
+| `/graphite:merge-queue` | Enqueue (or dequeue with `--remove`) the current PR via Graphite's merge label |
+
+### Merge queue configuration
+
+Graphite supports four merge-queue postures. Declare which one your repo uses so the plugin picks the right merge path:
+
+```yaml
+graphite:
+  enabled: true
+  merge-queue:
+    mode: graphite          # graphite | github-native | external | none
+    label: "merge-queue"     # used only when mode: graphite (must match Graphite settings)
+```
+
+| `mode` | What `/graphite:merge-queue` does |
+|---|---|
+| `graphite` | Applies/removes the configured label — Graphite enqueues |
+| `github-native` | Refuses; directs you to `gh pr merge --auto` |
+| `external` | Refuses; directs you to the external tool's enqueue mechanism |
+| `none` / unset | Refuses; directs you to `gt submit --merge` or `gh pr merge` |
+
+Fallback chain for the label (when `mode: graphite`): `graphite.merge-queue.label` → `$MERGE_QUEUE_LABEL` → `merge-queue`.
 
 ## How it works
 
@@ -93,3 +116,8 @@ A `SessionStart` hook also detects `.graphite_repo_config` inside the git common
 - [Setup: merge queue integration](https://graphite.com/docs/setup-merge-queue-integration)
 - [Setup: recommended CI settings](https://graphite.com/docs/setup-recommended-ci-settings)
 - [Stacking and CI](https://graphite.com/docs/stacking-and-ci)
+
+### Merge queue (covered by the `graphite-merge-queue` skill)
+
+- [Get started with Merge Queue](https://graphite.com/docs/get-started-merge-queue)
+- [Set up the Merge Queue](https://graphite.com/docs/set-up-merge-queue)

--- a/plugins/graphite/commands/merge-queue.md
+++ b/plugins/graphite/commands/merge-queue.md
@@ -13,11 +13,19 @@ Graphite's merge queue is driven entirely by a label — applying it enqueues; r
 Before reading `merge-queue` config at all, check whether the repo has opted out:
 
 ```bash
+# Depth-tracked: only the immediate child `enabled: false` under `graphite:`
+# bails out. A nested `graphite.merge-queue.enabled: false` does not match.
 GRAPHITE_DISABLED="$(
   awk '
-    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-    /^[^[:space:]#]/                { in_graphite=0 }
-    in_graphite && /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/ { print 1; exit }
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; child_indent=0; next }
+    /^[^[:space:]#]/                { in_graphite=0; child_indent=0 }
+    in_graphite && /^[[:space:]]*($|#)/ { next }
+    in_graphite {
+      match($0, /^[[:space:]]*/); indent = RLENGTH
+      if (child_indent == 0) child_indent = indent
+      if (indent == child_indent && $0 ~ /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/) { print 1; exit }
+      if (indent < child_indent) { in_graphite = 0; child_indent = 0 }
+    }
   ' .please/config.yml 2>/dev/null
 )"
 if [ "$GRAPHITE_DISABLED" = "1" ]; then

--- a/plugins/graphite/commands/merge-queue.md
+++ b/plugins/graphite/commands/merge-queue.md
@@ -1,0 +1,104 @@
+---
+description: Enqueue or dequeue the current PR in Graphite's merge queue via label
+allowed-tools: Bash, Read
+argument-hint: [--remove | --stack | <pr-number>]
+---
+
+Add or remove the configured Graphite merge-queue label on a pull request. User input: `$ARGUMENTS`.
+
+Graphite's merge queue is driven entirely by a label — applying it enqueues; removing it dequeues. For stacked PRs, the label cascades to dependent PRs automatically (label the topmost PR you want merged; do not iterate).
+
+## Bail out for non-Graphite queue modes
+
+Before doing anything, resolve `graphite.merge-queue.mode` from `.please/config.yml`. Only proceed with the label flow if mode is `graphite`. Otherwise stop and direct the user to the right path:
+
+| Mode | What to do instead |
+|---|---|
+| `github-native` | `gh pr merge --auto --squash` (or chosen strategy) — GitHub queues automatically |
+| `external` | Defer to the external tool (Mergify/Kodiak/etc.) — apply its enqueue label, not Graphite's |
+| `none` | `gt submit --merge` for stacks, or `gh pr merge` for a single PR |
+| unset | Ask the user which mode the repo uses, then offer to persist it to `.please/config.yml` |
+
+```bash
+MERGE_MODE="$(
+  awk '
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+    /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
+    in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
+    in_mq && /^[[:space:]]+mode:[[:space:]]*/ {
+      sub(/^[[:space:]]+mode:[[:space:]]*/, "")
+      sub(/[[:space:]]+#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print; exit
+    }
+  ' .please/config.yml 2>/dev/null
+)"
+MERGE_MODE="${MERGE_MODE:-${GRAPHITE_MERGE_QUEUE_MODE:-}}"
+
+case "$MERGE_MODE" in
+  graphite) ;;  # continue below
+  "")       echo "merge-queue.mode not configured. Ask the user, then persist to .please/config.yml."; exit 0 ;;
+  *)        echo "Repo uses '$MERGE_MODE' merge queue, not Graphite's. Skipping label flow."; exit 0 ;;
+esac
+```
+
+## Resolve the merge label
+
+Only relevant when `mode: graphite`. Read the label name from configuration, in this order:
+
+1. `graphite.merge-queue.label` in `.please/config.yml` at the repo root.
+2. `$MERGE_QUEUE_LABEL` environment variable.
+3. Fall back to `merge-queue`.
+
+Shell snippet (works without `yq`):
+
+```bash
+MERGE_LABEL="$(
+  awk '
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+    /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
+    in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
+    in_mq && /^[[:space:]]+label:[[:space:]]*/ {
+      sub(/^[[:space:]]+label:[[:space:]]*/, "")
+      sub(/[[:space:]]+#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print; exit
+    }
+  ' .please/config.yml 2>/dev/null
+)"
+MERGE_LABEL="${MERGE_LABEL:-${MERGE_QUEUE_LABEL:-merge-queue}}"
+```
+
+If `.please/config.yml` has no label and the user hasn't named one, tell them: the default `merge-queue` will be used; persist it to `.please/config.yml` by adding:
+
+```yaml
+graphite:
+  merge-queue:
+    label: "merge-queue"
+```
+
+## Steps
+
+1. Resolve `MERGE_LABEL` as above. Print it back to the user so they can confirm the right queue is targeted.
+2. Resolve the target PR: a `<pr-number>` argument wins; otherwise default to the current branch's PR (`gh pr view --json number`).
+3. Run `gh pr view <pr> --json state,mergeable,reviewDecision,statusCheckRollup,labels` and show the result. If the PR is closed/merged, stop. If required checks are failing, surface that and ask whether to apply the label anyway (Graphite will hold it as "merge when ready").
+4. For a Graphite stack, run `gt ls` and identify the topmost PR the user wants merged. Apply the label to **that** PR only — Graphite cascades downstack automatically. Do not loop.
+5. Apply or remove the label:
+   - Default / `--stack`: `gh pr edit <pr> --add-label "$MERGE_LABEL"`
+   - `--remove`: `gh pr edit <pr> --remove-label "$MERGE_LABEL"`
+6. Wait ~10s, then re-check `gh pr view <pr> --json labels`. If the label was stripped, the labeling user likely has no Graphite account — direct them to `https://app.graphite.com`.
+7. Print the merge-queue dashboard URL for the repo: `https://app.graphite.com/<org>/<repo>/merge-queue`.
+
+## Key flags
+
+- `--remove` — dequeue instead of enqueue (removes the label; cascades to dependents)
+- `--stack` — explicitly label the topmost PR of the current Graphite stack (default is the current branch's PR)
+- `<pr-number>` — target a specific PR instead of the current branch's PR
+
+## Notes
+
+- The label IS the API. Do not also run `gh pr merge` — that bypasses the queue and can restart in-flight queue merges.
+- Fast-track (front-of-queue jump) is single-PR only and is available only in the Graphite app UI, not via label.
+- For background on cascade rules, failure modes, and config schema, see the `graphite-merge-queue` skill.

--- a/plugins/graphite/commands/merge-queue.md
+++ b/plugins/graphite/commands/merge-queue.md
@@ -8,35 +8,32 @@ Add or remove the configured Graphite merge-queue label on a pull request. User 
 
 Graphite's merge queue is driven entirely by a label — applying it enqueues; removing it dequeues. For stacked PRs, the label cascades to dependent PRs automatically (label the topmost PR you want merged; do not iterate).
 
-## Bail out if Graphite is disabled
+## Resolve config (enabled gate, mode, label)
 
-Before reading `merge-queue` config at all, check whether the repo has opted out:
+All parsing is centralized in `${CLAUDE_PLUGIN_ROOT}/scripts/read-merge-queue-config.sh`, which emits three `KEY=VALUE` lines. `eval` the output, then apply env-var overrides:
 
 ```bash
-# Depth-tracked: only the immediate child `enabled: false` under `graphite:`
-# bails out. A nested `graphite.merge-queue.enabled: false` does not match.
-GRAPHITE_DISABLED="$(
-  awk '
-    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; child_indent=0; next }
-    /^[^[:space:]#]/                { in_graphite=0; child_indent=0 }
-    in_graphite && /^[[:space:]]*($|#)/ { next }
-    in_graphite {
-      match($0, /^[[:space:]]*/); indent = RLENGTH
-      if (child_indent == 0) child_indent = indent
-      if (indent == child_indent && $0 ~ /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/) { print 1; exit }
-      if (indent < child_indent) { in_graphite = 0; child_indent = 0 }
-    }
-  ' .please/config.yml 2>/dev/null
-)"
+eval "$("${CLAUDE_PLUGIN_ROOT}/scripts/read-merge-queue-config.sh")"
+
+# Env-var overrides (caller can force a value without editing .please/config.yml)
+MERGE_MODE="${GRAPHITE_MERGE_QUEUE_MODE:-$MERGE_MODE}"
+MERGE_LABEL="${MERGE_QUEUE_LABEL:-${MERGE_LABEL:-merge-queue}}"
+
+# 1. Bail if graphite is disabled.
 if [ "$GRAPHITE_DISABLED" = "1" ]; then
   echo "graphite.enabled: false in .please/config.yml — repo opted out of Graphite. Skipping."
   exit 0
 fi
+
+# 2. Dispatch on mode. Only `graphite` continues with the label flow.
+case "$MERGE_MODE" in
+  graphite) ;;  # continue below
+  "")       echo "merge-queue.mode not configured in .please/config.yml. Ask the user which mode the repo uses, then persist it."; exit 0 ;;
+  *)        echo "Repo uses '$MERGE_MODE' merge queue, not Graphite's. Skipping label flow."; exit 0 ;;
+esac
 ```
 
-## Bail out for non-Graphite queue modes
-
-Once enabled, resolve `graphite.merge-queue.mode` from `.please/config.yml`. Only proceed with the label flow if mode is `graphite`. Otherwise stop and direct the user to the right path:
+### Modes that this command does NOT handle
 
 | Mode | What to do instead |
 |---|---|
@@ -45,57 +42,11 @@ Once enabled, resolve `graphite.merge-queue.mode` from `.please/config.yml`. Onl
 | `none` | `gt submit --merge` for stacks, or `gh pr merge` for a single PR |
 | unset | Ask the user which mode the repo uses, then offer to persist it to `.please/config.yml` |
 
-```bash
-MERGE_MODE="$(
-  awk '
-    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-    /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
-    in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
-    in_mq && /^[[:space:]]+mode:[[:space:]]*/ {
-      sub(/^[[:space:]]+mode:[[:space:]]*/, "")
-      sub(/[[:space:]]+#.*$/, "")
-      sub(/[[:space:]]+$/, "")
-      gsub(/^["'\'']|["'\'']$/, "")
-      print; exit
-    }
-  ' .please/config.yml 2>/dev/null
-)"
-MERGE_MODE="${MERGE_MODE:-${GRAPHITE_MERGE_QUEUE_MODE:-}}"
+### Resolution precedence
 
-case "$MERGE_MODE" in
-  graphite) ;;  # continue below
-  "")       echo "merge-queue.mode not configured. Ask the user, then persist to .please/config.yml."; exit 0 ;;
-  *)        echo "Repo uses '$MERGE_MODE' merge queue, not Graphite's. Skipping label flow."; exit 0 ;;
-esac
-```
-
-## Resolve the merge label
-
-Only relevant when `mode: graphite`. Read the label name from configuration, in this order:
-
-1. `graphite.merge-queue.label` in `.please/config.yml` at the repo root.
-2. `$MERGE_QUEUE_LABEL` environment variable.
-3. Fall back to `merge-queue`.
-
-Shell snippet (works without `yq`):
-
-```bash
-MERGE_LABEL="$(
-  awk '
-    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-    /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
-    in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
-    in_mq && /^[[:space:]]+label:[[:space:]]*/ {
-      sub(/^[[:space:]]+label:[[:space:]]*/, "")
-      sub(/[[:space:]]+#.*$/, "")
-      sub(/[[:space:]]+$/, "")
-      gsub(/^["'\'']|["'\'']$/, "")
-      print; exit
-    }
-  ' .please/config.yml 2>/dev/null
-)"
-MERGE_LABEL="${MERGE_LABEL:-${MERGE_QUEUE_LABEL:-merge-queue}}"
-```
+- **Mode:** `GRAPHITE_MERGE_QUEUE_MODE` env var → `graphite.merge-queue.mode` in `.please/config.yml` → empty (caller asks).
+- **Label:** `MERGE_QUEUE_LABEL` env var → `graphite.merge-queue.label` in `.please/config.yml` → `merge-queue` (default).
+- **Disabled gate:** only `graphite.enabled: false` at the immediate child of `graphite:` triggers bail-out; the script's depth-tracking ignores nested `enabled` keys.
 
 If `.please/config.yml` has no label and the user hasn't named one, tell them: the default `merge-queue` will be used; persist it to `.please/config.yml` by adding:
 
@@ -110,7 +61,7 @@ graphite:
 1. Resolve `MERGE_LABEL` as above. Print it back to the user so they can confirm the right queue is targeted.
 2. Resolve the target PR: a `<pr-number>` argument wins; otherwise default to the current branch's PR (`gh pr view --json number`).
 3. Run `gh pr view <pr> --json state,mergeable,reviewDecision,statusCheckRollup,labels` and show the result. If the PR is closed/merged, stop. If required checks are failing, surface that and ask whether to apply the label anyway (Graphite will hold it as "merge when ready").
-4. For a Graphite stack, run `gt ls` and identify the topmost PR the user wants merged. Apply the label to **that** PR only — Graphite cascades downstack automatically. Do not loop.
+4. For a Graphite stack, run `gt ls` and identify the topmost PR the user wants merged. Apply the label to **that** PR only — Graphite enqueues it plus all downstack ancestors as queue dependencies, and cascades the label upstack to any descendants. Do not loop.
 5. Apply or remove the label:
    - Default / `--stack`: `gh pr edit <pr> --add-label "$MERGE_LABEL"`
    - `--remove`: `gh pr edit <pr> --remove-label "$MERGE_LABEL"`

--- a/plugins/graphite/commands/merge-queue.md
+++ b/plugins/graphite/commands/merge-queue.md
@@ -8,9 +8,27 @@ Add or remove the configured Graphite merge-queue label on a pull request. User 
 
 Graphite's merge queue is driven entirely by a label — applying it enqueues; removing it dequeues. For stacked PRs, the label cascades to dependent PRs automatically (label the topmost PR you want merged; do not iterate).
 
+## Bail out if Graphite is disabled
+
+Before reading `merge-queue` config at all, check whether the repo has opted out:
+
+```bash
+GRAPHITE_DISABLED="$(
+  awk '
+    /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+    /^[^[:space:]#]/                { in_graphite=0 }
+    in_graphite && /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/ { print 1; exit }
+  ' .please/config.yml 2>/dev/null
+)"
+if [ "$GRAPHITE_DISABLED" = "1" ]; then
+  echo "graphite.enabled: false in .please/config.yml — repo opted out of Graphite. Skipping."
+  exit 0
+fi
+```
+
 ## Bail out for non-Graphite queue modes
 
-Before doing anything, resolve `graphite.merge-queue.mode` from `.please/config.yml`. Only proceed with the label flow if mode is `graphite`. Otherwise stop and direct the user to the right path:
+Once enabled, resolve `graphite.merge-queue.mode` from `.please/config.yml`. Only proceed with the label flow if mode is `graphite`. Otherwise stop and direct the user to the right path:
 
 | Mode | What to do instead |
 |---|---|

--- a/plugins/graphite/scripts/read-merge-queue-config.sh
+++ b/plugins/graphite/scripts/read-merge-queue-config.sh
@@ -96,7 +96,22 @@ awk '
     return s
   }
 
+  # Single-quote a value so that `eval` of the emitted KEY=VALUE line is safe
+  # regardless of whether the YAML value contains shell metacharacters
+  # ($ ` ; & | < > ( ) space etc.). Replaces every embedded single quote with
+  # the standard '\'' close-escape-reopen sequence.
+  #
+  # Built using sprintf("%c", 39) to avoid nested single-quote escaping
+  # inside this awk program (which is itself wrapped in shell single
+  # quotes).
+  function shell_quote(s,    q, esc) {
+    q   = sprintf("%c", 39)         # one literal single quote
+    esc = q "\\" q q                # the '\'' sequence
+    gsub(q, esc, s)
+    return q s q
+  }
+
   END {
-    printf "GRAPHITE_DISABLED=%d\nMERGE_MODE=%s\nMERGE_LABEL=%s\n", disabled, mode, label
+    printf "GRAPHITE_DISABLED=%d\nMERGE_MODE=%s\nMERGE_LABEL=%s\n", disabled, shell_quote(mode), shell_quote(label)
   }
 ' "$CONFIG_FILE"

--- a/plugins/graphite/scripts/read-merge-queue-config.sh
+++ b/plugins/graphite/scripts/read-merge-queue-config.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Read Graphite merge-queue configuration from .please/config.yml.
+#
+# Outputs three KEY=VALUE lines that the caller can `eval`:
+#   GRAPHITE_DISABLED=0|1   1 iff `graphite.enabled: false` is set at the
+#                            immediate child of `graphite:`.
+#   MERGE_MODE=<value>       The `graphite.merge-queue.mode` value, or empty.
+#   MERGE_LABEL=<value>      The `graphite.merge-queue.label` value, or empty.
+#
+# Depth-tracked: only direct children of `graphite:` and `graphite.merge-queue:`
+# are matched, so nested `enabled` / `mode` / `label` at deeper levels do not
+# trigger false reads. Mirrors the conventions used in
+# hooks/graphite-context.sh.
+#
+# Single source of truth for both the `graphite-merge-queue` skill and the
+# `/graphite:merge-queue` slash command — avoids the awk duplication flagged
+# in PR review (gemini-code-assist).
+#
+# Known limitation: the comment-stripping regex (`[[:space:]]+#.*$`) is
+# fragile for values containing an embedded `#`. Workaround for affected
+# users: set MERGE_QUEUE_LABEL or GRAPHITE_MERGE_QUEUE_MODE in the
+# environment, which callers should resolve before calling this script.
+
+set -euo pipefail
+
+CONFIG_FILE="${1:-.please/config.yml}"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  printf 'GRAPHITE_DISABLED=0\nMERGE_MODE=\nMERGE_LABEL=\n'
+  exit 0
+fi
+
+awk '
+  BEGIN {
+    in_graphite = 0; in_mq = 0
+    child_indent = 0; mq_child_indent = 0
+    disabled = 0; mode = ""; label = ""
+  }
+
+  # Top-level key other than `graphite:` resets state.
+  /^[^[:space:]#]/ && !/^graphite:[[:space:]]*(#.*)?$/ {
+    in_graphite = 0; in_mq = 0; child_indent = 0; mq_child_indent = 0
+  }
+
+  /^graphite:[[:space:]]*(#.*)?$/ {
+    in_graphite = 1; in_mq = 0; child_indent = 0; mq_child_indent = 0; next
+  }
+
+  # Blank / comment-only lines.
+  /^[[:space:]]*($|#)/ { next }
+
+  in_graphite {
+    match($0, /^[[:space:]]*/); indent = RLENGTH
+
+    if (child_indent == 0) child_indent = indent
+
+    if (indent < child_indent) {
+      in_graphite = 0; in_mq = 0
+      next
+    }
+
+    if (indent == child_indent) {
+      if ($0 ~ /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/) {
+        disabled = 1
+      }
+      if ($0 ~ /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/) {
+        in_mq = 1; mq_child_indent = 0; next
+      }
+      # Any other direct child means we are no longer inside merge-queue.
+      in_mq = 0
+    }
+
+    if (in_mq && indent > child_indent) {
+      if (mq_child_indent == 0) mq_child_indent = indent
+      if (indent < mq_child_indent) { in_mq = 0; next }
+
+      if (indent == mq_child_indent) {
+        if ($0 ~ /^[[:space:]]+mode:[[:space:]]*/) {
+          raw = $0
+          sub(/^[[:space:]]+mode:[[:space:]]*/, "", raw)
+          mode = strip_value(raw)
+        }
+        if ($0 ~ /^[[:space:]]+label:[[:space:]]*/) {
+          raw = $0
+          sub(/^[[:space:]]+label:[[:space:]]*/, "", raw)
+          label = strip_value(raw)
+        }
+      }
+    }
+  }
+
+  function strip_value(s) {
+    sub(/[[:space:]]+#.*$/, "", s)
+    sub(/[[:space:]]+$/, "", s)
+    gsub(/^["'\'']|["'\'']$/, "", s)
+    return s
+  }
+
+  END {
+    printf "GRAPHITE_DISABLED=%d\nMERGE_MODE=%s\nMERGE_LABEL=%s\n", disabled, mode, label
+  }
+' "$CONFIG_FILE"

--- a/plugins/graphite/skills/graphite-merge-queue/SKILL.md
+++ b/plugins/graphite/skills/graphite-merge-queue/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: graphite-merge-queue
+description: Operate the Graphite Merge Queue — enqueue PRs via label, dequeue, monitor queue status, and reason about stacked-PR queueing. Use when the user mentions Graphite merge queue, "merge when ready", queueing a PR, dequeueing, fast-track, the merge-queue label, "enqueue", "the queue", or when they ask to merge a PR/stack through Graphite (not directly). Triggers on phrases like "queue this PR", "add to merge queue", "enqueue stack", "remove from queue", "why didn't my PR merge", and on edits to `.please/config.yml` under `graphite.merge-queue`.
+tools: Bash, Read, Grep, Glob, Edit
+user-invocable: false
+---
+
+# Graphite Merge Queue — Label-Based Enqueueing
+
+This skill covers the **runtime** operation of Graphite's merge queue: adding/removing the merge label, reading queue config from `.please/config.yml`, and reasoning about stacked-PR enqueue cascade behavior.
+
+For one-time setup (enabling the queue, configuring branch protection, choosing rebase vs squash), use the `graphite-setup` skill instead.
+
+Source docs (cite when proposing actions):
+- [Get started with Merge Queue](https://graphite.com/docs/get-started-merge-queue)
+- [Set up the Merge Queue](https://graphite.com/docs/set-up-merge-queue)
+- [Merge queue integration](https://graphite.com/docs/setup-merge-queue-integration)
+
+## Mental model
+
+- The merge queue **takes ownership of the merge** once a PR is enqueued. Graphite rebases the PR onto trunk, reruns required CI, and merges only after CI passes.
+- **One label = one queue ticket.** Adding the configured merge label to a PR enqueues it. Removing the label dequeues it. There is no separate `/queue` command on Graphite's side — the label IS the queue API.
+- **`merge when ready`**: if the label is applied before the PR is approved or CI passes, Graphite enables "merge when ready" and queues automatically when the PR becomes mergeable.
+- **Stacks cascade.** Labeling a PR mid-stack also labels its dependents (you cannot merge a parent without its children getting queued behind it). Removing the label cascades downstack in the same way.
+- **Fast-track is single-PR only.** It does not apply to stacks. It still requires a rebase + CI rerun — it just jumps the queue position.
+- **A Graphite account is required.** If the user labeling the PR has no Graphite account, the queue removes the label and prompts for account creation. Treat that as "labeled by the wrong user," not a queue bug.
+
+## Repos that don't use Graphite's merge queue
+
+Graphite supports four merge-queue postures. The label-based flow in this skill applies **only to mode `graphite`** — do not blindly apply a label in the other modes; you'll either no-op (no queue exists) or break the active queue (e.g. labeling a PR in a GitHub-native queue repo confuses operators and changes nothing).
+
+| `merge-queue.mode` | Meaning | What to do when the user says "merge this PR" |
+|---|---|---|
+| `graphite` | Graphite's queue is enabled; label triggers enqueue | Apply the configured merge label (the rest of this skill) |
+| `github-native` | GitHub's native merge queue is enabled | `gh pr merge --auto --squash` (or whatever strategy) — GitHub queues automatically. Do **not** apply the Graphite label; it does nothing. |
+| `external` | Repo uses Mergify / Kodiak / etc. | Apply that tool's enqueue mechanism (usually its own label like `mergify-merge`). Defer to the external tool's docs; do not apply Graphite's label. |
+| `none` (default) | No queue at all | Merge directly: `gt submit --merge` (Graphite UI "Merge stack") for stacks, or `gh pr merge --squash` for single PRs. |
+
+Detect the active mode from `.please/config.yml` (see below). If it isn't set, **ask once** rather than assuming `graphite`. Choosing the wrong mode silently is worse than a one-line question.
+
+## Reading merge-queue config from `.please/config.yml`
+
+The label name and mode are repository-configurable. Read both from `.please/config.yml`:
+
+```yaml
+graphite:
+  enabled: true
+  merge-queue:
+    mode: graphite               # graphite | github-native | external | none
+    label: "merge-queue"          # used only when mode: graphite (must match Graphite settings)
+    # remove-label: "merge-queue-remove"  # optional: separate dequeue label
+```
+
+**Mode resolution order** (use the first that exists):
+1. `graphite.merge-queue.mode` in `.please/config.yml`.
+2. The `GRAPHITE_MERGE_QUEUE_MODE` environment variable.
+3. Fall back to `none` — assume no queue rather than silently labeling.
+
+**Label resolution order** (use the first that exists; only meaningful when `mode: graphite`):
+1. `graphite.merge-queue.label` in `.please/config.yml`.
+2. The `MERGE_QUEUE_LABEL` environment variable.
+3. Fall back to `merge-queue` (the most common default).
+
+If `mode` is unset, ask: "Which merge queue does this repo use — Graphite's, GitHub-native, an external tool, or none?" — then offer to persist the answer.
+
+### Reading the label without `yq`
+
+The existing graphite hook parses `.please/config.yml` with awk to avoid a hard `yq` dependency. Use the same approach when you need the label from a shell:
+
+```bash
+# Print the configured merge-queue label, or "merge-queue" if missing.
+awk '
+  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+  /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
+  in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
+  in_mq && /^[[:space:]]+label:[[:space:]]*/ {
+    sub(/^[[:space:]]+label:[[:space:]]*/, "")
+    sub(/[[:space:]]+#.*$/, "")        # strip inline comment
+    sub(/[[:space:]]+$/, "")            # strip trailing whitespace
+    gsub(/^["'\'']|["'\'']$/, "")      # strip surrounding quotes
+    print; exit
+  }
+' .please/config.yml 2>/dev/null || echo "merge-queue"
+```
+
+Prefer `yq` when available (`yq '.graphite.merge-queue.label // "merge-queue"' .please/config.yml`), but never make `yq` a hard requirement — many repos won't have it installed.
+
+## Enqueueing a PR (the golden path)
+
+The label is the API. Use `gh` to apply it:
+
+```bash
+# 1. Confirm the PR is mergeable (or will be, with "merge when ready").
+gh pr view --json number,state,mergeable,reviewDecision,statusCheckRollup
+
+# 2. Apply the configured merge label.
+gh pr edit --add-label "$MERGE_LABEL"
+
+# 3. Verify Graphite picked it up — the label should still be present after a few seconds.
+#    If Graphite strips it, the user labeling the PR likely lacks a Graphite account.
+gh pr view --json labels --jq '.labels[].name'
+```
+
+Default to operating on the **current branch's PR** unless the user names one. Use `gh pr view` without arguments — `gh` resolves the PR from the checked-out branch.
+
+### Enqueueing a whole stack
+
+When the user says "queue the stack" in a Graphite repo:
+
+1. Run `gt ls` to show the stack shape.
+2. Identify the **topmost** branch the user wants merged. Label that PR's parent chain by labeling the **topmost PR** — Graphite cascades the label downstack to every dependent PR automatically, so you don't need to label each PR individually.
+3. If the user wants only part of the stack queued (e.g. "queue up to branch X"), label X — everything below X queues automatically; everything above X is not queued.
+
+Do not loop and label each PR with `gh pr edit` — that's redundant and risks racing the cascade.
+
+## Dequeueing
+
+```bash
+gh pr edit --remove-label "$MERGE_LABEL"
+```
+
+Removing the label from a mid-stack PR cascades **downstack** (dependents drop out of the queue). Branches above the dequeued PR in the stack are unaffected.
+
+Tell the user that dequeueing while CI is mid-rerun cancels the in-flight rebase but does not roll back any rebase that already landed on trunk.
+
+## Inspecting queue state
+
+There is no CLI command for the queue dashboard — direct the user to `https://app.graphite.com/<org>/<repo>/merge-queue`. From the terminal you can only check:
+
+```bash
+gh pr view <number> --json labels,mergeStateStatus,statusCheckRollup
+```
+
+A PR is "in the queue" iff:
+- The configured merge label is present, AND
+- The PR is open, AND
+- A Graphite-side queue record exists (visible only in the Graphite UI).
+
+If the label is present but the PR isn't merging, the cause is almost always one of: CI failing on the rebased SHA, the labeling user has no Graphite account (label gets stripped — check `gh pr view --json labels` again 30s later), or the queue is paused at the org level.
+
+## Stacked-PR cascade — practical rules
+
+| Action | Effect |
+|---|---|
+| Label PR at top of stack | Queues the top; cascades down (every ancestor PR also queues, in dependency order) |
+| Label PR mid-stack | Queues that PR and every PR below it; PRs above are untouched |
+| Label PR at bottom (just above trunk) | Queues only that PR |
+| Remove label from top | Dequeues top; PRs below remain queued |
+| Remove label from mid-stack | Dequeues that PR and every PR below it |
+| Approve a queued PR after labeling | "Merge when ready" fires automatically once mergeable |
+
+The cascade direction is **from labeled PR toward trunk**, because Graphite must merge ancestors before descendants. This is the opposite of git's "downstack" terminology — be explicit when explaining to the user.
+
+## Common failure modes
+
+- **"My PR is labeled but not merging."** Check: (a) `gh pr view --json reviewDecision,statusCheckRollup` — required reviews/checks passing? (b) Is the queue paused at the org level (Graphite UI)? (c) Did Graphite strip the label (no account)?
+- **"The label keeps disappearing."** The user applying the label has no Graphite account, or it's not linked to the org. Direct them to `https://app.graphite.com`.
+- **"A teammate's non-queue merge broke my queued PR."** Admins/maintainers can bypass branch protection. Their direct push to trunk restarts Graphite's in-flight merge. Recommend the user re-enable "restrict pushes to graphite-app only" — covered in the `graphite-setup` skill.
+- **"My stack queued out of order."** Graphite queues in stack-dependency order, not labeling order. If the user labeled mid-stack PRs first, dependents still wait for ancestors. This is correct behavior, not a bug.
+- **CI fails on the rebased SHA.** The PR is removed from the queue. Investigate the failure, fix, push, and re-label to re-enqueue.
+
+## Operating principles for Claude
+
+- **Always resolve `merge-queue.mode` first.** The merge-queue *flow* is mode-dependent; the rest of this skill is the `mode: graphite` branch. If mode isn't set in `.please/config.yml`, ask the user once and persist the answer.
+- When mode is `github-native`, `external`, or `none`, **do not apply the Graphite label.** Use the merge path for that mode (see the table above) and recommend the user uninstall this skill's trigger if they'll never use the Graphite queue.
+- Before applying the label (mode: graphite), run `gh pr view --json state,mergeable,reviewDecision` and surface the result — the user should see why their PR will or won't queue successfully.
+- Never apply the label to a PR with a failing required check **unless** the user explicitly says "merge when ready" — silently queueing a known-broken PR wastes a CI run and queue slot.
+- When labeling a stack, label only the topmost PR the user wants merged; do not iterate.
+- When the user says "merge this PR" in a Graphite-queue repo, default to the queue path (label it) rather than `gh pr merge`. Confirm before bypassing the queue with `gh pr merge` — direct merges defeat the queue's ordering guarantees and can restart in-flight queue merges.
+- If `.please/config.yml` lacks a `graphite.merge-queue.label`, ask once and offer to persist it.
+- Cite the relevant Graphite doc page when proposing a configuration change so the user can verify.

--- a/plugins/graphite/skills/graphite-merge-queue/SKILL.md
+++ b/plugins/graphite/skills/graphite-merge-queue/SKILL.md
@@ -21,7 +21,9 @@ Source docs (cite when proposing actions):
 - The merge queue **takes ownership of the merge** once a PR is enqueued. Graphite rebases the PR onto trunk, reruns required CI, and merges only after CI passes.
 - **One label = one queue ticket.** Adding the configured merge label to a PR enqueues it. Removing the label dequeues it. There is no separate `/queue` command on Graphite's side — the label IS the queue API.
 - **`merge when ready`**: if the label is applied before the PR is approved or CI passes, Graphite enables "merge when ready" and queues automatically when the PR becomes mergeable.
-- **Stacks cascade.** Labeling a PR mid-stack also labels its dependents (you cannot merge a parent without its children getting queued behind it). Removing the label cascades downstack in the same way.
+- **Stacks cascade.** Labeling a PR mid-stack also labels its descendants (upstack), and Graphite separately enqueues all ancestors (downstack) as queue dependencies — you cannot merge a parent without its children getting queued, and you cannot merge a child until its ancestors land. Removing the label cascades upstack in the same way (descendants drop out of the queue); downstack ancestors are unaffected.
+
+> **Graphite stack terminology.** *Downstack* = toward trunk (ancestors). *Upstack* = away from trunk (descendants). Label propagation cascades **upstack**; queue dependencies pull in **downstack** ancestors.
 - **Fast-track is single-PR only.** It does not apply to stacks. It still requires a rebase + CI rerun — it just jumps the queue position.
 - **A Graphite account is required.** If the user labeling the PR has no Graphite account, the queue removes the label and prompts for account creation. Treat that as "labeled by the wrong user," not a queue bug.
 
@@ -50,6 +52,19 @@ graphite:
     label: "merge-queue"          # used only when mode: graphite (must match Graphite settings)
     # remove-label: "merge-queue-remove"  # optional: separate dequeue label
 ```
+
+**Bail-out check (run first):** if `graphite.enabled` is explicitly `false` in `.please/config.yml`, do not read or act on any `merge-queue` config — the repo has opted out of Graphite. Skip the rest of this skill and tell the user the repo is opted out.
+
+```bash
+# True if graphite is explicitly disabled — exit early when this prints "1".
+awk '
+  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
+  /^[^[:space:]#]/                { in_graphite=0 }
+  in_graphite && /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/ { print 1; exit }
+' .please/config.yml 2>/dev/null
+```
+
+If the bail-out check passes (or `.please/config.yml` is absent / `enabled` is unset / set to `true`), proceed.
 
 **Mode resolution order** (use the first that exists):
 1. `graphite.merge-queue.mode` in `.please/config.yml`.
@@ -108,10 +123,10 @@ Default to operating on the **current branch's PR** unless the user names one. U
 When the user says "queue the stack" in a Graphite repo:
 
 1. Run `gt ls` to show the stack shape.
-2. Identify the **topmost** branch the user wants merged. Label that PR's parent chain by labeling the **topmost PR** — Graphite cascades the label downstack to every dependent PR automatically, so you don't need to label each PR individually.
-3. If the user wants only part of the stack queued (e.g. "queue up to branch X"), label X — everything below X queues automatically; everything above X is not queued.
+2. Identify the **topmost** branch the user wants merged. Label that PR — Graphite enqueues it plus all downstack ancestors (queue dependencies), so you don't need to label each ancestor individually. If the topmost PR has any upstack descendants, the label also cascades upstack and queues them.
+3. To queue only "up to branch X" (X not at the top), label X — Graphite queues X plus all downstack ancestors AND all upstack descendants via the label cascade. There is no way to selectively queue downstack-only via labels; if the user wants to stop short of the top, the upstack descendants must be either out of scope (closed/merged) or you must hold off labeling until they are.
 
-Do not loop and label each PR with `gh pr edit` — that's redundant and risks racing the cascade.
+Do not loop and label each PR with `gh pr edit` — that's redundant and races the cascade.
 
 ## Dequeueing
 
@@ -119,7 +134,7 @@ Do not loop and label each PR with `gh pr edit` — that's redundant and risks r
 gh pr edit --remove-label "$MERGE_LABEL"
 ```
 
-Removing the label from a mid-stack PR cascades **downstack** (dependents drop out of the queue). Branches above the dequeued PR in the stack are unaffected.
+Removing the label from a mid-stack PR cascades **upstack** (descendants drop out of the queue). Downstack ancestors are unaffected — they remain queued if they had been labeled separately.
 
 Tell the user that dequeueing while CI is mid-rerun cancels the in-flight rebase but does not roll back any rebase that already landed on trunk.
 
@@ -142,14 +157,14 @@ If the label is present but the PR isn't merging, the cause is almost always one
 
 | Action | Effect |
 |---|---|
-| Label PR at top of stack | Queues the top; cascades down (every ancestor PR also queues, in dependency order) |
-| Label PR mid-stack | Queues that PR and every PR below it; PRs above are untouched |
-| Label PR at bottom (just above trunk) | Queues only that PR |
-| Remove label from top | Dequeues top; PRs below remain queued |
-| Remove label from mid-stack | Dequeues that PR and every PR below it |
+| Label PR at top of stack | Queues the top and all ancestors (downstack) |
+| Label PR mid-stack | Queues that PR, all ancestors (downstack), and all descendants (upstack) |
+| Label PR at bottom (just above trunk) | Queues that PR and all descendants (upstack) |
+| Remove label from top | Dequeues top; descendants (if any) are also dequeued; ancestors remain |
+| Remove label from mid-stack | Dequeues that PR and all descendants (upstack); ancestors remain |
 | Approve a queued PR after labeling | "Merge when ready" fires automatically once mergeable |
 
-The cascade direction is **from labeled PR toward trunk**, because Graphite must merge ancestors before descendants. This is the opposite of git's "downstack" terminology — be explicit when explaining to the user.
+The cascade direction for label propagation is **upstack** (away from trunk). However, Graphite ensures all **downstack** ancestors are also enqueued to satisfy dependencies.
 
 ## Common failure modes
 

--- a/plugins/graphite/skills/graphite-merge-queue/SKILL.md
+++ b/plugins/graphite/skills/graphite-merge-queue/SKILL.md
@@ -53,27 +53,7 @@ graphite:
     # remove-label: "merge-queue-remove"  # optional: separate dequeue label
 ```
 
-**Bail-out check (run first):** if `graphite.enabled` is explicitly `false` in `.please/config.yml`, do not read or act on any `merge-queue` config — the repo has opted out of Graphite. Skip the rest of this skill and tell the user the repo is opted out.
-
-```bash
-# True if graphite is explicitly disabled — exit early when this prints "1".
-# Depth-tracked: only matches `enabled: false` at the immediate child level of
-# `graphite:`, so a nested `graphite.merge-queue.enabled: false` does not
-# trigger a false bail-out. (Mirrors hooks/graphite-context.sh.)
-awk '
-  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; child_indent=0; next }
-  /^[^[:space:]#]/                { in_graphite=0; child_indent=0 }
-  in_graphite && /^[[:space:]]*($|#)/ { next }
-  in_graphite {
-    match($0, /^[[:space:]]*/); indent = RLENGTH
-    if (child_indent == 0) child_indent = indent
-    if (indent == child_indent && $0 ~ /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/) { print 1; exit }
-    if (indent < child_indent) { in_graphite = 0; child_indent = 0 }
-  }
-' .please/config.yml 2>/dev/null
-```
-
-If the bail-out check passes (or `.please/config.yml` is absent / `enabled` is unset / set to `true`), proceed.
+**Bail-out check (run first):** if `graphite.enabled` is explicitly `false` in `.please/config.yml`, do not read or act on any `merge-queue` config — the repo has opted out of Graphite. The centralized parser sets `GRAPHITE_DISABLED=1` in that case (see [Centralized parser](#centralized-parser--scriptsread-merge-queue-configsh) below); when you see that, stop and tell the user the repo is opted out.
 
 **Mode resolution order** (use the first that exists):
 1. `graphite.merge-queue.mode` in `.please/config.yml`.
@@ -87,27 +67,33 @@ If the bail-out check passes (or `.please/config.yml` is absent / `enabled` is u
 
 If `mode` is unset, ask: "Which merge queue does this repo use — Graphite's, GitHub-native, an external tool, or none?" — then offer to persist the answer.
 
-### Reading the label without `yq`
+### Centralized parser — `scripts/read-merge-queue-config.sh`
 
-The existing graphite hook parses `.please/config.yml` with awk to avoid a hard `yq` dependency. Use the same approach when you need the label from a shell:
+The plugin ships a single shell script that reads the disabled gate, mode, and label from `.please/config.yml` with one depth-tracked awk pass. Both this skill and the `/graphite:merge-queue` slash command call it; do not re-implement the parsing.
 
 ```bash
-# Print the configured merge-queue label, or "merge-queue" if missing.
-awk '
-  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-  /^[^[:space:]#]/                { in_graphite=0; in_mq=0 }
-  in_graphite && /^[[:space:]]+merge-queue:[[:space:]]*(#.*)?$/ { in_mq=1; next }
-  in_mq && /^[[:space:]]+label:[[:space:]]*/ {
-    sub(/^[[:space:]]+label:[[:space:]]*/, "")
-    sub(/[[:space:]]+#.*$/, "")        # strip inline comment
-    sub(/[[:space:]]+$/, "")            # strip trailing whitespace
-    gsub(/^["'\'']|["'\'']$/, "")      # strip surrounding quotes
-    print; exit
-  }
-' .please/config.yml 2>/dev/null || echo "merge-queue"
+# Outputs three KEY=VALUE lines you can `eval`.
+eval "$("${CLAUDE_PLUGIN_ROOT}/scripts/read-merge-queue-config.sh")"
+# Variables now set:
+#   GRAPHITE_DISABLED  — 1 iff graphite.enabled: false at the immediate
+#                        child of graphite: (else 0).
+#   MERGE_MODE         — graphite.merge-queue.mode, or empty.
+#   MERGE_LABEL        — graphite.merge-queue.label, or empty.
+
+# Apply env-var overrides:
+MERGE_MODE="${GRAPHITE_MERGE_QUEUE_MODE:-$MERGE_MODE}"
+MERGE_LABEL="${MERGE_QUEUE_LABEL:-${MERGE_LABEL:-merge-queue}}"
 ```
 
-Prefer `yq` when available (`yq '.graphite.merge-queue.label // "merge-queue"' .please/config.yml`), but never make `yq` a hard requirement — many repos won't have it installed.
+How the parser works (read `scripts/read-merge-queue-config.sh` for the awk):
+
+- Tracks the indent of the first child of `graphite:` so only direct children (`enabled`, `merge-queue`) match — nested `enabled` keys (e.g. `graphite.merge-queue.enabled`) cannot trigger a false bail-out.
+- Tracks the indent of the first child of `merge-queue:` the same way, so only direct children (`mode`, `label`) are read.
+- Strips inline `# comment` trailers and surrounding quotes from the value.
+
+Prefer `yq` if available (`yq '.graphite.merge-queue.label' .please/config.yml`), but never make `yq` a hard requirement — many repos won't have it installed. The shell script is the no-dependency fallback.
+
+> **Known limitation:** the comment-stripping regex (`[[:space:]]+#`) does not respect quoted strings. A label like `"feature # tag"` would be truncated at the inner ` #`. Workaround for affected users: set `MERGE_QUEUE_LABEL` in the environment — env-var resolution happens before the YAML parse. If real-world users hit this, swap the parser for a quote-aware implementation in one place (`scripts/read-merge-queue-config.sh`).
 
 ## Enqueueing a PR (the golden path)
 

--- a/plugins/graphite/skills/graphite-merge-queue/SKILL.md
+++ b/plugins/graphite/skills/graphite-merge-queue/SKILL.md
@@ -57,10 +57,19 @@ graphite:
 
 ```bash
 # True if graphite is explicitly disabled — exit early when this prints "1".
+# Depth-tracked: only matches `enabled: false` at the immediate child level of
+# `graphite:`, so a nested `graphite.merge-queue.enabled: false` does not
+# trigger a false bail-out. (Mirrors hooks/graphite-context.sh.)
 awk '
-  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; next }
-  /^[^[:space:]#]/                { in_graphite=0 }
-  in_graphite && /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/ { print 1; exit }
+  /^graphite:[[:space:]]*(#.*)?$/ { in_graphite=1; child_indent=0; next }
+  /^[^[:space:]#]/                { in_graphite=0; child_indent=0 }
+  in_graphite && /^[[:space:]]*($|#)/ { next }
+  in_graphite {
+    match($0, /^[[:space:]]*/); indent = RLENGTH
+    if (child_indent == 0) child_indent = indent
+    if (indent == child_indent && $0 ~ /^[[:space:]]+enabled:[[:space:]]*false([[:space:]]|#|$)/) { print 1; exit }
+    if (indent < child_indent) { in_graphite = 0; child_indent = 0 }
+  }
 ' .please/config.yml 2>/dev/null
 ```
 

--- a/plugins/graphite/skills/graphite-merge-queue/SKILL.md
+++ b/plugins/graphite/skills/graphite-merge-queue/SKILL.md
@@ -55,14 +55,14 @@ graphite:
 
 **Bail-out check (run first):** if `graphite.enabled` is explicitly `false` in `.please/config.yml`, do not read or act on any `merge-queue` config — the repo has opted out of Graphite. The centralized parser sets `GRAPHITE_DISABLED=1` in that case (see [Centralized parser](#centralized-parser--scriptsread-merge-queue-configsh) below); when you see that, stop and tell the user the repo is opted out.
 
-**Mode resolution order** (use the first that exists):
-1. `graphite.merge-queue.mode` in `.please/config.yml`.
-2. The `GRAPHITE_MERGE_QUEUE_MODE` environment variable.
-3. Fall back to `none` — assume no queue rather than silently labeling.
+**Mode resolution order** (env var takes precedence — it's an explicit per-invocation override):
+1. The `GRAPHITE_MERGE_QUEUE_MODE` environment variable.
+2. `graphite.merge-queue.mode` in `.please/config.yml`.
+3. Fall back to empty (and ask the user) — assume no queue rather than silently labeling.
 
-**Label resolution order** (use the first that exists; only meaningful when `mode: graphite`):
-1. `graphite.merge-queue.label` in `.please/config.yml`.
-2. The `MERGE_QUEUE_LABEL` environment variable.
+**Label resolution order** (env var takes precedence; only meaningful when effective mode is `graphite`):
+1. The `MERGE_QUEUE_LABEL` environment variable.
+2. `graphite.merge-queue.label` in `.please/config.yml`.
 3. Fall back to `merge-queue` (the most common default).
 
 If `mode` is unset, ask: "Which merge queue does this repo use — Graphite's, GitHub-native, an external tool, or none?" — then offer to persist the answer.


### PR DESCRIPTION
## What changed

### New: `/graphite:merge-queue` command (`plugins/graphite/commands/merge-queue.md`)
Slash command that enqueues (or removes) a PR from the merge queue. Accepts three argument shapes:
- `/graphite:merge-queue <pr-number>` — enqueue a specific PR
- `/graphite:merge-queue --stack` — enqueue the full stack bottom-to-top
- `/graphite:merge-queue --remove [<pr-number>]` — dequeue current or specified PR

### New: graphite-merge-queue skill (`plugins/graphite/skills/graphite-merge-queue/SKILL.md`)
Runtime skill that carries the full merge-queue workflow: label-based enqueueing, stack cascade rules, prerequisite checks (CI green, approved, no conflicts), and mode-specific instructions.

### Config schema (`.please/config.yml`)
Added two new fields under the `graphite` namespace:
```yaml
graphite:
  merge-queue:
    mode: graphite          # graphite | github-native | external | none
    label: merge-queue      # label name used to trigger the queue
```

### README update (`plugins/graphite/README.md`)
Documented the new skill, command, and mode matrix.

---

## Why

Graphite Merge Queue requires attaching a specific label to trigger enqueueing. Without tooling, developers must remember the exact label name and apply it manually — error-prone at scale and in stacked-PR workflows where every PR in the stack must be enqueued in order.

This feature adds label-based automation with safety checks and supports teams that use GitHub-native, external (Mergify/Aviator), or no merge queue — the mode matrix below governs dispatch.

---

## Mode matrix

| Mode | Behaviour |
|---|---|
| `graphite` | Applies the configured label via `gt` / `gh pr edit`; respects stack order |
| `github-native` | Uses GitHub's built-in merge queue (enqueue-on-label) |
| `external` | Applies the queue label understood by Mergify, Aviator, etc. |
| `none` | Command is a no-op; logs a notice that the queue is disabled |

---

## References

- https://graphite.com/docs/get-started-merge-queue
- https://graphite.com/docs/set-up-merge-queue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mode-aware Graphite merge queue with a `/graphite:merge-queue` command and a runtime skill to enqueue/dequeue via label, with corrected stack cascade rules and a secure, centralized config parser that aligns env‑var precedence.

- **New Features**
  - Added `/graphite:merge-queue` command (`--stack`, `--remove`, or `<pr-number>`) to enqueue/dequeue via the configured label.
  - Introduced `graphite-merge-queue` skill with CI/approval/conflict checks and corrected cascade semantics (label propagates upstack; queue pulls downstack ancestors).
  - Centralized config parsing in `plugins/graphite/scripts/read-merge-queue-config.sh`, shared by the command and skill: depth-tracked bail-out for `graphite.enabled: false`, shell-quoted `KEY=VALUE` output to prevent `eval` injection, and env-var overrides (`GRAPHITE_MERGE_QUEUE_MODE`, `MERGE_QUEUE_LABEL`) taking precedence.
  - Updated docs: `.please/config.yml` supports `graphite.merge-queue.mode` (`graphite | github-native | external | none`) and `graphite.merge-queue.label`; README clarifies mode behavior, label resolution (env vars override config), and terminology.

- **Migration**
  - Configure `.please/config.yml`: set `graphite.enabled: true`, `graphite.merge-queue.mode`, and (for `graphite`) `graphite.merge-queue.label`.
  - Mode behavior: `graphite` applies the label; `github-native`/`external` direct to their enqueue paths; `none` is a no-op. If unset, it defaults to `none`.

<sup>Written for commit 74bcdc11d2d3265aa056c10ec487266454acd45d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

