### PR TITLE
feat(codegraph): add CodeGraph local code-intelligence plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,6 +17,18 @@
       "category": "Database"
     },
     {
+      "name": "codegraph",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codegraph"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    },
+    {
       "name": "nuxt-ui",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,14 @@
       "source": "./plugins/neo4j"
     },
     {
+      "name": "codegraph",
+      "description": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+      "category": "development",
+      "keywords": ["code-intelligence", "knowledge-graph", "code-navigation", "semantic-search"],
+      "tags": ["mcp", "code-intelligence"],
+      "source": "./plugins/codegraph"
+    },
+    {
       "name": "chrome-devtools-mcp",
       "description": "Control and inspect a live Chrome browser through MCP - automate actions, debug, and analyze performance using Chrome DevTools",
       "category": "browser",

--- a/plugins/codegraph/.claude-plugin/plugin.json
+++ b/plugins/codegraph/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "codegraph",
+  "version": "1.0.1",
+  "description": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+  "author": {
+    "name": "Colby McHenry",
+    "url": "https://github.com/colbymchenry"
+  },
+  "homepage": "https://github.com/colbymchenry/codegraph",
+  "repository": "https://github.com/colbymchenry/codegraph",
+  "license": "MIT",
+  "keywords": ["code-intelligence", "knowledge-graph", "code-navigation", "semantic-search", "local-first"],
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@colbymchenry/codegraph", "serve", "--mcp"]
+    }
+  }
+}

--- a/plugins/codegraph/.codex-plugin/plugin.json
+++ b/plugins/codegraph/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "codegraph",
+  "version": "1.0.1",
+  "description": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+  "author": {
+    "name": "Colby McHenry",
+    "url": "https://github.com/colbymchenry"
+  },
+  "interface": {
+    "displayName": "Codegraph",
+    "shortDescription": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+    "longDescription": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+    "developerName": "Colby McHenry",
+    "category": "Development",
+    "capabilities": [
+      "Tool"
+    ],
+    "defaultPrompt": [
+      "Use Codegraph for my current task."
+    ],
+    "websiteURL": "https://github.com/colbymchenry/codegraph"
+  },
+  "homepage": "https://github.com/colbymchenry/codegraph",
+  "repository": "https://github.com/colbymchenry/codegraph",
+  "license": "MIT",
+  "keywords": [
+    "code-intelligence",
+    "knowledge-graph",
+    "code-navigation",
+    "semantic-search",
+    "local-first"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/codegraph/.mcp.json
+++ b/plugins/codegraph/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@colbymchenry/codegraph",
+        "serve",
+        "--mcp"
+      ]
+    }
+  }
+}

--- a/plugins/codegraph/hooks.json
+++ b/plugins/codegraph/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Inject CodeGraph navigation guidance at session start when the repo is indexed (a .codegraph/ directory exists)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codegraph/hooks/context.sh
+++ b/plugins/codegraph/hooks/context.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Emit CodeGraph navigation guidance ONLY when the current project is indexed
+# (a `.codegraph/` directory exists at the repo root). In an unindexed repo we
+# stay silent — indexing is the user's decision, and an unconditional "this
+# repo is indexed" claim would send subagents into failing codegraph calls.
+#
+# The wording mirrors CodeGraph's own marker-fenced instructions block, which
+# exists because the MCP server's `initialize` instructions reach only the main
+# agent — Task-tool subagents and non-MCP harnesses see this context instead.
+
+if [ ! -d ".codegraph" ]; then
+  exit 0
+fi
+
+cat <<'EOF'
+## CodeGraph
+
+This repository is indexed by CodeGraph (a `.codegraph/` directory exists). Reach for it BEFORE grep/find or reading files when you need to understand or locate code:
+
+- **MCP tools** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them. `codegraph_node` returns one symbol's source + callers, or reads a whole file with line numbers. If the tools are listed but deferred, load them by name via tool search.
+- **Shell** (always works): `codegraph explore "<symbol names or question>"` and `codegraph node <symbol-or-file>` print the same output — useful for subagents or harnesses without an MCP client.
+EOF

--- a/plugins/codegraph/hooks/context.sh
+++ b/plugins/codegraph/hooks/context.sh
@@ -8,7 +8,24 @@
 # exists because the MCP server's `initialize` instructions reach only the main
 # agent — Task-tool subagents and non-MCP harnesses see this context instead.
 
-if [ ! -d ".codegraph" ]; then
+# Locate the indexed root. A SessionStart hook usually runs at the repo root,
+# but if the session starts in a subdirectory (common in monorepos) a bare CWD
+# check would miss a `.codegraph/` at the root. Prefer the git repo root, fall
+# back to an upward walk for `.codegraph/`, then the CWD.
+root="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$root" ]; then
+  dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.codegraph" ]; then
+      root="$dir"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+fi
+: "${root:=$PWD}"
+
+if [ ! -d "$root/.codegraph" ]; then
   exit 0
 fi
 
