### PR TITLE
feat: add semble plugin for semantic code search

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -413,6 +413,18 @@
       "category": "Tooling"
     },
     {
+      "name": "semble",
+      "source": {
+        "source": "local",
+        "path": "./plugins/semble"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    },
+    {
       "name": "ast-grep",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -383,10 +383,10 @@
     },
     {
       "name": "semble",
-      "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+      "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
       "category": "development",
       "keywords": ["semble", "code-search", "semantic-search", "embeddings", "grep", "codebase"],
-      "tags": ["skill", "search"],
+      "tags": ["mcp", "skill", "search"],
       "source": "./plugins/semble"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -382,6 +382,14 @@
       "source": "./plugins/fetch"
     },
     {
+      "name": "semble",
+      "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+      "category": "development",
+      "keywords": ["semble", "code-search", "semantic-search", "embeddings", "grep", "codebase"],
+      "tags": ["skill", "search"],
+      "source": "./plugins/semble"
+    },
+    {
       "name": "ast-grep",
       "description": "Guide for writing ast-grep rules to perform structural code search and analysis. Use when users need to search codebases using Abstract Syntax Tree (AST) patterns, find specific code structures, or perform complex code queries that go beyond simple text search.",
       "category": "development",

--- a/plugins/semble/.claude-plugin/plugin.json
+++ b/plugins/semble/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semble",
   "version": "0.1.0",
-  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
   "author": {
     "name": "Minish Lab",
     "url": "https://github.com/MinishLab"
@@ -16,5 +16,15 @@
     "embeddings",
     "grep",
     "codebase"
-  ]
+  ],
+  "mcpServers": {
+    "semble": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "semble[mcp]",
+        "semble"
+      ]
+    }
+  }
 }

--- a/plugins/semble/.claude-plugin/plugin.json
+++ b/plugins/semble/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "semble",
+  "version": "0.1.0",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "author": {
+    "name": "Minish Lab",
+    "url": "https://github.com/MinishLab"
+  },
+  "homepage": "https://github.com/MinishLab/semble",
+  "repository": "https://github.com/MinishLab/semble",
+  "license": "MIT",
+  "keywords": [
+    "semble",
+    "code-search",
+    "semantic-search",
+    "embeddings",
+    "grep",
+    "codebase"
+  ]
+}

--- a/plugins/semble/.claude-plugin/plugin.json
+++ b/plugins/semble/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "grep",
     "codebase"
   ],
+  "skills": "./skills/",
   "mcpServers": {
     "semble": {
       "command": "uvx",

--- a/plugins/semble/.codex-plugin/plugin.json
+++ b/plugins/semble/.codex-plugin/plugin.json
@@ -13,6 +13,7 @@
     "developerName": "Minish Lab",
     "category": "Development",
     "capabilities": [
+      "Skill",
       "Tool"
     ],
     "defaultPrompt": [
@@ -31,5 +32,6 @@
     "grep",
     "codebase"
   ],
+  "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/semble/.codex-plugin/plugin.json
+++ b/plugins/semble/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "semble",
+  "version": "0.1.0",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "author": {
+    "name": "Minish Lab",
+    "url": "https://github.com/MinishLab"
+  },
+  "interface": {
+    "displayName": "Semble",
+    "shortDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+    "longDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+    "developerName": "Minish Lab",
+    "category": "Development",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Semble for my current task."
+    ],
+    "websiteURL": "https://github.com/MinishLab/semble"
+  },
+  "homepage": "https://github.com/MinishLab/semble",
+  "repository": "https://github.com/MinishLab/semble",
+  "license": "MIT",
+  "keywords": [
+    "semble",
+    "code-search",
+    "semantic-search",
+    "embeddings",
+    "grep",
+    "codebase"
+  ]
+}

--- a/plugins/semble/.codex-plugin/plugin.json
+++ b/plugins/semble/.codex-plugin/plugin.json
@@ -1,22 +1,22 @@
 {
   "name": "semble",
   "version": "0.1.0",
-  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
   "author": {
     "name": "Minish Lab",
     "url": "https://github.com/MinishLab"
   },
   "interface": {
     "displayName": "Semble",
-    "shortDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
-    "longDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+    "shortDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
+    "longDescription": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
     "developerName": "Minish Lab",
     "category": "Development",
     "capabilities": [
-      "Skill"
+      "Tool"
     ],
     "defaultPrompt": [
-      "Help me use Semble for my current task."
+      "Use Semble for my current task."
     ],
     "websiteURL": "https://github.com/MinishLab/semble"
   },
@@ -30,5 +30,6 @@
     "embeddings",
     "grep",
     "codebase"
-  ]
+  ],
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/semble/.mcp.json
+++ b/plugins/semble/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "semble": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "semble[mcp]",
+        "semble"
+      ]
+    }
+  }
+}

