### PR TITLE
feat(tsdown): add tsdown-migrate skill for tsup migration

### DIFF
--- a/plugins/tsdown/.agents/skills/tsdown-migrate/README.md
+++ b/plugins/tsdown/.agents/skills/tsdown-migrate/README.md
@@ -1,0 +1,69 @@
+# tsdown-migrate Skill
+
+Agent skill that teaches AI coding agents how to migrate projects from [tsup](https://tsup.egoist.dev/) to [tsdown](https://tsdown.dev).
+
+## Installation
+
+This skill is included when you install the tsdown skills:
+
+```bash
+npx skills add rolldown/tsdown
+```
+
+Or install it separately:
+
+```bash
+npx skills add rolldown/tsdown --skill tsdown-migrate
+```
+
+## What's Included
+
+This skill provides AI agents with complete knowledge to perform tsup→tsdown migrations:
+
+- **Option Mappings** - Every tsup option and its tsdown equivalent
+- **Config Transformations** - File renames, import changes, value transforms
+- **Default Differences** - What changed between tsup and tsdown defaults
+- **Unsupported Options** - What to remove and what alternatives exist
+- **Package.json Migration** - Dependency, script, and config field changes
+- **New Features** - tsdown-exclusive features to suggest after migration
+
+## Usage
+
+Once installed, AI agents will use this knowledge when:
+
+- Migrating tsup projects to tsdown
+- Explaining differences between tsup and tsdown
+- Troubleshooting post-migration build issues
+- Advising on tsdown configuration after migration
+
+### Example Prompts
+
+```
+Migrate my tsup project to tsdown
+```
+
+```
+What are the differences between tsup and tsdown options?
+```
+
+```
+Convert my tsup.config.ts to tsdown format
+```
+
+```
+My build broke after migrating from tsup — help me fix it
+```
+
+## Documentation
+
+- [tsdown Documentation](https://tsdown.dev)
+- [Migration Guide](https://tsdown.dev/guide/migrate-from-tsup)
+- [GitHub Repository](https://github.com/rolldown/tsdown)
+
+## Related Skills
+
+- [tsdown](https://github.com/rolldown/tsdown/tree/main/skills/tsdown) - Core tsdown skill for building and configuring TypeScript libraries
+
+## License
+
+MIT

--- a/plugins/tsdown/.agents/skills/tsdown-migrate/SKILL.md
+++ b/plugins/tsdown/.agents/skills/tsdown-migrate/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: tsdown-migrate
+description: Migrate TypeScript library projects from tsup to tsdown. Provides complete option mappings, config transformation rules, default value differences, and unsupported option alternatives so AI agents can intelligently perform migrations.
+---
+
+# Migrating from tsup to tsdown
+
+Knowledge base for AI agents to migrate tsup projects to tsdown — the Rolldown-powered library bundler.
+
+## Runtime Requirement
+
+`tsdown` requires **Node.js 22.18.0 or higher to run** (build-time only). The bundled output can still target lower Node.js versions via the [`target`](../tsdown/references/option-target.md) option, so a library that previously supported Node.js 18 / 20 with tsup can continue to do so after migrating.
+
+Recommended workflow when supporting Node.js 18 / 20:
+
+- **Build with Node.js 22+ in CI**, setting an explicit `target` such as `'node18'` or `'node20'`.
+- **Test the built output (or the packed tarball) on the lower Node.js versions** you need to support.
+
+## When to Use
+
+- Migrating a project from tsup to tsdown
+- Understanding differences between tsup and tsdown options
+- Reviewing or fixing post-migration configuration issues
+- Advising users on tsup→tsdown compatibility
+
+## Migration Overview
+
+Follow these steps to migrate a tsup project:
+
+1. **Rename config file**: `tsup.config.*` → `tsdown.config.*`
+2. **Update imports**: `'tsup'` → `'tsdown'`
+3. **Apply option mappings**: Rename/transform options per tables below
+4. **Preserve tsup defaults**: Explicitly set options that differ (format, clean, dts, target)
+5. **Update package.json**: Dependencies, scripts, root config field
+6. **Remove unsupported options**: Replace with alternatives where available
+7. **Test build**: Run `tsdown` and verify output
+
+## Config File Migration
+
+### File Rename
+
+| tsup | tsdown |
+|------|--------|
+| `tsup.config.ts` | `tsdown.config.ts` |
+| `tsup.config.cts` | `tsdown.config.cts` |
+| `tsup.config.mts` | `tsdown.config.mts` |
+| `tsup.config.js` | `tsdown.config.js` |
+| `tsup.config.cjs` | `tsdown.config.cjs` |
+| `tsup.config.mjs` | `tsdown.config.mjs` |
+| `tsup.config.json` | `tsdown.config.json` |
+
+### Import and Identifier Changes
+
+```ts
+// Before
+import { defineConfig } from 'tsup'
+
+// After
+import { defineConfig } from 'tsdown'
+```
+
+Replace all identifiers: `tsup` → `tsdown`, `TSUP` → `TSDOWN`.
+
+## Option Mappings
+
+### Property Renames
+
+| tsup | tsdown | Notes |
+|------|--------|-------|
+| `cjsInterop` | `cjsDefault` | CJS default export handling |
+| `esbuildPlugins` | `plugins` | Now uses Rolldown/Unplugin plugins |
+| `outExtension` | `outExtensions` | Custom output extensions |
+
+### Deprecated but Compatible
+
+These tsup options still work in tsdown for backward compatibility, but emit deprecation warnings and **will be removed in a future version**. Migrate them immediately.
+
+| tsup (deprecated) | tsdown (preferred) | Notes |
+|--------------------|--------------------|-------|
+| `entryPoints` | `entry` | Also deprecated in tsup itself |
+| `publicDir` | `copy` | Copy static files to output |
+| `bundle: true` | _(remove)_ | Bundle is default behavior |
+| `bundle: false` | `unbundle: true` | Preserve file structure |
+| `removeNodeProtocol: true` | `nodeProtocol: 'strip'` | Strip `node:` prefix |
+| `injectStyle: true` | `css: { inject: true }` | CSS injection |
+| `injectStyle: false` | _(remove)_ | Default behavior |
+| `external: [...]` | `deps: { neverBundle: [...] }` | Moved to deps namespace |
+| `noExternal: [...]` | `deps: { alwaysBundle: [...] }` | Moved to deps namespace |
+| `skipNodeModulesBundle` | `deps: { skipNodeModulesBundle: true }` | Moved to deps namespace |
+
+### Output Filename Differences
+
+For IIFE builds, `tsdown` emits names like `[name].iife.js`, while `tsup` commonly emitted `[name].global.js`. `outExtensions` customizes extensions or suffixes, but it does not remove the built-in `.iife` or `.umd` segment. Use `outputOptions.entryFileNames: '[name].global.js'` to preserve old IIFE filenames.
+
+### Dependency Namespace Moves
+
+Dependencies config moved under `deps` namespace. If both `external` and `noExternal` exist, merge into a single `deps` object:
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react'],
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+tsdown also adds `deps.onlyBundle` (whitelist of allowed bundled packages) — no tsup equivalent.
+
+### Plugin Import Transforms
+
+```ts
+// Before (tsup - esbuild plugins)
+import plugin from 'unplugin-example/esbuild'
+
+// After (tsdown - Rolldown plugins)
+import plugin from 'unplugin-example/rolldown'
+```
+
+All `unplugin-*/esbuild` imports should change to `unplugin-*/rolldown`.
+
+For complete before/after examples of every transformation, see [guide-option-mappings.md](references/guide-option-mappings.md).
+
+## Default Value Differences
+
+tsdown changes several defaults from tsup. When migrating, explicitly set these to preserve tsup behavior, then let the user decide which new defaults to adopt.
+
+| Option | tsup Default | tsdown Default | Migration Action |
+|--------|-------------|----------------|-----------------|
+| `format` | `'cjs'` | `'esm'` | Set `format: 'cjs'` to preserve |
+| `clean` | `false` | `true` | Set `clean: false` to preserve |
+| `dts` | `false` | Auto-enabled if `types`/`typings` in package.json | Set `dts: false` to preserve |
+| `target` | _(none)_ | Auto-reads from `engines.node` in package.json | Set `target: false` to preserve |
+
+After migration, suggest the user review these — tsdown's defaults are generally better:
+- ESM is the modern standard
+- Cleaning output prevents stale files
+- Auto DTS from package.json reduces config
+- Auto target from engines.node ensures consistency
+
+## Unsupported Options
+
+These tsup options have no direct equivalent in tsdown. Remove them and inform the user.
+
+| tsup Option | Status | Alternative |
+|-------------|--------|-------------|
+| `splitting` | Always enabled | Remove — code splitting cannot be disabled in tsdown |
+| `metafile` | Not available | Suggest `devtools: true` for Vite DevTools bundle analysis |
+| `swc` | Not supported | Remove — tsdown uses oxc for transformation (built-in) |
+| `experimentalDts` | Not supported | Use the `dts` option instead |
+| `legacyOutput` | Not supported | Remove — no alternative |
+| `plugins` (tsup experimental) | Incompatible | Migrate to Rolldown plugins manually; tsup's plugin API differs from Rolldown's |
+
+## Package.json Migration
+
+### Scripts
+
+Replace `tsup` and `tsup-node` with `tsdown` in all script commands:
+
+```json
+// Before
+{
+  "scripts": {
+    "build": "tsup src/index.ts",
+    "dev": "tsup --watch"
+  }
+}
+
+// After
+{
+  "scripts": {
+    "build": "tsdown src/index.ts",
+    "dev": "tsdown --watch"
+  }
+}
+```
+
+### Dependencies
+
+| Location | Action |
+|----------|--------|
+| `dependencies.tsup` | Rename to `dependencies.tsdown` |
+| `devDependencies.tsup` | Rename to `devDependencies.tsdown` |
+| `optionalDependencies.tsup` | Rename to `optionalDependencies.tsdown` |
+| `peerDependencies.tsup` | Rename to `peerDependencies.tsdown` |
+| `peerDependenciesMeta.tsup` | Rename to `peerDependenciesMeta.tsdown` |
+
+### Root Config Field
+
+If package.json has a root-level `tsup` field (inline config), rename to `tsdown`:
+
+```json
+// Before
+{ "tsup": { "entry": ["src/index.ts"] } }
+
+// After
+{ "tsdown": { "entry": ["src/index.ts"] } }
+```
+
+For detailed package.json examples, see [guide-package-json.md](references/guide-package-json.md).
+
+## New tsdown Features
+
+After migration, suggest these tsdown-exclusive features to the user:
+
+| Feature | Config | Description |
+|---------|--------|-------------|
+| Node protocol | `nodeProtocol: true \| 'strip'` | Add or strip `node:` prefix on built-in imports |
+| Workspace | `workspace: 'packages/*'` | Build multiple packages in a monorepo |
+| Package exports | `exports: true` | Auto-generate `exports` field in package.json |
+| Package validation | `publint: true`, `attw: true` | Lint package and check type correctness |
+| Executable | `exe: true` | Bundle as Node.js standalone executable (SEA) |
+| DevTools | `devtools: true` | Vite DevTools integration for bundle analysis |
+| Hooks | `hooks: { 'build:done': ... }` | Lifecycle hooks: `build:prepare`, `build:before`, `build:done` |
+| CSS modules | `css: { modules: { ... } }` | Scoped class names for `.module.css` files |
+| Glob import | `globImport: true` | Support `import.meta.glob` (Vite-style) |
+
+For detailed comparisons, see [guide-differences-detailed.md](references/guide-differences-detailed.md).
+
+## References
+
+| Topic | Description | Reference |
+|-------|-------------|-----------|
+| Option Mappings | Complete before/after for every option transform | [guide-option-mappings](references/guide-option-mappings.md) |
+| Detailed Differences | Architecture, features, compatibility comparison | [guide-differences-detailed](references/guide-differences-detailed.md) |
+| Package.json | Dependency, script, and config field migration | [guide-package-json](references/guide-package-json.md) |
+
+## Migration Checklist
+
+Use this checklist when performing a migration:
+
+```
+- [ ] Rename tsup.config.* → tsdown.config.*
+- [ ] Update import from 'tsup' to 'tsdown'
+- [ ] Replace tsup/TSUP identifiers with tsdown/TSDOWN
+- [ ] Apply property renames (cjsInterop→cjsDefault, esbuildPlugins→plugins, outExtension→outExtensions)
+- [ ] Migrate deprecated options (publicDir→copy, bundle→unbundle, removeNodeProtocol→nodeProtocol, injectStyle→css.inject)
+- [ ] Move external/noExternal/skipNodeModulesBundle into deps namespace
+- [ ] Update unplugin imports from /esbuild to /rolldown
+- [ ] Set explicit defaults to preserve tsup behavior (format, clean, dts, target)
+- [ ] Remove unsupported options (splitting, metafile, swc, etc.)
+- [ ] Update package.json scripts (tsup→tsdown)
+- [ ] Update package.json dependencies
+- [ ] Rename root-level tsup config field if present
+- [ ] Run tsdown and verify build output
+- [ ] Suggest new tsdown features to the user
+```

--- a/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-differences-detailed.md
+++ b/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-differences-detailed.md
@@ -1,0 +1,169 @@
+# Detailed Differences: tsdown vs tsup
+
+Comprehensive comparison of tsdown and tsup for understanding migration impact and new capabilities.
+
+## Architecture
+
+| Aspect | tsup | tsdown |
+|--------|------|--------|
+| Core bundler | esbuild (Go) | Rolldown (Rust) |
+| Plugin system | esbuild plugins | Rolldown + Rollup + Unplugin plugins |
+| Type declarations | Single pass | Dual-format with separate CJS dts pass |
+| Package.json integration | Basic | Advanced (auto-exports, validation) |
+| Watch mode | Standard | Enhanced with keyboard shortcuts (`r` rebuild, `q` quit) |
+| Module system | CJS-first | ESM-first |
+
+## Default Value Comparison
+
+| Option | tsup | tsdown | Impact |
+|--------|------|--------|--------|
+| `format` | `'cjs'` | `'esm'` | Output format changes — set explicitly during migration |
+| `clean` | `false` | `true` | Output dir cleaned before build — may surprise users |
+| `dts` | `false` | Auto if `types`/`typings` in package.json | Types generated automatically — usually desired |
+| `target` | _(none)_ | Reads `engines.node` from package.json | Compilation target auto-detected — usually desired |
+
+## Feature Compatibility
+
+### Fully Supported (works the same)
+
+- Multiple entry points (array, object, globs)
+- Multiple formats (ESM, CJS, IIFE, UMD)
+- TypeScript declarations (`dts`)
+- Source maps
+- Minification
+- Watch mode
+- Tree shaking
+- Shims (`__dirname`, `__filename`, `require`)
+- Clean output directory
+- Define (global constants)
+- Banner/footer injection
+- `onSuccess` callback
+
+### Supported with Changes (Renamed)
+
+| Feature | tsup | tsdown | Change |
+|---------|------|--------|--------|
+| CJS interop | `cjsInterop` | `cjsDefault` | Property rename |
+| Plugins | `esbuildPlugins` | `plugins` | Different plugin format (Rolldown) |
+| Output extensions | `outExtension` | `outExtensions` | Property rename |
+
+### Deprecated but Compatible
+
+These tsup options still work in tsdown but emit deprecation warnings. They will be removed in a future version — migrate immediately.
+
+| Feature | tsup (deprecated) | tsdown (preferred) | Change |
+|---------|-------------------|--------------------|--------|
+| Entry points | `entryPoints` | `entry` | Also deprecated in tsup itself |
+| Copy files | `publicDir` | `copy` | Property rename |
+| Bundleless | `bundle: false` | `unbundle: true` | Inverted logic |
+| Strip node: | `removeNodeProtocol` | `nodeProtocol: 'strip'` | New option with more modes |
+| CSS inject | `injectStyle` | `css: { inject: true }` | Moved to css namespace |
+| External deps | `external` | `deps.neverBundle` | Moved to deps namespace |
+| Inline deps | `noExternal` | `deps.alwaysBundle` | Moved to deps namespace |
+| Skip node_modules | `skipNodeModulesBundle` | `deps.skipNodeModulesBundle` | Moved to deps namespace |
+
+### Output Filename Differences
+
+For IIFE builds, `tsdown` emits `[name].iife.js`; `tsup` commonly emitted `[name].global.js`. `outExtensions` customizes extensions or suffixes, but it does not remove `.iife` or `.umd`. Use `outputOptions.entryFileNames` for full filename patterns.
+
+### Not Supported
+
+| Feature | Reason | Alternative |
+|---------|--------|-------------|
+| `splitting: false` | Code splitting always enabled | None — splitting cannot be disabled |
+| `metafile` | Not implemented | `devtools: true` for bundle analysis |
+| `swc` | Uses oxc instead | Built-in, no config needed |
+| `experimentalDts` | Superseded | Use `dts` option |
+| `legacyOutput` | Not implemented | None |
+| `plugins` (tsup API) | Different plugin architecture | Rewrite as Rolldown/Unplugin plugins |
+
+## New Features in tsdown
+
+### Node Protocol Control
+
+```ts
+nodeProtocol: true       // Add node: prefix (fs → node:fs)
+nodeProtocol: 'strip'    // Remove node: prefix (node:fs → fs)
+nodeProtocol: false       // Keep as-is (default)
+```
+
+### Workspace / Monorepo
+
+```ts
+export default defineConfig({
+  workspace: 'packages/*',
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+})
+```
+
+### Auto Package Exports
+
+```ts
+export default defineConfig({
+  exports: true, // Generate package.json exports field
+})
+```
+
+### Package Validation
+
+```ts
+export default defineConfig({
+  publint: true,    // Lint package for common issues
+  attw: true,       // Check "are the types wrong"
+})
+```
+
+### Standalone Executable
+
+```ts
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  exe: true, // Bundle as Node.js SEA
+})
+```
+
+### Vite DevTools
+
+```ts
+export default defineConfig({
+  devtools: true, // Vite DevTools bundle analysis
+})
+```
+
+### Lifecycle Hooks
+
+```ts
+export default defineConfig({
+  hooks: {
+    'build:prepare': async (ctx) => { /* before any build */ },
+    'build:before': async (ctx) => { /* before each format */ },
+    'build:done': async (ctx) => { /* after build, access chunks */ },
+  },
+})
+```
+
+### CSS Modules
+
+```ts
+export default defineConfig({
+  css: {
+    modules: {
+      localsConvention: 'camelCase',
+    },
+  },
+})
+```
+
+### Glob Import
+
+```ts
+export default defineConfig({
+  globImport: true, // Support import.meta.glob (Vite-style)
+})
+```
+
+## Related
+
+- [guide-option-mappings.md](guide-option-mappings.md) - Before/after for every option
+- [guide-package-json.md](guide-package-json.md) - Package.json migration

--- a/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-option-mappings.md
+++ b/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-option-mappings.md
@@ -1,0 +1,231 @@
+# Option Mappings: tsup → tsdown
+
+Complete before/after reference for every config option transformation.
+
+## Property Renames
+
+### cjsInterop → cjsDefault
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  cjsInterop: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  cjsDefault: true,
+})
+```
+
+### esbuildPlugins → plugins
+
+```ts
+// Before (tsup)
+import myPlugin from 'unplugin-example/esbuild'
+
+export default defineConfig({
+  esbuildPlugins: [myPlugin()],
+})
+
+// After (tsdown)
+import myPlugin from 'unplugin-example/rolldown'
+
+export default defineConfig({
+  plugins: [myPlugin()],
+})
+```
+
+Note: All `unplugin-*/esbuild` imports must change to `unplugin-*/rolldown`.
+
+### outExtension → outExtensions
+
+`outExtension` was renamed to `outExtensions`.
+
+## Deprecated but Compatible
+
+These options still work in tsdown for backward compatibility but emit deprecation warnings. Migrate them immediately — they will be removed in a future version.
+
+### entryPoints → entry
+
+`entryPoints` is also deprecated in tsup itself. Both tsup and tsdown use `entry`.
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  entryPoints: ['src/index.ts', 'src/cli.ts'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts'],
+})
+```
+
+### publicDir → copy
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  publicDir: 'public',
+})
+
+// After (tsdown)
+export default defineConfig({
+  copy: 'public',
+})
+```
+
+### bundle → unbundle
+
+```ts
+// Before (tsup) — bundle: true is default, just remove
+export default defineConfig({
+  bundle: true,
+})
+
+// After (tsdown) — remove entirely
+export default defineConfig({})
+```
+
+```ts
+// Before (tsup) — bundle: false
+export default defineConfig({
+  bundle: false,
+})
+
+// After (tsdown)
+export default defineConfig({
+  unbundle: true,
+})
+```
+
+### removeNodeProtocol → nodeProtocol
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  removeNodeProtocol: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  nodeProtocol: 'strip',
+})
+```
+
+### injectStyle → css.inject
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  injectStyle: true,
+})
+
+// After (tsdown)
+export default defineConfig({
+  css: { inject: true },
+})
+```
+
+`injectStyle: false` should be removed (it's the default).
+
+### external → deps.neverBundle
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react', 'react-dom', /^@myorg\//],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react', 'react-dom', /^@myorg\//],
+  },
+})
+```
+
+### noExternal → deps.alwaysBundle
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+### Combined Example
+
+```ts
+// Before (tsup)
+export default defineConfig({
+  external: ['react'],
+  noExternal: ['lodash-es'],
+})
+
+// After (tsdown)
+export default defineConfig({
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+})
+```
+
+## Full Migration Example
+
+```ts
+// Before (tsup.config.ts)
+import { defineConfig } from 'tsup'
+import myPlugin from 'unplugin-example/esbuild'
+
+export default defineConfig({
+  entryPoints: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  bundle: true,
+  external: ['react'],
+  noExternal: ['lodash-es'],
+  publicDir: 'public',
+  cjsInterop: true,
+  removeNodeProtocol: true,
+  injectStyle: true,
+  esbuildPlugins: [myPlugin()],
+  splitting: true,
+  clean: true,
+})
+
+// After (tsdown.config.ts)
+import { defineConfig } from 'tsdown'
+import myPlugin from 'unplugin-example/rolldown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  deps: {
+    neverBundle: ['react'],
+    alwaysBundle: ['lodash-es'],
+  },
+  copy: 'public',
+  cjsDefault: true,
+  nodeProtocol: 'strip',
+  css: { inject: true },
+  plugins: [myPlugin()],
+  // splitting removed — always enabled in tsdown
+  clean: true,
+})
+```
+
+## Related
+
+- [guide-differences-detailed.md](guide-differences-detailed.md) - Architecture and feature comparison
+- [guide-package-json.md](guide-package-json.md) - Package.json migration

