### PR TITLE
feat(marketplace): add eve plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -759,6 +759,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Tooling"
+    },
+    {
+      "name": "eve",
+      "source": {
+        "source": "local",
+        "path": "./plugins/eve"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tooling"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -706,6 +706,14 @@
       "keywords": ["vercel-sandbox", "sandbox", "microvm", "vercel", "isolated-execution"],
       "tags": ["skills", "vercel"],
       "source": "./plugins/vercel-sandbox"
+    },
+    {
+      "name": "eve",
+      "description": "Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.",
+      "category": "tooling",
+      "keywords": ["eve", "agents", "ai-agents", "backend", "vercel", "framework"],
+      "tags": ["skills", "vercel"],
+      "source": "./plugins/eve"
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -57,5 +57,6 @@
   "plugins/fetch": "1.1.0",
   "plugins/java-development": "1.0.0",
   "plugins/mcp-dev": "1.0.0",
-  "plugins/vercel-sandbox": "1.1.0"
+  "plugins/vercel-sandbox": "1.1.0",
+  "plugins/eve": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -393,6 +393,12 @@ Creates isolated Linux MicroVMs using Vercel Sandbox SDK. Use when building code
 
 **Install:** `/plugin install vercel-sandbox@pleaseai` | **Source:** [plugins/vercel-sandbox](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/vercel-sandbox)
 
+#### eve
+
+Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.
+
+**Install:** `/plugin install eve@pleaseai` | **Source:** [plugins/eve](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/eve)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:

--- a/plugins/eve/.agents/skills/eve/SKILL.md
+++ b/plugins/eve/.agents/skills/eve/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: eve
+description: Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.
+---
+
+# eve
+
+eve is a filesystem-first framework for durable backend AI agents. An agent is
+a directory on disk — instructions, skills, tools, connections, channels,
+subagents, and schedules are all files — and eve compiles and runs it.
+
+## Source of truth
+
+The complete documentation ships inside the `eve` package. Do not rely on this
+skill for guidance — always read the bundled docs, which match the installed
+version exactly:
+
+```
+node_modules/eve/docs/
+```
+
+Start with `node_modules/eve/docs/README.md`. It contains the full
+index and recommended reading order. Before writing any eve code, read the
+relevant guide there first.
+
+If `eve` is not installed yet, install it (`npm install eve`) or scaffold a new
+agent with `npx eve init <agent-name>`, then read the bundled docs.

--- a/plugins/eve/.claude-plugin/plugin.json
+++ b/plugins/eve/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "eve",
+  "version": "1.0.0",
+  "description": "Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.",
+  "author": {
+    "name": "Vercel Inc.",
+    "url": "https://github.com/vercel/eve"
+  },
+  "homepage": "https://github.com/vercel/eve",
+  "repository": "https://github.com/vercel/eve",
+  "license": "Apache-2.0",
+  "keywords": ["eve", "agents", "ai-agents", "backend", "vercel", "framework"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/eve/.codex-plugin/plugin.json
+++ b/plugins/eve/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "eve",
+  "version": "1.0.0",
+  "description": "Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.",
+  "author": {
+    "name": "Vercel Inc.",
+    "url": "https://github.com/vercel/eve"
+  },
+  "interface": {
+    "displayName": "Eve",
+    "shortDescription": "Build durable backend AI agents with the eve framework",
+    "longDescription": "Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.",
+    "developerName": "Vercel Inc.",
+    "category": "Tooling",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Eve for my current task."
+    ],
+    "websiteURL": "https://github.com/vercel/eve"
+  },
+  "homepage": "https://github.com/vercel/eve",
+  "repository": "https://github.com/vercel/eve",
+  "license": "Apache-2.0",
+  "keywords": [
+    "eve",
+    "agents",
+    "ai-agents",
+    "backend",
+    "vercel",
+    "framework"
+  ]
+}

--- a/plugins/eve/plugin.json
+++ b/plugins/eve/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "eve",
+  "version": "1.0.0",
+  "description": "Build durable backend AI agents with the eve framework. Use when creating, editing, or debugging an eve project — agent instructions, skills, tools, connections, channels, sandboxes, subagents, schedules, or evals.",
+  "author": {
+    "name": "Vercel Inc.",
+    "url": "https://github.com/vercel/eve"
+  },
+  "homepage": "https://github.com/vercel/eve",
+  "repository": "https://github.com/vercel/eve",
+  "license": "Apache-2.0",
+  "keywords": [
+    "eve",
+    "agents",
+    "ai-agents",
+    "backend",
+    "vercel",
+    "framework"
+  ]
+}

