### PR TITLE
feat: add port.io internal developer portal plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -509,6 +509,18 @@
       "category": "Development"
     },
     {
+      "name": "port",
+      "source": {
+        "source": "local",
+        "path": "./plugins/port"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tooling"
+    },
+    {
       "name": "portone",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -435,6 +435,15 @@
       "source": "./plugins/tosspayments"
     },
     {
+      "name": "port",
+      "description": "Port.io Internal Developer Portal integration. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps requests — via the Port MCP server. Supports US and EU regions.",
+      "category": "tooling",
+      "keywords": ["port", "port.io", "idp", "internal-developer-portal", "platform-engineering", "sdlc", "devops", "scorecards"],
+      "tags": ["mcp", "platform"],
+      "source": "./plugins/port",
+      "homepage": "https://www.port.io"
+    },
+    {
       "name": "portone",
       "description": "포트원(PortOne) 결제 연동 코드 생성 및 검토 플러그인. V1/V2 API를 지원하며, MCP 서버를 통해 최신 문서와 예시 코드를 활용합니다.",
       "category": "development",

--- a/plugins/port/.claude-plugin/plugin.json
+++ b/plugins/port/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "port",
+  "version": "1.0.0",
+  "description": "Port.io Internal Developer Portal integration. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps requests — via the Port MCP server. Supports both US and EU regions.",
+  "author": {
+    "name": "Port",
+    "url": "https://www.port.io"
+  },
+  "homepage": "https://www.port.io",
+  "repository": "https://github.com/port-labs/port-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "port",
+    "port.io",
+    "idp",
+    "internal-developer-portal",
+    "platform-engineering",
+    "sdlc",
+    "devops",
+    "scorecards",
+    "mcp"
+  ],
+  "mcpServers": {
+    "port-us": {
+      "type": "http",
+      "url": "https://mcp.us.port.io/v1"
+    },
+    "port-eu": {
+      "type": "http",
+      "url": "https://mcp.port.io/v1"
+    }
+  }
+}

--- a/plugins/port/.codex-plugin/plugin.json
+++ b/plugins/port/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "port",
+  "version": "1.0.0",
+  "description": "Port.io Internal Developer Portal integration. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps requests — via the Port MCP server. Supports both US and EU regions.",
+  "author": {
+    "name": "Port",
+    "url": "https://www.port.io"
+  },
+  "interface": {
+    "displayName": "Port",
+    "shortDescription": "Port.io Internal Developer Portal integration",
+    "longDescription": "Port.io Internal Developer Portal integration. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps requests — via the Port MCP server. Supports both US and EU regions.",
+    "developerName": "Port",
+    "category": "Tooling",
+    "capabilities": [
+      "Tool"
+    ],
+    "defaultPrompt": [
+      "Use Port for my current task."
+    ],
+    "websiteURL": "https://www.port.io"
+  },
+  "homepage": "https://www.port.io",
+  "repository": "https://github.com/port-labs/port-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "port",
+    "port.io",
+    "idp",
+    "internal-developer-portal",
+    "platform-engineering",
+    "sdlc",
+    "devops",
+    "scorecards",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/port/.mcp.json
+++ b/plugins/port/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "port-us": {
+      "type": "http",
+      "url": "https://mcp.us.port.io/v1"
+    },
+    "port-eu": {
+      "type": "http",
+      "url": "https://mcp.port.io/v1"
+    }
+  }
+}

