### PR TITLE
feat(bun): add Tessl plugin manifest for registry publishing

### DIFF
--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -1,0 +1,50 @@
+name: Tessl Publish
+
+# Publishes the bun plugin to the Tessl registry as `pleaseai/bun` whenever
+# release-please cuts a bun release. release-please tags components as
+# `<component>-v<version>` (e.g. `bun-v1.3.0`) using a GitHub App token, so
+# the tag push triggers this workflow. The checked-out tag already has the
+# bumped version in plugins/bun/.tessl-plugin/plugin.json, so `tessl plugin
+# publish` publishes exactly that version.
+#
+# Requires repository secret TESSL_TOKEN (create via `tessl api-key create`).
+# When the secret is absent the job no-ops with a warning instead of failing.
+on:
+  push:
+    tags:
+      - 'bun-v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-bun:
+    name: Publish pleaseai/bun to Tessl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check TESSL_TOKEN is configured
+        id: guard
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: |
+          if [ -z "$TESSL_TOKEN" ]; then
+            echo "::warning::TESSL_TOKEN not configured — skipping Tessl publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Tessl CLI
+        if: steps.guard.outputs.skip != 'true'
+        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+
+      - name: Publish plugin
+        if: steps.guard.outputs.skip != 'true'
+        run: tessl plugin publish plugins/bun

--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -1,15 +1,16 @@
 name: Tessl Skill Review
 
-# Runs `tessl skill review` on the use-bun skill for PRs that touch it, so the
-# skill's quality/compliance score (and the 1024-char description limit) are
-# checked before merge. Review output is written to the Actions log.
+# Reviews the use-bun SKILL.md on PRs that touch it using the official
+# tesslio/skill-review action, which runs `tessl skill review` on changed
+# SKILL.md files and posts the quality scores as a PR comment.
 #
-# This uses the inline `setup-tessl` + `tessl skill review` form rather than the
-# tesslio/skill-review wrapper action, which is currently unreleased (no tags).
+# Auth: the skill-review composite runs tesslio/setup-tessl WITHOUT a token, and
+# the tessl CLI authenticates from the TESSL_TOKEN env var — so it is provided at
+# job level here. When the secret is absent the job no-ops with a warning instead
+# of failing the PR.
 #
-# Requires repository secret TESSL_TOKEN. When absent the job no-ops with a
-# warning instead of failing the PR. To gate merges on a minimum score, add
-# `--threshold <0-100>` to the review command (it exits non-zero below the bar).
+# Pinning: skill-review has no tagged release yet, so it is pinned to a main
+# commit SHA. Bump the SHA to adopt upstream changes.
 on:
   pull_request:
     branches: [main]
@@ -18,16 +19,17 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write # required for the action to post its review comment
 
 jobs:
   review-use-bun:
     name: Review use-bun skill
     runs-on: ubuntu-latest
+    env:
+      TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
     steps:
       - name: Check TESSL_TOKEN is configured
         id: guard
-        env:
-          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
         run: |
           if [ -z "$TESSL_TOKEN" ]; then
             echo "::warning::TESSL_TOKEN not configured — skipping Tessl skill review"
@@ -40,12 +42,10 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Tessl CLI
+      - name: Review changed skills
         if: steps.guard.outputs.skip != 'true'
-        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main (no tagged release)
         with:
-          token: ${{ secrets.TESSL_TOKEN }}
-
-      - name: Review skill
-        if: steps.guard.outputs.skip != 'true'
-        run: tessl skill review plugins/bun/skills/use-bun/SKILL.md
+          path: plugins/bun
+          comment: 'true'
+          fail-threshold: '0'