@@ -18,5 +35,5 @@ cat <<'EOF'
 This repository is indexed by CodeGraph (a `.codegraph/` directory exists). Reach for it BEFORE grep/find or reading files when you need to understand or locate code:
 
 - **MCP tools** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them. `codegraph_node` returns one symbol's source + callers, or reads a whole file with line numbers. If the tools are listed but deferred, load them by name via tool search.
-- **Shell** (always works): `codegraph explore "<symbol names or question>"` and `codegraph node <symbol-or-file>` print the same output — useful for subagents or harnesses without an MCP client.
+- **Shell** (no MCP client needed): `npx -y @colbymchenry/codegraph explore "<symbol names or question>"` and `npx -y @colbymchenry/codegraph node <symbol-or-file>` print the same output — portable even without a global `codegraph` install (drop the `npx -y @colbymchenry/` prefix if the CLI is on your PATH).
 EOF

--- a/plugins/codegraph/hooks/hooks.json
+++ b/plugins/codegraph/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Inject CodeGraph navigation guidance at session start when the repo is indexed (a .codegraph/ directory exists)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codegraph/mcp_config.json
+++ b/plugins/codegraph/mcp_config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@colbymchenry/codegraph",
+        "serve",
+        "--mcp"
+      ]
+    }
+  }
+}

--- a/plugins/codegraph/plugin.json
+++ b/plugins/codegraph/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "codegraph",
+  "version": "1.0.1",
+  "description": "Local-first code intelligence for AI agents (MCP) - query a pre-indexed knowledge graph of symbols, call graphs, and code structure instead of scanning files",
+  "author": {
+    "name": "Colby McHenry",
+    "url": "https://github.com/colbymchenry"
+  },
+  "homepage": "https://github.com/colbymchenry/codegraph",
+  "repository": "https://github.com/colbymchenry/codegraph",
+  "license": "MIT",
+  "keywords": [
+    "code-intelligence",
+    "knowledge-graph",
+    "code-navigation",
+    "semantic-search",
+    "local-first"
+  ]
+}

--- a/plugins/codegraph/skills/codegraph/SKILL.md
+++ b/plugins/codegraph/skills/codegraph/SKILL.md
@@ -39,9 +39,10 @@ you need to understand or locate code:
    `codegraph_callers` / `codegraph_callees`.
 3. Before refactoring or renaming, run `codegraph_impact` to find everything affected.
 4. If the MCP tools are listed but deferred, load them by name via tool search.
-5. **Shell fallback (always works):** `codegraph explore "<symbols or question>"`
-   and `codegraph node <symbol-or-file>` print the same output as the MCP tools —
-   useful for subagents or harnesses without an MCP client.
+5. **Shell fallback (no MCP client needed):** `npx -y @colbymchenry/codegraph explore "<symbols or question>"`
+   and `npx -y @colbymchenry/codegraph node <symbol-or-file>` print the same output as
+   the MCP tools — portable even without a global `codegraph` install (drop the
+   `npx -y @colbymchenry/` prefix if the CLI is on your PATH).
 6. If a tool response shows a `⚠️` staleness banner naming a file, `Read` that file
    directly for live content — it was edited within the sync debounce window.
 