--- a/plugins/port/README.md
+++ b/plugins/port/README.md
@@ -1,0 +1,46 @@
+# Port Plugin
+
+[Port.io](https://www.port.io) Internal Developer Portal integration for Claude Code. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps/platform requests — directly from Claude through the Port MCP server.
+
+## Regions
+
+Port operates in two regions. This plugin configures both as separate MCP servers; use the one that matches your Port account:
+
+| Region | MCP server | Endpoint |
+|--------|------------|----------|
+| US     | `port-us`  | `https://mcp.us.port.io/v1` |
+| EU     | `port-eu`  | `https://mcp.port.io/v1` |
+
+## Installation
+
+```sh
+claude
+/plugin marketplace add pleaseai/claude-code-plugins
+/plugin install port@pleaseai
+```
+
+## Authentication
+
+The Port MCP server uses OAuth. After installing, run `/mcp` and complete the
+authentication flow for your region (`port-us` or `port-eu`). No API key
+environment variable is required.
+
+If you only use one region, you can disable the unused MCP server from the
+`/plugin` menu.
+
+## Capabilities
+
+- **Software catalog**: list blueprints and entities, explore services, owners, and dependencies.
+- **Scorecards**: inspect scorecard rules and levels, and see which entities pass or fail.
+- **Self-service actions**: list, run, and track Port self-service actions.
+- **Org knowledge**: answer questions about your software using Port's knowledge sources.
+- **Portal config**: inspect the sidebar and manage dashboard folders and widgets.
+
+A bundled skill (`Port Internal Developer Portal`) activates these tools
+automatically when you ask about your developer portal, scorecards, catalog, or
+self-service actions.
+
+## Links
+
+- Website: https://www.port.io
+- Port MCP server: https://github.com/port-labs/port-mcp-server

--- a/plugins/port/mcp_config.json
+++ b/plugins/port/mcp_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "port-us": {
+      "type": "http",
+      "url": "https://mcp.us.port.io/v1"
+    },
+    "port-eu": {
+      "type": "http",
+      "url": "https://mcp.port.io/v1"
+    }
+  }
+}

--- a/plugins/port/plugin.json
+++ b/plugins/port/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "port",
+  "version": "1.0.0",
+  "description": "Port.io Internal Developer Portal integration. Manage your entire SDLC — blueprints, entities, scorecards, self-service actions, incidents, and DevOps requests — via the Port MCP server. Supports both US and EU regions.",
+  "author": {
+    "name": "Port",
+    "url": "https://www.port.io"
+  },
+  "homepage": "https://www.port.io",
+  "repository": "https://github.com/port-labs/port-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "port",
+    "port.io",
+    "idp",
+    "internal-developer-portal",
+    "platform-engineering",
+    "sdlc",
+    "devops",
+    "scorecards",
+    "mcp"
+  ]
+}

--- a/plugins/port/skills/port/SKILL.md
+++ b/plugins/port/skills/port/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: Port Internal Developer Portal
+description: Query and operate Port.io — the Internal Developer Portal that governs your SDLC. Use when working with software catalogs, blueprints, entities, scorecards, self-service actions, incidents, or DevOps/platform requests. Triggers on mentions of Port, port.io, IDP, developer portal, scorecards, blueprints, service catalog, or self-service actions.
+allowed-tools: mcp__port-us__list_blueprints, mcp__port-us__list_entities, mcp__port-us__list_actions, mcp__port-us__list_scorecards, mcp__port-us__run_action, mcp__port-us__track_action_run, mcp__port-us__describe_user_details, mcp__port-us__search_port_knowledge_sources, mcp__port-us__get_sidebar, mcp__port-us__load_skill, mcp__port-eu__list_blueprints, mcp__port-eu__list_entities, mcp__port-eu__list_actions, mcp__port-eu__list_scorecards, mcp__port-eu__run_action, mcp__port-eu__track_action_run, mcp__port-eu__describe_user_details, mcp__port-eu__search_port_knowledge_sources, mcp__port-eu__get_sidebar, mcp__port-eu__load_skill
+---
+
+# Port Internal Developer Portal
+
+Use the Port MCP tools automatically when the user works with their Internal Developer Portal — the software catalog, scorecards, self-service actions, or any SDLC governance task on Port.io.
+
+## Regions
+
+Port operates in two regions, exposed as two MCP servers in this plugin:
+
+| Region | MCP server | Endpoint |
+|--------|------------|----------|
+| US     | `port-us`  | `https://mcp.us.port.io/v1` |
+| EU     | `port-eu`  | `https://mcp.port.io/v1` |
+
+Use **one** region — whichever matches the user's Port account. If unsure which region they are on, call `describe_user_details` on each and use the one that authenticates, or ask. Do not duplicate calls across both regions.
+
+## When to Use
+
+- **Catalog discovery**: list blueprints/entities, find services, owners, dependencies.
+- **Scorecards & quality**: check scorecard rules, levels, and which entities pass/fail.
+- **Self-service**: list and run self-service actions, then track their run status.
+- **Knowledge**: answer questions about the org's software using `search_port_knowledge_sources`.
+- **Portal config**: inspect the sidebar, manage folders and dashboard widgets.
+
+## How to Use
+
+1. Start with `describe_user_details` to confirm the active org/region when context is missing.
+2. Use `list_blueprints` → `list_entities` to explore the catalog before answering catalog questions.
+3. Use `list_scorecards` for quality/compliance questions.
+4. For self-service: `list_actions` to find the action, `run_action` to execute, then `track_action_run` to monitor until completion. Confirm with the user before running any action that creates or changes infrastructure.
+5. For org-knowledge questions, prefer `search_port_knowledge_sources` over guessing.
+
+## Important Notes
+
+- Authentication is handled by the Port MCP server's OAuth flow (`/mcp` to connect). No API key env var is required.
+- `run_action` may trigger real infrastructure changes — treat it as a write operation and confirm intent first.
+- Some MCP servers expose additional capabilities via `load_skill`; call it to discover Port-specific guided workflows when available.