--- a/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-package-json.md
+++ b/plugins/tsdown/.agents/skills/tsdown-migrate/references/guide-package-json.md
@@ -1,0 +1,92 @@
+# Package.json Migration
+
+How to update package.json when migrating from tsup to tsdown.
+
+## Scripts
+
+Replace all occurrences of `tsup` and `tsup-node` with `tsdown`:
+
+```json
+// Before
+{
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm",
+    "dev": "tsup --watch",
+    "build:node": "tsup-node src/server.ts"
+  }
+}
+
+// After
+{
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs,esm",
+    "dev": "tsdown --watch",
+    "build:node": "tsdown src/server.ts"
+  }
+}
+```
+
+## Dependencies
+
+Rename `tsup` to `tsdown` in whichever dependency field it appears:
+
+```json
+// Before
+{
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+
+// After
+{
+  "devDependencies": {
+    "tsdown": "^0.21.3",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+### All Dependency Fields
+
+| Field | tsup version | tsdown version |
+|-------|-------------|----------------|
+| `dependencies` | any | latest tsdown |
+| `devDependencies` | any | latest tsdown |
+| `optionalDependencies` | any | latest tsdown |
+| `peerDependencies` | any | `*` |
+| `peerDependenciesMeta` | rename key only | rename key only |
+
+## Root Config Field
+
+If the project uses inline config in package.json (root-level `tsup` field), rename to `tsdown`:
+
+```json
+// Before
+{
+  "name": "my-lib",
+  "tsup": {
+    "entry": ["src/index.ts"],
+    "format": ["cjs", "esm"],
+    "dts": true
+  }
+}
+
+// After
+{
+  "name": "my-lib",
+  "tsdown": {
+    "entry": ["src/index.ts"],
+    "format": ["cjs", "esm"],
+    "dts": true
+  }
+}
+```
+
+Note: Option mappings (entryPoints→entry, etc.) also apply inside the root config field.
+
+## Related
+
+- [guide-option-mappings.md](guide-option-mappings.md) - Config option transforms
+- [guide-differences-detailed.md](guide-differences-detailed.md) - Feature comparison

--- a/plugins/tsdown/skills-lock.json
+++ b/plugins/tsdown/skills-lock.json
@@ -6,6 +6,12 @@
       "sourceType": "github",
       "skillPath": "skills/tsdown/SKILL.md",
       "computedHash": "47f632fbbbdefb7d5b18263502c218cec477255c0fa14baf168c47b83edabeee"
+    },
+    "tsdown-migrate": {
+      "source": "rolldown/tsdown",
+      "sourceType": "github",
+      "skillPath": "skills/tsdown-migrate/SKILL.md",
+      "computedHash": "2ef3e45913861eaf12af22188656733c3b3f7244258f46a60ff892eae9831537"
     }
   }
 }


### PR DESCRIPTION
## Summary

The `tsdown` plugin already shipped the `tsdown` skill, but the upstream repo (`rolldown/tsdown/skills`) ships a **second** skill — `tsdown-migrate` — that was missing. This PR installs it into the existing plugin.

- `tsdown-migrate` — knowledge base for migrating TypeScript library projects from **tsup → tsdown** (option mappings, config transformation rules, default-value differences, unsupported-option alternatives).

## Changes

- `plugins/tsdown/.agents/skills/tsdown-migrate/` — skill files, installed via `bunx skills add rolldown/tsdown --skill tsdown-migrate`
- `plugins/tsdown/skills-lock.json` — added the `tsdown-migrate` lock entry

## No manifest changes needed

`plugins/tsdown/.claude-plugin/plugin.json` already declares `"skills": "./.agents/skills/"`, which auto-loads every skill directory. Both `tsdown` and `tsdown-migrate` are now picked up without touching the manifest, marketplace, or multi-format artifacts.

## Test

```
/plugin install tsdown@pleaseai
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `tsdown-migrate` skill from `rolldown/tsdown` to the `tsdown` plugin so agents can migrate projects from `tsup` to `tsdown`. It auto-loads via the existing skills path; no manifest changes needed.

- **New Features**
  - Option mappings and config transforms (`tsup` → `tsdown`).
  - Default differences with guidance to preserve behavior.
  - Unsupported options with alternatives.
  - Package.json script and dependency rename guidance.
  - Plugin import changes (`unplugin-*/esbuild` → `unplugin-*/rolldown`).

- **Dependencies**
  - Added `plugins/tsdown/.agents/skills/tsdown-migrate/` files.
  - Updated `plugins/tsdown/skills-lock.json` with `tsdown-migrate`.

<sup>Written for commit 74b8935a88dcd7add2c77c14660cec4b62cb9a4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