--- a/plugins/eve/skills-lock.json
+++ b/plugins/eve/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "eve": {
+      "source": "vercel/eve",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "62fc3ce0539201477af0ea395ec61084d8b3ea7348bafa0ceb46e5277c45d2ab"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -890,6 +890,27 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/eve": {
+      "release-type": "simple",
+      "component": "eve",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

Adds the **eve** built-in plugin to the Claude Code plugin marketplace. The eve plugin wraps the `eve` agent skill from [vercel/eve](https://github.com/vercel/eve) (Apache-2.0) — a filesystem-first framework for durable backend AI agents.

## Files Changed

- `plugins/eve/` (new) — plugin directory containing:
  - `.agents/skills/eve/SKILL.md` — skill installed via `bunx skills add vercel/eve --skill eve`
  - `.claude-plugin/plugin.json` — Claude Code runtime manifest
  - `.codex-plugin/plugin.json` — Codex runtime manifest (generated via `bun scripts/cli.ts multi-format`)
  - `plugin.json` — Antigravity runtime manifest (generated)
  - `skills-lock.json` — tracks the installed skill
- `.claude-plugin/marketplace.json` — eve entry added (source of truth)
- `.agents/plugins/marketplace.json` — Codex marketplace regenerated (eve entry only)
- `release-please-config.json` — `plugins/eve` package entry added with version-bearing manifests in `extra-files`
- `.release-please-manifest.json` — `plugins/eve: 1.0.0` added
- `README.md` — Built-in Plugins entry added

## Notes

- **License**: Apache-2.0 (vercel/eve)
- **Skill source**: `bunx skills add vercel/eve --skill eve` — eve's `SKILL.md` lives at the monorepo root of vercel/eve, so skills.sh cloned the full monorepo. The skill directory was trimmed to only `SKILL.md` to avoid vendoring the entire framework. A future `bunx skills update` may re-copy the full tree and will need re-trimming.
- **Validation**: `claude plugin validate plugins/eve` passes.
- **Multi-format**: Codex/Antigravity manifests were generated via `bun scripts/cli.ts multi-format`; only the eve-related files are included in this commit (unrelated churn was not committed per the marketplace-sync rule).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the built-in `eve` plugin to the marketplace, wrapping the `eve` agent skill from `vercel/eve`. Enables creating, editing, and debugging Eve-based backend agents across Claude, Codex, and Antigravity runtimes.

- **New Features**
  - Added `plugins/eve/` with `.agents/skills/eve/SKILL.md`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `plugin.json`.
  - Updated marketplace entries in `.claude-plugin/marketplace.json` and regenerated `.agents/plugins/marketplace.json`.
  - Added README entry with install command for `eve`.
  - Configured `release-please` for `plugins/eve` (`1.0.0`) in `release-please-config.json` and `.release-please-manifest.json`.

<sup>Written for commit 8bd1fd7301933634a32b5ee51e46d4c36edb4a2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The eve plugin is now available in the marketplace, enabling users to build and manage durable backend AI agents with integrated project editing and debugging capabilities.

* **Documentation**
  * Comprehensive plugin documentation, skill guides, and setup instructions have been added for the eve plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->