--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -1,0 +1,51 @@
+name: Tessl Skill Review
+
+# Runs `tessl skill review` on the use-bun skill for PRs that touch it, so the
+# skill's quality/compliance score (and the 1024-char description limit) are
+# checked before merge. Review output is written to the Actions log.
+#
+# This uses the inline `setup-tessl` + `tessl skill review` form rather than the
+# tesslio/skill-review wrapper action, which is currently unreleased (no tags).
+#
+# Requires repository secret TESSL_TOKEN. When absent the job no-ops with a
+# warning instead of failing the PR. To gate merges on a minimum score, add
+# `--threshold <0-100>` to the review command (it exits non-zero below the bar).
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/bun/skills/**'
+
+permissions:
+  contents: read
+
+jobs:
+  review-use-bun:
+    name: Review use-bun skill
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check TESSL_TOKEN is configured
+        id: guard
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: |
+          if [ -z "$TESSL_TOKEN" ]; then
+            echo "::warning::TESSL_TOKEN not configured — skipping Tessl skill review"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Tessl CLI
+        if: steps.guard.outputs.skip != 'true'
+        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+
+      - name: Review skill
+        if: steps.guard.outputs.skip != 'true'
+        run: tessl skill review plugins/bun/skills/use-bun/SKILL.md

--- a/plugins/bun/.tessl-plugin/plugin.json
+++ b/plugins/bun/.tessl-plugin/plugin.json
@@ -2,6 +2,10 @@
   "name": "pleaseai/bun",
   "description": "All-in-one JavaScript/TypeScript toolkit: fast runtime, package manager, test runner, and bundler. Version-aware skill backed by the ask CLI.",
   "version": "1.2.0",
+  "author": {
+    "name": "Bun",
+    "url": "https://github.com/oven-sh/bun"
+  },
   "skills": [
     "skills/use-bun"
   ]

--- a/plugins/bun/.tessl-plugin/plugin.json
+++ b/plugins/bun/.tessl-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pleaseai/bun",
+  "description": "All-in-one JavaScript/TypeScript toolkit: fast runtime, package manager, test runner, and bundler. Version-aware skill backed by the ask CLI.",
+  "version": "1.2.0",
+  "skills": [
+    "skills/use-bun"
+  ]
+}

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -71,7 +71,7 @@ The manifest `version` is kept in sync with the other manifests by release-pleas
 CI automates this (requires a `TESSL_TOKEN` repo secret; both jobs no-op without it):
 
 - **`.github/workflows/tessl-publish.yml`** — publishes to the registry when release-please tags a release (`bun-v*`).
-- **`.github/workflows/tessl-skill-review.yml`** — runs `tessl skill review` on PRs that touch `plugins/bun/skills/**`.
+- **`.github/workflows/tessl-skill-review.yml`** — runs the [`tesslio/skill-review`](https://github.com/tesslio/skill-review) action on PRs that touch `plugins/bun/skills/**`, posting the skill's quality score as a PR comment.
 
 ## Prerequisites
 

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -68,6 +68,11 @@ tessl plugin publish            # requires `tessl login` or a TESSL_TOKEN
 
 The manifest `version` is kept in sync with the other manifests by release-please (it is a `$.version` extra-file alongside `.claude-plugin`, `.codex-plugin`, and root `plugin.json`). Tessl caps a skill's `description` at 1024 characters, so `skills/use-bun/SKILL.md` keeps its description within that limit.
 
+CI automates this (requires a `TESSL_TOKEN` repo secret; both jobs no-op without it):
+
+- **`.github/workflows/tessl-publish.yml`** — publishes to the registry when release-please tags a release (`bun-v*`).
+- **`.github/workflows/tessl-skill-review.yml`** — runs `tessl skill review` on PRs that touch `plugins/bun/skills/**`.
+
 ## Prerequisites
 
 - Bun installed (`curl -fsSL https://bun.sh/install | bash`)

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -11,8 +11,9 @@ The `SKILL.md` format is shared by Claude Code, Cursor, Codex CLI, Gemini CLI, G
 | Claude Code | `.claude-plugin/plugin.json` | `./skills/` |
 | Codex | `.codex-plugin/plugin.json` | `./skills/` |
 | Antigravity | `plugin.json` (at plugin root) | `./skills/` |
+| Tessl | `.tessl-plugin/plugin.json` | `skills/use-bun` |
 
-All three tools read the same `skills/use-bun/SKILL.md`. Antigravity additionally accepts `mcp_config.json`, `hooks.json`, and `rules/` at plugin root if needed (this plugin uses none of them).
+All tools read the same `skills/use-bun/SKILL.md`. Antigravity additionally accepts `mcp_config.json`, `hooks.json`, and `rules/` at plugin root if needed (this plugin uses none of them). Tessl publishes the skill to its registry as `pleaseai/bun` (see [Tessl](#tessl) below).
 
 ## Install
 
@@ -52,6 +53,21 @@ cp -R <path-to-this-plugin>/skills/use-bun ~/.gemini/antigravity/skills/
 
 See the [Antigravity plugins docs](https://antigravity.google/docs/plugins) and the [Authoring Skills](https://codelabs.developers.google.com/getting-started-with-antigravity-skills) codelab for background.
 
+### Tessl
+
+This plugin ships a [Tessl](https://tessl.io) manifest (`.tessl-plugin/plugin.json`) so the `use-bun` skill can be published to and installed from the Tessl registry as `pleaseai/bun`.
+
+```bash
+# Install from the registry
+tessl install pleaseai/bun
+
+# Validate / publish from this directory (maintainers)
+tessl plugin lint plugins/bun
+tessl plugin publish            # requires `tessl login` or a TESSL_TOKEN
+```
+
+The manifest `version` is kept in sync with the other manifests by release-please (it is a `$.version` extra-file alongside `.claude-plugin`, `.codex-plugin`, and root `plugin.json`). Tessl caps a skill's `description` at 1024 characters, so `skills/use-bun/SKILL.md` keeps its description within that limit.
+
 ## Prerequisites
 
 - Bun installed (`curl -fsSL https://bun.sh/install | bash`)
@@ -64,6 +80,7 @@ plugins/bun/
 ├── .claude-plugin/plugin.json     # Claude Code manifest
 ├── .codex-plugin/plugin.json      # Codex manifest
 ├── plugin.json                     # Antigravity marker file
+├── .tessl-plugin/plugin.json      # Tessl plugin manifest (pleaseai/bun)
 ├── README.md                       # this file
 └── skills/use-bun/
     ├── SKILL.md                    # entry point — universal across all tools

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -534,6 +534,11 @@
           "type": "json",
           "path": "plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".tessl-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Makes the existing **`bun`** plugin publishable to the [Tessl](https://tessl.io) registry as **`pleaseai/bun`** by adding a Tessl manifest (`.tessl-plugin/plugin.json`) alongside the existing Claude Code / Codex / Antigravity manifests. No new plugin is created — this extends `plugins/bun/`.

## Changes

- **`plugins/bun/.tessl-plugin/plugin.json`** — Tessl manifest (`name: pleaseai/bun`, `skills: ["skills/use-bun"]`, `version: 1.2.0`). Generated/validated with the `tessl` CLI.
- **`plugins/bun/skills/use-bun/SKILL.md`** — trimmed the skill `description` from **1501 → 1014 chars** to satisfy Tessl's 1024-char skill-description limit. All core triggers retained (a few redundant API names / duplicate trigger keywords dropped).
- **`release-please-config.json`** — added `.tessl-plugin/plugin.json` as a 4th `$.version` extra-file under `plugins/bun`, so its version stays in sync with `.claude-plugin`, `.codex-plugin`, and root `plugin.json` on every release.
- **`plugins/bun/README.md`** — documented the Tessl manifest, install/publish commands, and added Tessl to the cross-tool compatibility table.

## Validation

```
tessl plugin lint plugins/bun     ✔ Plugin pleaseai/bun@1.2.0 is valid   (tessl CLI v0.81.0)
claude plugin validate plugins/bun ✔ Validation passed
```

## Notes

- The 1024-char description limit is a hard Tessl constraint — `tessl plugin lint`/`publish` reject the skill above it. The trim keeps Claude Code's auto-activation triggers substantially intact.
- **Publishing to the registry** (`tessl plugin publish`) needs `tessl login` or a `TESSL_TOKEN`. A publish-on-push / `skill-review` GitHub Actions workflow (via `tesslio/setup-tessl` + `tesslio/skill-review`) can be added as a follow-up — not included here to avoid committing outward-facing CI that requires the secret.

Supersedes #193 (which created a separate `tessl` plugin — not what was wanted).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the existing `bun` plugin publishable on Tessl as `pleaseai/bun`. Adds CI to auto-publish tagged releases and comment skill reviews on PRs; keeps versions in sync and trims the skill description to Tessl’s 1024‑char limit.

- New Features
  - Added Tessl manifest at `plugins/bun/.tessl-plugin/plugin.json` (`name: pleaseai/bun`, `skills: ["skills/use-bun"]`, `author`), with version synced via `release-please`.
  - CI: `.github/workflows/tessl-publish.yml` publishes on `bun-v*` tags; `.github/workflows/tessl-skill-review.yml` uses `tesslio/skill-review` to review changed skills and post a score comment (both no-op without `TESSL_TOKEN`).
  - Trimmed `skills/use-bun/SKILL.md` description to 1014 chars; updated `plugins/bun/README.md` with Tessl install/publish and automation.

<sup>Written for commit 2a2452c9fc22e2361954b3b01362448c391e03ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