### PR DESCRIPTION
## Summary

Adds a new built-in plugin for [Port.io](https://getport.io), an Internal Developer Portal (IDP) platform that centralises SDLC visibility — pull requests, incidents, deployments, Jira tasks, and DevOps/Platform requests.

## What the Plugin Does

- Connects Claude Code to Port.io's MCP API for natural-language queries against your organisation's software catalog, service scorecards, and developer workflows.
- Supports two regional endpoints so teams can stay within their data residency zone.

## Regional MCP Endpoints

| Region | Endpoint |
|--------|----------|
| US | `https://mcp.us.port.io/v1` |
| EU | `https://mcp.port.io/v1` |

Both are configured as remote HTTP MCP servers (`port-us` and `port-eu`) in `plugin.json`.

## Authentication

OAuth-based — no API key needed. Users authenticate through Port.io's standard OAuth flow.

## Bundled Skill

`skills/port/SKILL.md` enables intelligent activation: Claude loads the Port.io context only when the conversation is relevant (IDP queries, service catalog lookups, scorecard checks, etc.), avoiding unnecessary token usage on unrelated tasks.

## Marketplace Registration

- Added `port` entry to `.claude-plugin/marketplace.json` (Claude Code marketplace)
- Regenerated `.agents/plugins/marketplace.json` (Codex marketplace)
- Multi-runtime manifests generated: `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, root `plugin.json` + `mcp_config.json` (Antigravity)

## Files Changed

- `plugins/port/` — entire new plugin directory
- `.claude-plugin/marketplace.json` — new marketplace entry
- `.agents/plugins/marketplace.json` — regenerated Codex marketplace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `port` plugin that integrates Port.io’s Internal Developer Portal via MCP, enabling catalog, scorecard, and self-service actions from Claude Code. Supports US and EU regions, uses OAuth, and includes a bundled skill for smart activation.

- **New Features**
  - New `plugins/port/` with HTTP MCP servers: `port-us` and `port-eu`.
  - OAuth authentication; no API key needed.
  - Bundled skill (`skills/port/SKILL.md`) to auto-load Port context when relevant.
  - Registered in `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`.

- **Migration**
  - Install `port` from the marketplace, then choose `port-us` or `port-eu` based on your Port account.
  - Run `/mcp` to complete OAuth sign-in and optionally disable the unused region.

<sup>Written for commit 83a0cf061dd91a6326c31f950cfb9854cf7193ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

