### PR TITLE
docs: track TD-001..TD-004 tech debt from awesome-copilot-java track

### DIFF
--- a/.please/docs/tracks/tech-debt-tracker.md
+++ b/.please/docs/tracks/tech-debt-tracker.md
@@ -6,6 +6,10 @@
 
 | ID | Source Track | Description | Priority | Created |
 |----|------------|-------------|----------|---------|
+| TD-001 | awesome-copilot-java-20260528 | `bun scripts/cli.ts multi-format` rewrites ALL plugin manifests instead of accepting a `--only <plugin>` filter; forces manual reversion when adding a single plugin | Low | 2026-05-28 |
+| TD-002 | awesome-copilot-java-20260528 | 93 plugins have stale Codex/Antigravity manifests vs Claude source — needs a dedicated `chore(multi-format): re-sync stale runtime manifests` track | Medium | 2026-05-28 |
+| TD-003 | awesome-copilot-java-20260528 | `.claude-plugin/marketplace.json` schema warns on `homepage` and `repository` fields — pre-existing, needs schema reconciliation | Low | 2026-05-28 |
+| TD-004 | awesome-copilot-java-20260528 | No automated upstream-sync for `plugins/java-development/` — manual re-copy required when upstream changes | Low | 2026-05-28 |
 
 ## Resolved
 


### PR DESCRIPTION
## Summary

Add four tech debt entries to the tracker sourced from the `awesome-copilot-java-20260528` track.

## Tech Debt Entries Added

| ID | Priority | Description |
|----|----------|-------------|
| TD-001 | Low | `bun scripts/cli.ts multi-format` rewrites ALL plugin manifests instead of accepting a `--only <plugin>` filter; forces manual reversion when adding a single plugin |
| TD-002 | Medium | 93 plugins have stale Codex/Antigravity manifests vs Claude source — needs a dedicated `chore(multi-format): re-sync stale runtime manifests` track |
| TD-003 | Low | `.claude-plugin/marketplace.json` schema warns on `homepage` and `repository` fields — pre-existing, needs schema reconciliation |
| TD-004 | Low | No automated upstream-sync for `plugins/java-development/` — manual re-copy required when upstream changes |

## Source Track

All entries sourced from: `awesome-copilot-java-20260528` (2026-05-28)

## Changes

- `.please/docs/tracks/tech-debt-tracker.md` — 4 new rows added to the open tech debt table

## Notes

- No code changes; documentation/tracking only
- TD-002 (Medium priority) tracks a follow-up track needed for the 93 stale manifests issue
- `AGENTS.md` and `.claude/worktrees/` left uncommitted — unrelated to this change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added four tech debt entries (TD-001..TD-004) to the tracker from the `awesome-copilot-java-20260528` track. Docs-only; covers missing `--only` filtering in `bun scripts/cli.ts multi-format`, 93 stale manifests, `.claude-plugin/marketplace.json` schema warnings, and no upstream sync for `plugins/java-development/`.

<sup>Written for commit cdddb34b0d907838acc85e059dec6dba087b6d2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