--- a/plugins/semble/README.md
+++ b/plugins/semble/README.md
@@ -1,0 +1,44 @@
+# semble
+
+Semantic code search — find code by description or symbol name instead of grep, powered by the [Semble](https://github.com/MinishLab/semble) CLI.
+
+**Install:** `/plugin install semble@pleaseai`
+
+## What it does
+
+Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and it returns the most relevant chunks ranked by semantic similarity. The index is built and cached automatically on first run and refreshes when files change.
+
+This plugin ships a **skill** (`semble`) that activates automatically when you explore an unfamiliar codebase, search by intent, or ask how a feature works — driving the `semble` CLI for you.
+
+## Requirements
+
+Semble runs via [`uv`](https://docs.astral.sh/uv/) (`uvx`). Install `uv` if `semble` is not already on your `$PATH`:
+
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+No API key is required.
+
+## Usage
+
+Once installed, just ask exploratory questions and the skill will use Semble automatically — for example "where is authentication handled?" or "find the code that retries failed requests".
+
+By default Semble searches code. It can also search documentation (`docs`), config files (`config`), or everything (`all`).
+
+### CLI
+
+The same capabilities are available directly on the command line:
+
+```sh
+semble search "authentication flow" ./my-project
+semble search "save model to disk" --content all
+semble find-related src/auth.py 42 ./my-project
+```
+
+If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place.
+
+## Links
+
+- Repository: https://github.com/MinishLab/semble
+- Installation docs: https://github.com/MinishLab/semble/blob/main/docs/installation.md

--- a/plugins/semble/README.md
+++ b/plugins/semble/README.md
@@ -32,7 +32,15 @@ The MCP tools:
 - `search(query, repo, top_k)` — find relevant code by description or symbol. Pass the project root (or an explicit `https://` git URL) as `repo`.
 - `find_related(file_path, line, repo, top_k)` — given a result location, find semantically similar code elsewhere.
 
-By default Semble indexes code. To also index documentation, config, or all file types, append a content flag to the server args (`--content docs`, `--content config`, or `--content all`).
+### Content scope
+
+By default the MCP server indexes only code files. To also index documentation, config, or everything, append `--content docs`, `--content config`, or `--content all` to the server command.
+
+The plugin bundles the server in code-only mode. To run it with a wider scope, register it manually instead — for example, in Claude Code:
+
+```sh
+claude mcp add semble -s user -- uvx --from "semble[mcp]" semble --content all
+```
 
 ## Links
 

--- a/plugins/semble/README.md
+++ b/plugins/semble/README.md
@@ -1,18 +1,21 @@
 # semble
 
-Semantic code search — find code by description or symbol name instead of grep, powered by the [Semble](https://github.com/MinishLab/semble) CLI.
+Semantic code search — find code by description or symbol name instead of grep, powered by the [Semble](https://github.com/MinishLab/semble) MCP server.
 
 **Install:** `/plugin install semble@pleaseai`
 
 ## What it does
 
-Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and it returns the most relevant chunks ranked by semantic similarity. The index is built and cached automatically on first run and refreshes when files change.
+Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and it returns the most relevant chunks ranked by semantic similarity. The index is built and cached automatically on first use and refreshes when files change.
 
-This plugin ships a **skill** (`semble`) that activates automatically when you explore an unfamiliar codebase, search by intent, or ask how a feature works — driving the `semble` CLI for you.
+This plugin ships:
+
+- An **MCP server** (`semble`) exposing two tools — `search` and `find_related`.
+- A **skill** (`semble`) that activates automatically when you explore an unfamiliar codebase, search by intent, or ask how a feature works — driving the Semble MCP tools for you.
 
 ## Requirements
 
-Semble runs via [`uv`](https://docs.astral.sh/uv/) (`uvx`). Install `uv` if `semble` is not already on your `$PATH`:
+The MCP server runs via [`uv`](https://docs.astral.sh/uv/) (`uvx --from "semble[mcp]" semble`). Install `uv` if it is not already available:
 
 ```sh
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -24,19 +27,12 @@ No API key is required.
 
 Once installed, just ask exploratory questions and the skill will use Semble automatically — for example "where is authentication handled?" or "find the code that retries failed requests".
 
-By default Semble searches code. It can also search documentation (`docs`), config files (`config`), or everything (`all`).
+The MCP tools:
 
-### CLI
+- `search(query, repo, top_k)` — find relevant code by description or symbol. Pass the project root (or an explicit `https://` git URL) as `repo`.
+- `find_related(file_path, line, repo, top_k)` — given a result location, find semantically similar code elsewhere.
 
-The same capabilities are available directly on the command line:
-
-```sh
-semble search "authentication flow" ./my-project
-semble search "save model to disk" --content all
-semble find-related src/auth.py 42 ./my-project
-```
-
-If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place.
+By default Semble indexes code. To also index documentation, config, or all file types, append a content flag to the server args (`--content docs`, `--content config`, or `--content all`).
 
 ## Links
 

--- a/plugins/semble/mcp_config.json
+++ b/plugins/semble/mcp_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "semble": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "semble[mcp]",
+        "semble"
+      ]
+    }
+  }
+}

--- a/plugins/semble/plugin.json
+++ b/plugins/semble/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "semble",
+  "version": "0.1.0",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "author": {
+    "name": "Minish Lab",
+    "url": "https://github.com/MinishLab"
+  },
+  "homepage": "https://github.com/MinishLab/semble",
+  "repository": "https://github.com/MinishLab/semble",
+  "license": "MIT",
+  "keywords": [
+    "semble",
+    "code-search",
+    "semantic-search",
+    "embeddings",
+    "grep",
+    "codebase"
+  ]
+}

--- a/plugins/semble/plugin.json
+++ b/plugins/semble/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semble",
   "version": "0.1.0",
-  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble CLI",
+  "description": "Semantic code search - find code by description or symbol name instead of grep, powered by the Semble MCP server",
   "author": {
     "name": "Minish Lab",
     "url": "https://github.com/MinishLab"

--- a/plugins/semble/skills/semble/SKILL.md
+++ b/plugins/semble/skills/semble/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: semble
-description: Semantic code search using the Semble CLI. Use when exploring an unfamiliar codebase, finding code by what it does rather than exact text, locating an implementation, understanding how a feature works, or discovering related code. Triggers on requests like "where is X handled", "find the code that does Y", "how does Z work", "search the codebase for", or any semantic/exploratory code question where grep's literal matching is a poor fit.
-allowed-tools: Bash, Read
+description: Semantic code search using the Semble MCP server. Use when exploring an unfamiliar codebase, finding code by what it does rather than exact text, locating an implementation, understanding how a feature works, or discovering related code. Triggers on requests like "where is X handled", "find the code that does Y", "how does Z work", "search the codebase for", or any semantic/exploratory code question where grep's literal matching is a poor fit.
+allowed-tools: mcp__semble__search, mcp__semble__find_related, Read
 ---
 
 # Semble - Semantic Code Search
 
-Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and Semble returns the most relevant chunks ranked by semantic similarity. It builds and caches an index automatically on first run and invalidates it when files change.
+Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and Semble returns the most relevant chunks ranked by semantic similarity. It builds and caches an index automatically on first use and refreshes it when files change.
 
-Prefer Semble over Grep/Glob for any exploratory or semantic question. Reserve grep for exhaustive literal matches or confirming an exact string.
+Prefer Semble over Grep/Glob/Read for any exploratory or semantic question. Reserve grep for exhaustive literal matches or confirming an exact string.
 
 ## When to Use
 
@@ -19,45 +19,36 @@ Prefer Semble over Grep/Glob for any exploratory or semantic question. Reserve g
 
 ## How to Use
 
-Run `semble` via `Bash`. If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place (requires [`uv`](https://docs.astral.sh/uv/)).
+This plugin provides the Semble MCP server, which exposes two tools.
 
-### Search by description or symbol
+### `mcp__semble__search`
 
-```bash
-semble search "authentication flow" ./my-project
-semble search "save_pretrained" ./my-project
-semble search "save model to disk" ./my-project --top-k 10
-```
+Find relevant code with a natural-language or code query.
 
-Results are cached automatically on first run and invalidated when files change. `path` defaults to the current directory when omitted; git URLs are accepted.
+- `query` (required) — natural language or code, e.g. `"authentication flow"`, `"save model to disk"`, or a symbol like `save_pretrained`.
+- `repo` (optional) — the project root to index. When working in a local project, pass the absolute project root. For remote code, pass an explicit `https://` git URL. **Never guess or infer URLs.**
+- `top_k` (optional, default 5) — number of results to return.
 
-### Widen the content scope
+The index is built on first use and cached for the session; it refreshes automatically when files change.
 
-By default Semble searches code. Widen the scope when the answer may live elsewhere:
+### `mcp__semble__find_related`
 
-```bash
-semble search "deployment guide" ./my-project --content docs    # documentation and prose
-semble search "database host port" ./my-project --content config # config files (yaml, toml, ...)
-semble search "authentication" ./my-project --content all        # code, docs, and config
-```
+Find code semantically similar to a specific location — use after `search` to explore connected implementations or callers.
 
-### Find related code
-
-Pass a `file_path` and `line` from a prior search result to discover similar implementations:
-
-```bash
-semble find-related src/auth.py 42 ./my-project
-```
+- `file_path` (required) — use the `file_path` from a prior `search` result.
+- `line` (required) — 1-indexed line number from that result.
+- `repo` (optional) — same as above.
+- `top_k` (optional, default 5).
 
 ## Recommended Workflow
 
-1. Start with `semble search` to find relevant chunks; the index is built and cached automatically.
-2. Switch content scope to `docs`, `config`, or `all` when a code-only search misses the target.
-3. Inspect full files (with `Read`) only when a returned chunk lacks enough context.
-4. Use `semble find-related` on a promising result to explore connected implementations.
-5. Fall back to grep only for exhaustive literal matching.
+1. Start with `mcp__semble__search`, passing the project root as `repo`; the index builds and caches automatically.
+2. Inspect full files (with `Read`) only when a returned chunk lacks enough context.
+3. Use `mcp__semble__find_related` on a promising result to explore connected implementations.
+4. Fall back to grep only for exhaustive literal matching.
 
 ## Important Notes
 
-- **`uv` is required** when running via `uvx`. Install `uv` if `semble` is not already on `$PATH`.
-- Indexing happens on first search and is cached; subsequent searches are fast and refresh automatically when files change.
+- The MCP server runs via `uvx --from "semble[mcp]" semble`, so [`uv`](https://docs.astral.sh/uv/) must be installed. No API key is required.
+- The first search in a session indexes the repo (downloads a small embedding model on first ever run); subsequent searches are fast and refresh automatically when files change.
+- Content scope (code vs. docs/config) is fixed at server launch. By default Semble indexes code; append `--content docs`, `--content config`, or `--content all` to the server args to widen it.

--- a/plugins/semble/skills/semble/SKILL.md
+++ b/plugins/semble/skills/semble/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: semble
 description: Semantic code search using the Semble MCP server. Use when exploring an unfamiliar codebase, finding code by what it does rather than exact text, locating an implementation, understanding how a feature works, or discovering related code. Triggers on requests like "where is X handled", "find the code that does Y", "how does Z work", "search the codebase for", or any semantic/exploratory code question where grep's literal matching is a poor fit.
-allowed-tools: mcp__semble__search, mcp__semble__find_related, Read
+allowed-tools: mcp__semble__search, mcp__semble__find_related, Grep, Read
 ---
 
 # Semble - Semantic Code Search

--- a/plugins/semble/skills/semble/SKILL.md
+++ b/plugins/semble/skills/semble/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: semble
+description: Semantic code search using the Semble CLI. Use when exploring an unfamiliar codebase, finding code by what it does rather than exact text, locating an implementation, understanding how a feature works, or discovering related code. Triggers on requests like "where is X handled", "find the code that does Y", "how does Z work", "search the codebase for", or any semantic/exploratory code question where grep's literal matching is a poor fit.
+allowed-tools: Bash, Read
+---
+
+# Semble - Semantic Code Search
+
+Semble finds code by **meaning**, not literal text. Describe what code does (or name a symbol) and Semble returns the most relevant chunks ranked by semantic similarity. It builds and caches an index automatically on first run and invalidates it when files change.
+
+Prefer Semble over Grep/Glob for any exploratory or semantic question. Reserve grep for exhaustive literal matches or confirming an exact string.
+
+## When to Use
+
+- **Exploring an unfamiliar codebase**: "where is authentication handled?", "how does the caching layer work?"
+- **Finding an implementation by intent**: "find the code that retries failed requests" — even when you don't know the function name.
+- **Locating a symbol**: search by an identifier like `save_pretrained` and let Semble surface every relevant usage and definition.
+- **Discovering related code**: given a known file and line, find structurally/semantically similar code elsewhere.
+
+## How to Use
+
+Run `semble` via `Bash`. If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place (requires [`uv`](https://docs.astral.sh/uv/)).
+
+### Search by description or symbol
+
+```bash
+semble search "authentication flow" ./my-project
+semble search "save_pretrained" ./my-project
+semble search "save model to disk" ./my-project --top-k 10
+```
+
+Results are cached automatically on first run and invalidated when files change. `path` defaults to the current directory when omitted; git URLs are accepted.
+
+### Widen the content scope
+
+By default Semble searches code. Widen the scope when the answer may live elsewhere:
+
+```bash
+semble search "deployment guide" ./my-project --content docs    # documentation and prose
+semble search "database host port" ./my-project --content config # config files (yaml, toml, ...)
+semble search "authentication" ./my-project --content all        # code, docs, and config
+```
+
+### Find related code
+
+Pass a `file_path` and `line` from a prior search result to discover similar implementations:
+
+```bash
+semble find-related src/auth.py 42 ./my-project
+```
+
+## Recommended Workflow
+
+1. Start with `semble search` to find relevant chunks; the index is built and cached automatically.
+2. Switch content scope to `docs`, `config`, or `all` when a code-only search misses the target.
+3. Inspect full files (with `Read`) only when a returned chunk lacks enough context.
+4. Use `semble find-related` on a promising result to explore connected implementations.
+5. Fall back to grep only for exhaustive literal matching.
+
+## Important Notes
+
+- **`uv` is required** when running via `uvx`. Install `uv` if `semble` is not already on `$PATH`.
+- Indexing happens on first search and is cached; subsequent searches are fast and refresh automatically when files change.


### PR DESCRIPTION
## Summary

Adds the **semble** plugin to the marketplace — semantic code search that finds code by description or symbol name instead of grep, powered by the [Semble](https://github.com/MinishLab/semble) CLI (run via `uvx`).

The plugin is **skill-only**: per the discussion, the MCP server and agent were dropped. The bundled skill activates on exploratory/semantic code questions ("where is X handled", "how does Y work") and drives the `semble` CLI, with optional `--content docs|config|all` scopes and `semble find-related` lookups.

## Contents

- `plugins/semble/.claude-plugin/plugin.json` — manifest (source of truth, no MCP)
- `plugins/semble/skills/semble/SKILL.md` — semantic-search skill (`Bash`, `Read`)
- `plugins/semble/README.md` — install + usage docs
- `.codex-plugin/plugin.json` + root `plugin.json` — multi-format artifacts (generated via `bun scripts/cli.ts multi-format`)
- Marketplace entries in `.claude-plugin/marketplace.json` and the generated Codex `.agents/plugins/marketplace.json`

## Notes

- Scoped intentionally to semble only. The `multi-format` run also surfaced pre-existing version-sync drift in ~70 unrelated generated manifests; that drift was restored and left out of this PR.
- Requires [`uv`](https://docs.astral.sh/uv/); no API key.

## Validation

- `claude plugin validate plugins/semble` → passed
- `claude plugin validate .claude-plugin/marketplace.json` → passed (warnings are pre-existing, unrelated plugins)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `semble` plugin for semantic code search with a bundled MCP server (via `uvx`) and a skill that calls `mcp__semble__search`/`mcp__semble__find_related` to find code by description or symbol. Defaults to code-only indexing; the README shows `--content` scopes and manual install for wider indexing.

- **New Features**
  - Ships MCP server + skill; the skill uses MCP tools instead of the CLI.
  - Updates marketplace entry under Development with new tags/description.
  - Adds manifests and MCP configs in `plugins/semble`; requires `uv`; no API key.
  - Declares skills path so Codex shows ["Skill", "Tool"]; restores `Grep` in allowed-tools for the documented fallback.

<sup>Written for commit bcf7cb1bc57f816cc8da1449bc984e029034781c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

