### PR TITLE
docs(bun): add tessl registry badge and marketplace entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install emulate@pleaseai
 /plugin install ask@pleaseai
 /plugin install workflow@pleaseai
+/plugin install portless@pleaseai
+/plugin install zod@pleaseai
 /plugin install bun@pleaseai
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,13 @@ TypeScript-first schema validation with static type inference — version-aware 
 
 **Install:** `/plugin install zod@pleaseai` | **Source:** [plugins/zod](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/zod)
 
+#### Bun
+[![tessl](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.tessl.io%2Fv1%2Fbadges%2Fpleaseai%2Fbun)](https://tessl.io/registry/pleaseai/bun)
+
+Version-aware skill for the Bun JavaScript/TypeScript toolkit — runtime, package manager, test runner, and bundler.
+
+**Install:** `/plugin install bun@pleaseai` | **Source:** [plugins/bun](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/bun)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:
@@ -442,6 +449,7 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install emulate@pleaseai
 /plugin install ask@pleaseai
 /plugin install workflow@pleaseai
+/plugin install bun@pleaseai
 ```
 
 ## What Are Claude Code Plugins?

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -1,5 +1,7 @@
 # bun
 
+[![tessl](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.tessl.io%2Fv1%2Fbadges%2Fpleaseai%2Fbun)](https://tessl.io/registry/pleaseai/bun)
+
 Version-aware skill for the Bun JavaScript/TypeScript toolkit — runtime, package manager, test runner, and bundler. Ships a single `use-bun` skill that uses the [`ask`](https://github.com/pleaseai/ask) CLI to pin docs and source to the exact Bun version installed in the project.
 
 ## Compatibility


### PR DESCRIPTION
## Summary

Docs-only change adding the tessl registry badge to the bun plugin and registering it in the root marketplace listing.

## Changes

- `plugins/bun/README.md`: added the tessl badge under the title
- `README.md` (root): added a Bun entry to the Built-in Plugins section (with tessl badge, description, install command, source link) and added `/plugin install bun@pleaseai` to the install-commands list

## Notes

- No code or configuration changes — documentation only
- Does not touch CHANGELOG or plugin.json versions (release-please owns those)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the tessl registry badge to the `bun` plugin and lists `bun` in the root marketplace to improve discoverability and show version status. Also updates install commands to include `/plugin install bun@pleaseai` (plus `portless` and `zod`).

<sup>Written for commit 0e7d81ce5b39b86011efae31c14401d48754b365. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

