### PR TITLE
feat: add modern-web-guidance plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -633,6 +633,18 @@
       "source": "./plugins/bun"
     },
     {
+      "name": "modern-web-guidance",
+      "description": "Keep your coding agent up to date with the latest web best practices from the Google Chrome team",
+      "category": "development",
+      "keywords": ["web", "best-practices", "chrome", "baseline", "css", "performance"],
+      "tags": ["skill", "web"],
+      "source": {
+        "source": "github",
+        "repo": "GoogleChrome/modern-web-guidance"
+      },
+      "homepage": "https://github.com/GoogleChrome/modern-web-guidance"
+    },
+    {
       "name": "java-development",
       "description": "Comprehensive collection of skills for Java development including Spring Boot, Quarkus, testing, documentation, and best practices - imported from github/awesome-copilot",
       "category": "language",


### PR DESCRIPTION
## Summary

Add [GoogleChrome/modern-web-guidance](https://github.com/GoogleChrome/modern-web-guidance) to the marketplace as a GitHub-sourced plugin (per [plugin-marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces#github-repositories)).

The upstream repo already ships a Claude Code plugin manifest (`.claude-plugin/plugin.json`, v0.0.170) with two skills:
- `modern-web-guidance` — latest web platform best practices (Baseline, CSS, performance) from the Chrome team
- `chrome-extensions` — Chrome extension development guidance

## Changes
- Add `modern-web-guidance` entry to `.claude-plugin/marketplace.json` with `github` source

## Validation
- `claude plugin validate .claude-plugin/marketplace.json` passes (warnings are pre-existing)

## Install
```
/plugin install modern-web-guidance@pleaseai
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `modern-web-guidance` to the marketplace as a GitHub-sourced plugin from `GoogleChrome/modern-web-guidance`. This gives coding agents access to current web best practices and Chrome extension guidance.

- **New Features**
  - Marketplace entry with `source: github` pointing to `GoogleChrome/modern-web-guidance`.
  - Exposes `modern-web-guidance` and `chrome-extensions` skills from the upstream repo.

<sup>Written for commit 2c66978e0518c07a27b05d9d18ca224fc812b5fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

