### PR TITLE
chore: trim passionfactory plugins and add AGENTS.md symlink

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,24 +35,7 @@
     "vue-lsp@code-intelligence": true,
     "eslint-lsp@code-intelligence": true,
     "skill-creator@claude-plugins-official": true,
-    "backend@passionfactory": false,
-    "bun@passionfactory": true,
-    "context@passionfactory": true,
-    "dev-tools@passionfactory": true,
-    "frontend@passionfactory": true,
-    "genkit@passionfactory": false,
-    "github@passionfactory": true,
-    "graphql@passionfactory": false,
-    "please@passionfactory": true,
-    "review@passionfactory": true,
-    "reflexion@passionfactory": false,
-    "research@passionfactory": true,
-    "standards@passionfactory": true,
-    "testing@passionfactory": true,
-    "tidy-first@passionfactory": true,
-    "vuefire@passionfactory": false,
     "auth-skills@better-auth-agent-skills": false,
-    "claude-md-management@passionfactory": true,
     "nuxt@pleaseai": true,
     "vue@pleaseai": true,
     "turborepo@pleaseai": true,
@@ -65,12 +48,6 @@
     "modern-web-guidance@pleaseai": true
   },
   "extraKnownMarketplaces": {
-    "passionfactory": {
-      "source": {
-        "source": "github",
-        "repo": "chatbot-pf/engineering-standards"
-      }
-    },
     "code-intelligence": {
       "source": {
         "source": "github",

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,12 @@
+# .worktreeinclude — files to copy into an Orca/conductor worktree.
+# .gitignore syntax. Only files that match a pattern AND are gitignored get copied.
+# Claude Code --worktree handles this automatically; external tools (orca) run
+#   bunx @pleaseai/worktreeinclude <source> <target> from the setup hook.
+
+# Root environment variables
+.env
+.env.local
+.env.*.local
+
+# Claude Code local settings (permissions, enabled plugins, etc.)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,22 @@
+# orca.yaml — setup script run when Orca creates a worktree.
+#
+# Orca (a worktree-native IDE for parallel agents) runs scripts.setup when it
+# creates a new worktree. This file is committed, so the whole team shares it.
+#
+# This repo uses bun + .nvmrc (no mise) and git submodules (external-plugins/*),
+# so the setup initializes submodules, copies gitignored local files, then installs.
+#
+# Injected environment variables:
+#   $ORCA_ROOT_PATH     — main checkout (root repo) path; source for copying gitignored local files
+#   $ORCA_WORKTREE_PATH — the newly created worktree path; copy target and setup working directory
+
+scripts:
+  setup: |
+    set -e
+    # 1. Initialize plugin submodules (external-plugins/*) — a fresh worktree has none.
+    git submodule update --init --recursive
+    # 2. Copy gitignored local files (.env, .claude/settings.local.json, ...) from the main checkout.
+    #    Patterns are defined in .worktreeinclude.
+    bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
+    # 3. Install dependencies.
+    bun install


### PR DESCRIPTION
## Summary

Ports [vercel-labs/emulate#91](https://github.com/vercel-labs/emulate/pull/91) (Phase 1 Linear emulator, by @mvanhorn) into this fork's conventions.

The upstream PR targets a different structure (pnpm, `@emulators/*` scope, a `apps/web` docs site, `@emulators/core` as a workspace dep), so it could not be merged directly. The service core was re-homed to match this fork instead.

## What's included

- **New `@pleaseai/emulate-linear` package** under `packages/linear/`
  - bun export condition, `@emulators/core@^0.6.0` + `graphql` deps, `tsgo` type-check
- **Registered `linear`** in the CLI service registry (`packages/emulate`) + dependency wiring
- **Source adapted to fork's core 0.6.0**
  - `Hono` type sourced from `@emulators/core` (no direct `hono` dep)
  - explicit `405` handlers for non-POST `/graphql` (core's router has no `all`)
  - tests converted from `vitest` → `bun:test` using `createServer`
  - lint style aligned (single quotes, multiline `if`, `node:buffer` import)
- **Docs**: `skills/linear/SKILL.md`, package README, and root README entries adapted to fork CLI usage (`bun packages/emulate/dist/index.js --service linear`)

## Excluded from the upstream PR

`apps/web/*` docs site, `pnpm-lock.yaml`, and `emulate.config.example.yaml` — these don't exist in this fork.

## Surface (read-only GraphQL)

`POST /graphql` with schema introspection, PAT auth (`Authorization: <api_key>`), Relay-style pagination, and query resolvers for Issue, Project, Team, User, Organization, Label, and WorkflowState.

## Verification

- ✅ Monorepo `build` (7) · `type-check` (13) · `test` (13, **linear 26 pass**) · `lint`
- ✅ End-to-end: `emulate list` shows linear; service boots and answers GraphQL queries; missing auth returns `401`

Follow-up work: mutations, webhooks, OAuth 2.0, inspector UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `passionfactory` marketplace and plugins from `.claude/settings.json` to trim unused integrations. Added Orca worktree provisioning via `orca.yaml` and `.worktreeinclude`, and created `AGENTS.md` as a symlink to `CLAUDE.md`.

<sup>Written for commit 86b3df71ed03bce62b87714d02b36d85707cf490. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

