### PR TITLE
chore: remove pinned sha from posthog and revenuecat marketplace entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -462,8 +462,7 @@
       "category": "monitoring",
       "source": {
         "source": "url",
-        "url": "https://github.com/PostHog/ai-plugin.git",
-        "sha": "f2f37954ecef9f1afce4fa81b6a612454a96c410"
+        "url": "https://github.com/PostHog/ai-plugin.git"
       },
       "homepage": "https://posthog.com/docs/model-context-protocol"
     },
@@ -473,8 +472,7 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/RevenueCat/rc-claude-code-plugin.git",
-        "sha": "af7cb77996aee4e7e3c109c5afec81f716139032"
+        "url": "https://github.com/RevenueCat/rc-claude-code-plugin.git"
       },
       "homepage": "https://www.revenuecat.com"
     },


### PR DESCRIPTION
## Summary

Remove the pinned `sha` fields from the PostHog (`PostHog/ai-plugin`) and RevenueCat (`RevenueCat/rc-claude-code-plugin`) marketplace entries so both plugin sources track the latest commit instead of a fixed SHA.

## Changes

- `.claude-plugin/marketplace.json`: removed `sha` field from `posthog` entry (was `f2f37954ecef9f1afce4fa81b6a612454a96c410`)
- `.claude-plugin/marketplace.json`: removed `sha` field from `revenuecat` entry (was `af7cb77996aee4e7e3c109c5afec81f716139032`)

## Notes

- Uses `chore:` type — no release bump via release-please.
- CHANGELOG and version fields are not touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed pinned `sha` fields for `PostHog/ai-plugin` and `RevenueCat/rc-claude-code-plugin` in `.claude-plugin/marketplace.json`. These marketplace entries now track the latest commit from their repositories.

<sup>Written for commit 7e8d86211768ef9909d1b18de9e3bc1a0b148701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