--- a/plugins/codegraph/skills/codegraph/SKILL.md
+++ b/plugins/codegraph/skills/codegraph/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: Navigating Codebases with CodeGraph
+description: Query a pre-indexed knowledge graph of a codebase (symbols, call graphs, dependencies, impact) instead of scanning files with grep/glob/Read. Use when exploring an unfamiliar codebase, tracing who calls or is called by a function, assessing the blast radius of a change, finding where a symbol is defined or used, or answering architecture questions. Triggers on mentions of code navigation, call graph, callers, callees, impact analysis, symbol search, or understanding code structure.
+allowed-tools: mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_explore, mcp__codegraph__codegraph_callers, mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_node, mcp__codegraph__codegraph_status, mcp__codegraph__codegraph_files
+---
+
+# CodeGraph - Local Code Intelligence
+
+CodeGraph gives you a pre-indexed knowledge graph of the current project — symbol
+relationships, call graphs, and code structure — so you can answer questions
+instantly instead of consuming tokens scanning files with grep, glob, and Read.
+
+## When to Use
+
+**First check:** CodeGraph applies only in repositories it has indexed — a
+`.codegraph/` directory exists at the repo root. If there is no `.codegraph/`
+directory, skip CodeGraph entirely; indexing is the user's decision (suggest
+`codegraph init` only if they want it).
+
+In an indexed repo, reach for CodeGraph **before** grep/find or reading files when
+you need to understand or locate code:
+
+- **Explore / answer most code questions** in one call → `codegraph_explore`
+  (returns the relevant symbols' verbatim source plus the call paths between them)
+- **Inspect one symbol** (source + callers) or read a whole file with line numbers
+  → `codegraph_node`
+- **Search** for a symbol, type, or concept by name/intent → `codegraph_search`
+- **Trace callers** — who invokes this function/method? → `codegraph_callers`
+- **Trace callees** — what does this function call? → `codegraph_callees`
+- **Assess impact / blast radius** of changing a symbol → `codegraph_impact`
+- **List indexed files** in the project → `codegraph_files`
+- **Check index health / freshness** → `codegraph_status`
+
+## How to Use
+
+1. For broad questions ("how does X work?", "where is auth handled?"), start with
+   `codegraph_explore` — it answers most code questions in a single call.
+2. To navigate relationships from a known symbol, use `codegraph_node`, then
+   `codegraph_callers` / `codegraph_callees`.
+3. Before refactoring or renaming, run `codegraph_impact` to find everything affected.
+4. If the MCP tools are listed but deferred, load them by name via tool search.
+5. **Shell fallback (always works):** `codegraph explore "<symbols or question>"`
+   and `codegraph node <symbol-or-file>` print the same output as the MCP tools —
+   useful for subagents or harnesses without an MCP client.
+6. If a tool response shows a `⚠️` staleness banner naming a file, `Read` that file
+   directly for live content — it was edited within the sync debounce window.
+
+## Important Notes
+
+- **Indexing is per-project**, signalled by the `.codegraph/` directory. No
+  `.codegraph/` → don't call CodeGraph tools.
+- **100% local.** No code leaves the machine; the server bundles its own runtime.
+- The index auto-syncs on file changes via a native file watcher, so results stay
+  current as the codebase evolves.


### PR DESCRIPTION
## Summary

Adds the **codegraph** plugin wrapping [@colbymchenry/codegraph](https://github.com/colbymchenry/codegraph) — a local-first MCP server that exposes a pre-indexed knowledge graph (symbols, call graphs, impact) so agents query code structure instead of scanning files with grep/glob/Read.

Requested in the linked task: `https://github.com/colbymchenry/codegraph`.

## What's included

- **MCP server** — `codegraph` via `npx -y @colbymchenry/codegraph serve --mcp` (self-contained; no global install required, matching the marketplace's npx convention)
- **Skill** (`skills/codegraph/SKILL.md`) — intelligent activation; `allowed-tools` covers all 8 `mcp__codegraph__*` tools (exactly the auto-allow list the upstream installer writes)
- **Conditional SessionStart hook** (`hooks/`) — injects navigation guidance **only when the repo is indexed** (a `.codegraph/` directory exists). Mirrors CodeGraph's own `instructions-template.ts`, which stays silent in unindexed repos so subagents don't fire failing calls
- **Codex + Antigravity manifests** — generated via `bun scripts/cli.ts multi-format`
- **Marketplace entries** — Claude (`.claude-plugin/marketplace.json`) + Codex (`.agents/plugins/marketplace.json`)

## Why both a Skill and a hook

Upstream's `instructions-template.ts` documents that the MCP `initialize` instructions reach only the *main* agent — a Skill has the same limitation. The hook injects the `codegraph_explore`/`codegraph_node` pointers into Task-tool subagents and non-MCP harnesses too, closing the exact gap CodeGraph's CLAUDE.md block (#704) was reintroduced to address.

## Validation

- `claude plugin validate plugins/codegraph` → ✔ passed
- Hook tested: silent in unindexed dirs, emits guidance when `.codegraph/` present
- Diff scoped to codegraph only — no unrelated plugin drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `codegraph` local code-intelligence plugin powered by `@colbymchenry/codegraph`. Lets agents query a pre-indexed knowledge graph (symbols, call graphs, impact) instead of scanning files.

- **New Features**
  - MCP server via `npx -y @colbymchenry/codegraph serve --mcp` (no global install)
  - Skill with all 8 `mcp__codegraph__*` tools for smart activation
  - SessionStart hook that adds navigation tips only when `.codegraph/` exists
  - Claude and Codex manifests, plus marketplace entries under Development

- **Bug Fixes**
  - SessionStart hook now detects `.codegraph/` at the repo root even when starting in subdirectories (git root or upward walk), so guidance shows in monorepos
  - Updated shell fallback in the hook and Skill to `npx -y @colbymchenry/codegraph` for portability

<sup>Written for commit bf1b5295a20a7987dbe7a1603ead9a59abccca6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

