### PR TITLE
feat(emulate): add Linear, Stripe, Resend, Next.js and remaining emulator skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -575,7 +575,7 @@
     },
     {
       "name": "emulate",
-      "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+      "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
       "category": "development",
       "keywords": ["emulate", "api-emulation", "local-development", "testing"],
       "tags": ["tooling", "testing"],

--- a/plugins/emulate/.agents/skills/apple/SKILL.md
+++ b/plugins/emulate/.agents/skills/apple/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: apple
+description: Emulated Sign in with Apple / Apple OIDC for local development and testing. Use when the user needs to test Apple sign-in locally, emulate Apple OIDC discovery, handle Apple token exchange, configure Apple OAuth clients, or work with Apple userinfo without hitting real Apple APIs. Triggers include "Apple OAuth", "emulate Apple", "mock Apple login", "test Apple sign-in", "Sign in with Apple", "Apple OIDC", "local Apple auth", or any task requiring a local Apple OAuth/OIDC provider.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Apple Sign In Emulator
+
+Sign in with Apple emulation with authorization code flow, PKCE support, RS256 ID tokens, and OIDC discovery.
+
+## Start
+
+```bash
+# Apple only
+npx emulate --service apple
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const apple = await createEmulator({ service: 'apple', port: 4004 })
+// apple.url === 'http://localhost:4004'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+APPLE_EMULATOR_URL=http://localhost:4004
+```
+
+### OAuth URL Mapping
+
+| Real Apple URL | Emulator URL |
+|----------------|-------------|
+| `https://appleid.apple.com/.well-known/openid-configuration` | `$APPLE_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://appleid.apple.com/auth/authorize` | `$APPLE_EMULATOR_URL/auth/authorize` |
+| `https://appleid.apple.com/auth/token` | `$APPLE_EMULATOR_URL/auth/token` |
+| `https://appleid.apple.com/auth/keys` | `$APPLE_EMULATOR_URL/auth/keys` |
+| `https://appleid.apple.com/auth/revoke` | `$APPLE_EMULATOR_URL/auth/revoke` |
+
+### Auth.js / NextAuth.js
+
+```typescript
+import Apple from '@auth/core/providers/apple'
+
+Apple({
+  clientId: process.env.APPLE_CLIENT_ID,
+  clientSecret: process.env.APPLE_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.APPLE_EMULATOR_URL}/auth/authorize`,
+    params: { scope: 'openid email name', response_mode: 'form_post' },
+  },
+  token: {
+    url: `${process.env.APPLE_EMULATOR_URL}/auth/token`,
+  },
+  jwks_endpoint: `${process.env.APPLE_EMULATOR_URL}/auth/keys`,
+})
+```
+
+### Passport.js
+
+```typescript
+import { Strategy as AppleStrategy } from 'passport-apple'
+
+const APPLE_URL = process.env.APPLE_EMULATOR_URL ?? 'https://appleid.apple.com'
+
+new AppleStrategy({
+  clientID: process.env.APPLE_CLIENT_ID,
+  teamID: process.env.APPLE_TEAM_ID,
+  keyID: process.env.APPLE_KEY_ID,
+  callbackURL: 'http://localhost:3000/api/auth/callback/apple',
+  authorizationURL: `${APPLE_URL}/auth/authorize`,
+  tokenURL: `${APPLE_URL}/auth/token`,
+}, verifyCallback)
+```
+
+## Seed Config
+
+```yaml
+apple:
+  users:
+    - email: testuser@icloud.com
+      name: Test User
+      given_name: Test
+      family_name: User
+    - email: private@example.com
+      name: Private User
+      is_private_email: true
+  oauth_clients:
+    - client_id: com.example.app
+      team_id: TEAM001
+      name: My Apple App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/apple
+```
+
+When no OAuth clients are configured, the emulator accepts any `client_id`. With clients configured, strict validation is enforced for `client_id` and `redirect_uri`.
+
+Users with `is_private_email: true` get a generated `@privaterelay.appleid.com` email in the `id_token` instead of their real email.
+
+## API Endpoints
+
+### OIDC Discovery
+
+```bash
+curl http://localhost:4004/.well-known/openid-configuration
+```
+
+Returns the standard OIDC discovery document with all endpoints pointing to the emulator:
+
+```json
+{
+  "issuer": "http://localhost:4004",
+  "authorization_endpoint": "http://localhost:4004/auth/authorize",
+  "token_endpoint": "http://localhost:4004/auth/token",
+  "jwks_uri": "http://localhost:4004/auth/keys",
+  "revocation_endpoint": "http://localhost:4004/auth/revoke",
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["pairwise"],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "scopes_supported": ["openid", "email", "name"],
+  "token_endpoint_auth_methods_supported": ["client_secret_post"],
+  "response_modes_supported": ["query", "fragment", "form_post"]
+}
+```
+
+### JWKS
+
+```bash
+curl http://localhost:4004/auth/keys
+```
+
+Returns an RSA public key (`kid`: `emulate-apple-1`) for verifying `id_token` signatures.
+
+### Authorization
+
+```bash
+# Browser flow: redirects to a user picker page
+curl -v "http://localhost:4004/auth/authorize?\
+client_id=com.example.app&\
+redirect_uri=http://localhost:3000/api/auth/callback/apple&\
+scope=openid+email+name&\
+response_type=code&\
+state=random-state&\
+nonce=random-nonce&\
+response_mode=form_post"
+```
+
+Query parameters:
+
+| Param | Description |
+|-------|-------------|
+| `client_id` | OAuth client ID (Apple Services ID) |
+| `redirect_uri` | Callback URL |
+| `scope` | Space-separated scopes (`openid email name`) |
+| `state` | Opaque state for CSRF protection |
+| `nonce` | Nonce for ID token (optional) |
+| `response_mode` | `query` (default), `form_post`, or `fragment` |
+
+The emulator renders an HTML page where you select a seeded user. After selection, it redirects (or auto-submits a form for `form_post`) to `redirect_uri` with `code` and `state`. On the **first** authorization per user/client pair, a `user` JSON blob is also included (matching Apple's real behavior).
+
+### Token Exchange
+
+```bash
+curl -X POST http://localhost:4004/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<authorization_code>&\
+client_id=com.example.app&\
+client_secret=<client_secret>&\
+grant_type=authorization_code"
+```
+
+Returns:
+
+```json
+{
+  "access_token": "apple_...",
+  "refresh_token": "r_apple_...",
+  "id_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+The `id_token` is an RS256 JWT containing `sub`, `email`, `email_verified` (string), `is_private_email` (string), `real_user_status`, `auth_time`, and optional `nonce`.
+
+### Refresh Token
+
+```bash
+curl -X POST http://localhost:4004/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "refresh_token=r_apple_...&\
+client_id=com.example.app&\
+grant_type=refresh_token"
+```
+
+Returns a new `access_token` and `id_token`. No new `refresh_token` is issued on refresh (matching Apple's behavior).
+
+### Token Revocation
+
+```bash
+curl -X POST http://localhost:4004/auth/revoke \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=apple_..."
+```
+
+Returns `200 OK`. The token is removed from the emulator's token map.
+
+## Common Patterns
+
+### Full Authorization Code Flow
+
+```bash
+APPLE_URL="http://localhost:4004"
+CLIENT_ID="com.example.app"
+REDIRECT_URI="http://localhost:3000/api/auth/callback/apple"
+
+# 1. Open in browser (user picks a seeded account)
+#    $APPLE_URL/auth/authorize?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&scope=openid+email+name&response_type=code&state=abc&response_mode=form_post
+
+# 2. After user selection, emulator posts to:
+#    $REDIRECT_URI with code=<code>&state=abc (and user JSON on first auth)
+
+# 3. Exchange code for tokens
+curl -X POST $APPLE_URL/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<code>&client_id=$CLIENT_ID&grant_type=authorization_code"
+
+# 4. Decode the id_token JWT to get user info
+```
+
+### Private Relay Email
+
+When a user has `is_private_email: true` in the seed config, the `id_token` will contain a generated `@privaterelay.appleid.com` email instead of the user's real email. This matches Apple's Hide My Email behavior.

--- a/plugins/emulate/.agents/skills/aws/SKILL.md
+++ b/plugins/emulate/.agents/skills/aws/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: aws
+description: Emulated AWS cloud services (S3, SQS, IAM, STS) for local development and testing. Use when the user needs to interact with AWS API endpoints locally, test S3 bucket and object operations, emulate SQS queues and messages, manage IAM users/roles/access keys, test STS assume role, or work without hitting real AWS APIs. Triggers include "AWS emulator", "emulate AWS", "mock S3", "local SQS", "test IAM", "emulate S3", "AWS locally", "STS assume role", or any task requiring local AWS service emulation.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# AWS Emulator
+
+S3, SQS, IAM, and STS emulation with AWS SDK-compatible S3 paths and query-style SQS/IAM/STS endpoints. All state is in-memory, and responses use AWS-compatible XML.
+
+## Start
+
+```bash
+# AWS only
+npx emulate --service aws
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const aws = await createEmulator({ service: 'aws', port: 4006 })
+// aws.url === 'http://localhost:4006'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. Scoped permissions use `s3:*`, `sqs:*`, `iam:*`, `sts:*` patterns.
+
+```bash
+curl http://localhost:4006/ \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+AWS_EMULATOR_URL=http://localhost:4006
+```
+
+### AWS SDK v3
+
+```typescript
+import { S3Client } from '@aws-sdk/client-s3'
+
+const s3 = new S3Client({
+  endpoint: process.env.AWS_EMULATOR_URL,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+  forcePathStyle: true,
+})
+```
+
+```typescript
+import { SQSClient } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({
+  endpoint: `${process.env.AWS_EMULATOR_URL}/sqs`,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+})
+```
+
+```typescript
+import { IAMClient } from '@aws-sdk/client-iam'
+
+const iam = new IAMClient({
+  endpoint: `${process.env.AWS_EMULATOR_URL}/iam`,
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  },
+})
+```
+
+## Seed Config
+
+```yaml
+aws:
+  region: us-east-1
+  s3:
+    buckets:
+      - name: my-app-bucket
+      - name: my-app-uploads
+        region: eu-west-1
+  sqs:
+    queues:
+      - name: my-app-events
+      - name: my-app-dlq
+        visibility_timeout: 60
+      - name: my-app-orders.fifo
+        fifo: true
+  iam:
+    users:
+      - user_name: developer
+        create_access_key: true
+      - user_name: readonly-user
+    roles:
+      - role_name: lambda-execution-role
+        description: Role for Lambda function execution
+        assume_role_policy: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+```
+
+Default seed (always created): S3 bucket `emulate-default`, SQS queue `emulate-default-queue`, IAM user `admin` with access key pair (`AKIAIOSFODNN7EXAMPLE` / `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`).
+
+## API Endpoints
+
+### S3
+
+S3 routes use root paths matching the real AWS S3 wire format. Legacy `/s3/` prefixed paths are also supported.
+
+```bash
+# List all buckets
+curl http://localhost:4006/ \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create bucket
+curl -X PUT http://localhost:4006/my-bucket \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete bucket (must be empty)
+curl -X DELETE http://localhost:4006/my-bucket \
+  -H "Authorization: Bearer $TOKEN"
+
+# Head bucket (check existence, get region)
+curl -I http://localhost:4006/my-bucket \
+  -H "Authorization: Bearer $TOKEN"
+
+# List objects (with prefix, delimiter, pagination)
+curl "http://localhost:4006/my-bucket?prefix=uploads/&delimiter=/&max-keys=100" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Put object
+curl -X PUT http://localhost:4006/my-bucket/path/to/file.txt \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/plain" \
+  -H "x-amz-meta-author: test" \
+  --data-binary "file contents"
+
+# Get object
+curl http://localhost:4006/my-bucket/path/to/file.txt \
+  -H "Authorization: Bearer $TOKEN"
+
+# Head object (metadata only)
+curl -I http://localhost:4006/my-bucket/path/to/file.txt \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete object
+curl -X DELETE http://localhost:4006/my-bucket/path/to/file.txt \
+  -H "Authorization: Bearer $TOKEN"
+
+# Copy object
+curl -X PUT http://localhost:4006/dest-bucket/copy.txt \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-amz-copy-source: /source-bucket/original.txt"
+```
+
+### SQS
+
+All SQS operations use `POST /sqs/` with `Action` as a form-urlencoded parameter.
+
+```bash
+# Create queue
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "Action=CreateQueue&QueueName=my-queue"
+
+# Create queue with attributes
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "Action=CreateQueue&QueueName=my-queue&Attribute.1.Name=VisibilityTimeout&Attribute.1.Value=30"
+
+# List queues
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ListQueues"
+
+# List queues with prefix filter
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ListQueues&QueueNamePrefix=my-"
+
+# Get queue URL
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetQueueUrl&QueueName=my-queue"
+
+# Get queue attributes
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetQueueAttributes&QueueUrl=<queue_url>"
+
+# Send message
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello+World"
+
+# Send message with attributes
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=SendMessage&QueueUrl=<queue_url>&MessageBody=Hello&MessageAttribute.1.Name=type&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=greeting"
+
+# Receive messages
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ReceiveMessage&QueueUrl=<queue_url>&MaxNumberOfMessages=5"
+
+# Delete message
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=DeleteMessage&QueueUrl=<queue_url>&ReceiptHandle=<receipt_handle>"
+
+# Purge queue
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=PurgeQueue&QueueUrl=<queue_url>"
+
+# Delete queue
+curl -X POST http://localhost:4006/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=DeleteQueue&QueueUrl=<queue_url>"
+```
+
+### IAM
+
+All IAM operations use `POST /iam/` with `Action` as a form-urlencoded parameter.
+
+```bash
+# Create user
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=CreateUser&UserName=new-user"
+
+# Get user
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetUser&UserName=new-user"
+
+# List users
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ListUsers"
+
+# Delete user
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=DeleteUser&UserName=new-user"
+
+# Create access key
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=CreateAccessKey&UserName=developer"
+
+# List access keys
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ListAccessKeys&UserName=developer"
+
+# Delete access key
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=DeleteAccessKey&UserName=developer&AccessKeyId=AKIA..."
+
+# Create role
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=CreateRole&RoleName=my-role&AssumeRolePolicyDocument={}"
+
+# Get role
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetRole&RoleName=my-role"
+
+# List roles
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ListRoles"
+
+# Delete role
+curl -X POST http://localhost:4006/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=DeleteRole&RoleName=my-role"
+```
+
+### STS
+
+All STS operations use `POST /sts/` with `Action` as a form-urlencoded parameter.
+
+```bash
+# Get caller identity
+curl -X POST http://localhost:4006/sts/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetCallerIdentity"
+
+# Assume role
+curl -X POST http://localhost:4006/sts/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/my-role&RoleSessionName=my-session"
+```
+
+### Inspector
+
+```bash
+# HTML dashboard (shows S3, SQS, IAM state)
+curl http://localhost:4006/_inspector?tab=s3
+curl http://localhost:4006/_inspector?tab=sqs
+curl http://localhost:4006/_inspector?tab=iam
+```
+
+## Common Patterns
+
+### Upload and Retrieve an Object
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4006"
+
+# Create bucket
+curl -X PUT $BASE/my-data \
+  -H "Authorization: Bearer $TOKEN"
+
+# Upload file
+curl -X PUT $BASE/my-data/config.json \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary '{"key": "value"}'
+
+# Download file
+curl $BASE/my-data/config.json \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Send and Receive SQS Messages
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4006"
+
+# Get queue URL
+QUEUE_URL=$(curl -s -X POST $BASE/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=GetQueueUrl&QueueName=emulate-default-queue" | grep -oP '<QueueUrl>\K[^<]+')
+
+# Send message
+curl -X POST $BASE/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=SendMessage&QueueUrl=$QUEUE_URL&MessageBody=Hello+from+emulate"
+
+# Receive messages
+curl -X POST $BASE/sqs/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=ReceiveMessage&QueueUrl=$QUEUE_URL&MaxNumberOfMessages=1"
+```
+
+### Create IAM User with Access Key
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4006"
+
+# Create user
+curl -X POST $BASE/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=CreateUser&UserName=ci-user"
+
+# Generate access key
+curl -X POST $BASE/iam/ \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "Action=CreateAccessKey&UserName=ci-user"
+```

--- a/plugins/emulate/.agents/skills/github/SKILL.md
+++ b/plugins/emulate/.agents/skills/github/SKILL.md
@@ -1,0 +1,560 @@
+---
+name: github
+description: Emulated GitHub REST API for local development and testing. Use when the user needs to interact with GitHub API endpoints locally, test GitHub integrations, emulate repos/issues/PRs, set up GitHub OAuth flows, configure GitHub Apps, test webhooks, or work with actions/checks without hitting the real GitHub API. Triggers include "GitHub API", "emulate GitHub", "mock GitHub", "test GitHub OAuth", "GitHub App JWT", "local GitHub", or any task requiring a local GitHub API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# GitHub API Emulator
+
+Fully stateful GitHub REST API emulation. Creates, updates, and deletes persist in memory and affect related entities.
+
+## Start
+
+```bash
+# GitHub only
+npx emulate --service github
+
+# Default port
+# http://localhost:4001
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const github = await createEmulator({ service: 'github', port: 4001 })
+// github.url === 'http://localhost:4001'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>` or `Authorization: token <token>`.
+
+```bash
+curl http://localhost:4001/user \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+Public repo endpoints work without auth. Private repos and write operations require a valid token. When no token is provided, requests fall back to the first seeded user.
+
+### GitHub App JWT
+
+Configure apps in the seed config with a private key. Sign a JWT with `{ iss: "<app_id>" }` using RS256. The emulator verifies the signature and resolves the app.
+
+```yaml
+github:
+  apps:
+    - app_id: 12345
+      slug: my-github-app
+      name: My GitHub App
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+      permissions:
+        contents: read
+        issues: write
+      events: [push, pull_request]
+      webhook_url: http://localhost:8080/github/webhook
+      webhook_secret: my-webhook-secret
+      description: My CI/CD bot
+      installations:
+        - installation_id: 100
+          account: my-org
+          repository_selection: all
+          permissions:
+            contents: read
+          events: [push]
+          repositories: [my-org/org-repo]
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+GITHUB_EMULATOR_URL=http://localhost:4001
+```
+
+### Octokit
+
+```typescript
+import { Octokit } from '@octokit/rest'
+
+const octokit = new Octokit({
+  baseUrl: process.env.GITHUB_EMULATOR_URL ?? 'https://api.github.com',
+  auth: 'test_token_admin',
+})
+```
+
+### OAuth URL Mapping
+
+| Real GitHub URL | Emulator URL |
+|-----------------|-------------|
+| `https://github.com/login/oauth/authorize` | `$GITHUB_EMULATOR_URL/login/oauth/authorize` |
+| `https://github.com/login/oauth/access_token` | `$GITHUB_EMULATOR_URL/login/oauth/access_token` |
+| `https://api.github.com/user` | `$GITHUB_EMULATOR_URL/user` |
+
+### Auth.js / NextAuth.js
+
+```typescript
+import GitHub from '@auth/core/providers/github'
+
+GitHub({
+  clientId: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.GITHUB_EMULATOR_URL}/login/oauth/authorize`,
+  },
+  token: {
+    url: `${process.env.GITHUB_EMULATOR_URL}/login/oauth/access_token`,
+  },
+  userinfo: {
+    url: `${process.env.GITHUB_EMULATOR_URL}/user`,
+  },
+})
+```
+
+## Seed Config
+
+```yaml
+tokens:
+  test_token_admin:
+    login: admin
+    scopes: [repo, user, admin:org, admin:repo_hook]
+
+github:
+  users:
+    - login: octocat
+      name: The Octocat
+      email: octocat@github.com
+      bio: I am the Octocat
+      company: GitHub
+      location: San Francisco
+      blog: https://github.blog
+      twitter_username: github
+      site_admin: false
+  orgs:
+    - login: my-org
+      name: My Organization
+      description: A test organization
+      email: org@example.com
+  repos:
+    - owner: octocat
+      name: hello-world
+      description: My first repository
+      language: JavaScript
+      topics: [hello, world]
+      default_branch: main
+      private: false
+    - owner: my-org
+      name: org-repo
+      description: An organization repository
+      language: TypeScript
+  oauth_apps:
+    - client_id: Iv1.abc123
+      client_secret: secret_abc123
+      name: My Web App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/github
+```
+
+Repos are auto-initialized with a commit, branch, and README unless `auto_init: false` is set.
+
+## Pagination
+
+All list endpoints support `page` and `per_page` query params with `Link` headers:
+
+```bash
+curl "http://localhost:4001/repos/octocat/hello-world/issues?page=1&per_page=10" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## API Endpoints
+
+### Users
+
+```bash
+# Authenticated user
+curl http://localhost:4001/user -H "Authorization: Bearer $TOKEN"
+
+# Update profile
+curl -X PATCH http://localhost:4001/user \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"bio": "Hello!"}'
+
+# Get user by username
+curl http://localhost:4001/users/octocat
+
+# List users
+curl http://localhost:4001/users
+
+# User repos / orgs / followers / following
+curl http://localhost:4001/users/octocat/repos
+curl http://localhost:4001/users/octocat/orgs
+curl http://localhost:4001/users/octocat/followers
+curl http://localhost:4001/users/octocat/following
+
+# User hovercard
+curl http://localhost:4001/users/octocat/hovercard
+
+# User emails
+curl http://localhost:4001/user/emails -H "Authorization: Bearer $TOKEN"
+```
+
+### Repositories
+
+```bash
+# Get repo
+curl http://localhost:4001/repos/octocat/hello-world
+
+# Create user repo
+curl -X POST http://localhost:4001/user/repos \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "new-repo", "private": false}'
+
+# Create org repo
+curl -X POST http://localhost:4001/orgs/my-org/repos \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "org-project"}'
+
+# Update repo
+curl -X PATCH http://localhost:4001/repos/octocat/hello-world \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Updated description"}'
+
+# Delete repo (cascades issues, PRs, etc.)
+curl -X DELETE http://localhost:4001/repos/octocat/hello-world \
+  -H "Authorization: Bearer $TOKEN"
+
+# Topics, languages, contributors, forks, collaborators, tags, transfer
+```
+
+### Issues
+
+```bash
+# List issues (filter by state, labels, assignee, milestone, creator, since)
+curl "http://localhost:4001/repos/octocat/hello-world/issues?state=open&labels=bug"
+
+# Create issue
+curl -X POST http://localhost:4001/repos/octocat/hello-world/issues \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Bug report", "body": "Details here", "labels": ["bug"]}'
+
+# Get / update / lock / unlock / timeline / events / assignees
+```
+
+### Pull Requests
+
+```bash
+# List PRs
+curl "http://localhost:4001/repos/octocat/hello-world/pulls?state=open"
+
+# Create PR
+curl -X POST http://localhost:4001/repos/octocat/hello-world/pulls \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Feature", "head": "feature-branch", "base": "main"}'
+
+# Merge PR (enforces branch protection)
+curl -X PUT http://localhost:4001/repos/octocat/hello-world/pulls/1/merge \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"merge_method": "squash"}'
+
+# Commits, files, requested reviewers, update branch
+```
+
+### Comments
+
+```bash
+# Issue comments: full CRUD
+curl http://localhost:4001/repos/octocat/hello-world/issues/1/comments
+curl -X POST http://localhost:4001/repos/octocat/hello-world/issues/1/comments \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"body": "Looks good!"}'
+
+# Comment by ID (cross-resource)
+curl http://localhost:4001/repos/octocat/hello-world/issues/comments/1
+
+# PR review comments
+curl http://localhost:4001/repos/octocat/hello-world/pulls/1/comments
+
+# Commit comments
+curl http://localhost:4001/repos/octocat/hello-world/commits/abc123/comments
+
+# Repo-wide comment listings
+curl http://localhost:4001/repos/octocat/hello-world/issues/comments
+curl http://localhost:4001/repos/octocat/hello-world/pulls/comments
+curl http://localhost:4001/repos/octocat/hello-world/comments
+```
+
+### Reviews
+
+```bash
+# List / create / get / update / submit / dismiss reviews
+curl http://localhost:4001/repos/octocat/hello-world/pulls/1/reviews
+curl -X POST http://localhost:4001/repos/octocat/hello-world/pulls/1/reviews \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"event": "APPROVE", "body": "LGTM"}'
+```
+
+### Labels & Milestones
+
+Full CRUD for labels and milestones. Add/remove labels from issues, replace all labels. List labels for a milestone.
+
+### Branches & Git Data
+
+```bash
+# List branches
+curl http://localhost:4001/repos/octocat/hello-world/branches
+
+# Branch protection CRUD (status checks, PR reviews, enforce admins)
+curl -X PUT http://localhost:4001/repos/octocat/hello-world/branches/main/protection \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"required_status_checks": {"strict": true, "contexts": ["ci"]}}'
+
+# Refs, commits, trees (recursive), blobs, tags, matching-refs
+```
+
+### Organizations & Teams
+
+```bash
+# List all orgs / user's orgs / get org / update org
+curl http://localhost:4001/organizations
+curl http://localhost:4001/user/orgs -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4001/orgs/my-org
+curl -X PATCH http://localhost:4001/orgs/my-org \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Updated org"}'
+
+# Org members: list, get, remove
+curl http://localhost:4001/orgs/my-org/members
+curl http://localhost:4001/orgs/my-org/members/octocat
+curl -X DELETE http://localhost:4001/orgs/my-org/members/octocat \
+  -H "Authorization: Bearer $TOKEN"
+
+# Org memberships: get, set (invite/update role)
+curl http://localhost:4001/orgs/my-org/memberships/octocat -H "Authorization: Bearer $TOKEN"
+curl -X PUT http://localhost:4001/orgs/my-org/memberships/octocat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "admin"}'
+
+# Teams: CRUD
+curl http://localhost:4001/orgs/my-org/teams
+curl -X POST http://localhost:4001/orgs/my-org/teams \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "engineering", "privacy": "closed"}'
+
+# Team members and memberships
+curl http://localhost:4001/orgs/my-org/teams/engineering/members
+curl -X PUT http://localhost:4001/orgs/my-org/teams/engineering/memberships/octocat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "maintainer"}'
+
+# Team repos: list, add, remove
+curl http://localhost:4001/orgs/my-org/teams/engineering/repos
+curl -X PUT http://localhost:4001/orgs/my-org/teams/engineering/repos/my-org/org-repo \
+  -H "Authorization: Bearer $TOKEN"
+
+# Legacy team endpoints by ID
+curl http://localhost:4001/teams/1
+curl http://localhost:4001/teams/1/members
+```
+
+### GitHub Apps
+
+```bash
+# Get authenticated app (requires JWT auth)
+curl http://localhost:4001/app \
+  -H "Authorization: Bearer <jwt>"
+
+# List app installations
+curl http://localhost:4001/app/installations \
+  -H "Authorization: Bearer <jwt>"
+
+# Get installation
+curl http://localhost:4001/app/installations/100 \
+  -H "Authorization: Bearer <jwt>"
+
+# Create installation access token (mints ghs_... token)
+curl -X POST http://localhost:4001/app/installations/100/access_tokens \
+  -H "Authorization: Bearer <jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"permissions": {"contents": "read"}}'
+
+# Find installation for repo / org / user
+curl http://localhost:4001/repos/my-org/org-repo/installation
+curl http://localhost:4001/orgs/my-org/installation
+curl http://localhost:4001/users/octocat/installation
+```
+
+App webhook delivery: when events occur, the emulator POSTs `event_callback` payloads to configured `webhook_url` with `X-GitHub-Event` and `X-Hub-Signature-256` headers.
+
+### Releases
+
+```bash
+# Create release
+curl -X POST http://localhost:4001/repos/octocat/hello-world/releases \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tag_name": "v1.0.0", "name": "v1.0.0"}'
+
+# List, get, latest, by tag, generate notes
+
+# Release assets: list, upload
+curl http://localhost:4001/repos/octocat/hello-world/releases/1/assets
+curl -X POST http://localhost:4001/repos/octocat/hello-world/releases/1/assets \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  -H "name: binary.zip" \
+  --data-binary @binary.zip
+```
+
+### Webhooks
+
+```bash
+# Create webhook (real HTTP delivery on state changes)
+curl -X POST http://localhost:4001/repos/octocat/hello-world/hooks \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"config": {"url": "http://localhost:8080/webhook"}, "events": ["push", "pull_request"]}'
+
+# Full CRUD, ping, test, deliveries
+# Org webhooks also supported
+```
+
+### Search
+
+```bash
+# Search repositories
+curl "http://localhost:4001/search/repositories?q=language:JavaScript+user:octocat"
+
+# Search issues and PRs
+curl "http://localhost:4001/search/issues?q=repo:octocat/hello-world+is:open"
+
+# Search users, code, commits, topics, labels
+```
+
+### Actions
+
+```bash
+# Workflows: list, get, enable/disable, dispatch
+# Workflow runs: list, get, cancel, rerun, delete, logs
+# Jobs: list, get, logs
+# Artifacts: list, get, delete
+# Secrets: repo + org CRUD
+```
+
+### Checks
+
+```bash
+# Create check run
+curl -X POST http://localhost:4001/repos/octocat/hello-world/check-runs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "CI", "head_sha": "abc123", "status": "completed", "conclusion": "success"}'
+
+# Check suites: create, get, rerequest, preferences, list by ref
+# Check runs: list for suite, annotations
+# Automatic suite status rollup from check run results
+```
+
+### OAuth
+
+```bash
+# Authorize (browser flow, shows user picker)
+# GET /login/oauth/authorize?client_id=...&redirect_uri=...&scope=...&state=...
+
+# Token exchange
+curl -X POST http://localhost:4001/login/oauth/access_token \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{"client_id": "Iv1.abc123", "client_secret": "secret_abc123", "code": "<code>"}'
+
+# User emails
+curl http://localhost:4001/user/emails -H "Authorization: Bearer $TOKEN"
+
+# OAuth app management (settings)
+curl http://localhost:4001/settings/applications -H "Authorization: Bearer $TOKEN"
+curl http://localhost:4001/settings/connections/applications/Iv1.abc123 -H "Authorization: Bearer $TOKEN"
+
+# Revoke OAuth app
+curl -X POST http://localhost:4001/settings/connections/applications/Iv1.abc123/revoke \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Misc
+
+```bash
+curl http://localhost:4001/rate_limit
+curl http://localhost:4001/meta
+curl http://localhost:4001/emojis
+curl http://localhost:4001/versions
+curl http://localhost:4001/octocat
+curl http://localhost:4001/zen
+```
+
+## Common Patterns
+
+### Create Repo, Issue, and PR
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4001"
+
+# Create repo
+curl -X POST $BASE/user/repos \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-project"}'
+
+# Create issue
+curl -X POST $BASE/repos/admin/my-project/issues \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "First issue"}'
+
+# Create PR
+curl -X POST $BASE/repos/admin/my-project/pulls \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "First PR", "head": "feature", "base": "main"}'
+```
+
+### GitHub App Installation Token Flow
+
+```bash
+# 1. Sign a JWT with { iss: "12345" } using the app's private key (RS256)
+# 2. Create an installation access token
+curl -X POST $BASE/app/installations/100/access_tokens \
+  -H "Authorization: Bearer <jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"permissions": {"contents": "read", "issues": "write"}}'
+# Returns { "token": "ghs_...", ... }
+
+# 3. Use the installation token to call API endpoints
+curl $BASE/repos/my-org/org-repo \
+  -H "Authorization: Bearer ghs_..."
+```
+
+### OAuth Flow
+
+1. Redirect user to `$GITHUB_EMULATOR_URL/login/oauth/authorize?client_id=...&redirect_uri=...&scope=user+repo&state=...`
+2. User picks a seeded user on the emulator's UI
+3. Emulator redirects back with `?code=...&state=...`
+4. Exchange code for token via `POST /login/oauth/access_token`
+5. Use token to call API endpoints

--- a/plugins/emulate/.agents/skills/google/SKILL.md
+++ b/plugins/emulate/.agents/skills/google/SKILL.md
@@ -1,0 +1,600 @@
+---
+name: google
+description: Emulated Google OAuth 2.0, OpenID Connect, Gmail, Calendar, and Drive for local development and testing. Use when the user needs to test Google sign-in locally, emulate OIDC discovery, handle Google token exchange, configure Google OAuth clients, work with Gmail messages/drafts/threads/labels, manage Calendar events, upload or list Drive files, or work with Google userinfo without hitting real Google APIs. Triggers include "Google OAuth", "emulate Google", "mock Google login", "test Google sign-in", "OIDC emulator", "Google OIDC", "Gmail API", "Google Calendar", "Google Drive", "local Google auth", or any task requiring a local Google API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Google OAuth 2.0 / OIDC + Gmail, Calendar & Drive Emulator
+
+OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE support, ID tokens, OIDC discovery, refresh tokens, plus Gmail, Google Calendar, and Google Drive REST API surfaces.
+
+## Start
+
+```bash
+# Google only
+npx emulate --service google
+
+# Default port
+# http://localhost:4002
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const google = await createEmulator({ service: 'google', port: 4002 })
+// google.url === 'http://localhost:4002'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+GOOGLE_EMULATOR_URL=http://localhost:4002
+```
+
+### OAuth URL Mapping
+
+| Real Google URL | Emulator URL |
+|-----------------|-------------|
+| `https://accounts.google.com/o/oauth2/v2/auth` | `$GOOGLE_EMULATOR_URL/o/oauth2/v2/auth` |
+| `https://oauth2.googleapis.com/token` | `$GOOGLE_EMULATOR_URL/oauth2/token` |
+| `https://www.googleapis.com/oauth2/v2/userinfo` | `$GOOGLE_EMULATOR_URL/oauth2/v2/userinfo` |
+| `https://accounts.google.com/.well-known/openid-configuration` | `$GOOGLE_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://www.googleapis.com/oauth2/v3/certs` | `$GOOGLE_EMULATOR_URL/oauth2/v3/certs` |
+| `https://gmail.googleapis.com/gmail/v1/...` | `$GOOGLE_EMULATOR_URL/gmail/v1/...` |
+| `https://www.googleapis.com/calendar/v3/...` | `$GOOGLE_EMULATOR_URL/calendar/v3/...` |
+| `https://www.googleapis.com/drive/v3/...` | `$GOOGLE_EMULATOR_URL/drive/v3/...` |
+
+### google-auth-library (Node.js)
+
+```typescript
+import { OAuth2Client } from 'google-auth-library'
+
+const GOOGLE_URL = process.env.GOOGLE_EMULATOR_URL ?? 'https://accounts.google.com'
+
+const client = new OAuth2Client({
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  redirectUri: 'http://localhost:3000/api/auth/callback/google',
+})
+
+const emulatorAuthorizeUrl = `${GOOGLE_URL}/o/oauth2/v2/auth?client_id=${process.env.GOOGLE_CLIENT_ID}&redirect_uri=...&scope=openid+email+profile&response_type=code&state=...`
+```
+
+### Auth.js / NextAuth.js
+
+```typescript
+import Google from '@auth/core/providers/google'
+
+Google({
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.GOOGLE_EMULATOR_URL}/o/oauth2/v2/auth`,
+    params: { scope: 'openid email profile' },
+  },
+  token: {
+    url: `${process.env.GOOGLE_EMULATOR_URL}/oauth2/token`,
+  },
+  userinfo: {
+    url: `${process.env.GOOGLE_EMULATOR_URL}/oauth2/v2/userinfo`,
+  },
+})
+```
+
+### Passport.js
+
+```typescript
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20'
+
+const GOOGLE_URL = process.env.GOOGLE_EMULATOR_URL ?? 'https://accounts.google.com'
+
+new GoogleStrategy({
+  clientID: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  callbackURL: 'http://localhost:3000/api/auth/callback/google',
+  authorizationURL: `${GOOGLE_URL}/o/oauth2/v2/auth`,
+  tokenURL: `${GOOGLE_URL}/oauth2/token`,
+  userProfileURL: `${GOOGLE_URL}/oauth2/v2/userinfo`,
+}, verifyCallback)
+```
+
+## Seed Config
+
+```yaml
+google:
+  users:
+    - email: testuser@gmail.com
+      name: Test User
+      given_name: Test
+      family_name: User
+      picture: https://lh3.googleusercontent.com/a/default-user
+      email_verified: true
+      locale: en
+    - email: dev@example.com
+      name: Developer
+    - email: admin@acme.com
+      name: Admin
+      hd: acme.com
+  oauth_clients:
+    - client_id: my-client-id.apps.googleusercontent.com
+      client_secret: GOCSPX-secret
+      name: My App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/google
+  labels:
+    - id: Label_ops
+      user_email: testuser@gmail.com
+      name: Ops/Review
+      color_background: "#DDEEFF"
+      color_text: "#111111"
+  messages:
+    - id: msg_welcome
+      user_email: testuser@gmail.com
+      thread_id: thr_welcome
+      from: "welcome@example.com"
+      to: testuser@gmail.com
+      subject: Welcome to the Gmail emulator
+      body_text: You can now test Gmail flows locally.
+      label_ids: [INBOX, UNREAD, CATEGORY_UPDATES]
+      date: "2025-01-04T10:00:00.000Z"
+  calendars:
+    - id: primary
+      user_email: testuser@gmail.com
+      summary: testuser@gmail.com
+      primary: true
+      selected: true
+      time_zone: UTC
+  calendar_events:
+    - id: evt_kickoff
+      user_email: testuser@gmail.com
+      calendar_id: primary
+      summary: Project Kickoff
+      start_date_time: "2025-01-10T09:00:00.000Z"
+      end_date_time: "2025-01-10T09:30:00.000Z"
+      attendees:
+        - email: testuser@gmail.com
+          display_name: Test User
+      conference_entry_points:
+        - entry_point_type: video
+          uri: https://meet.google.com/example
+          label: Google Meet
+      hangout_link: https://meet.google.com/example
+  drive_items:
+    - id: drv_docs
+      user_email: testuser@gmail.com
+      name: Docs
+      mime_type: application/vnd.google-apps.folder
+      parent_ids: [root]
+    - id: drv_readme
+      user_email: testuser@gmail.com
+      name: README.md
+      mime_type: text/markdown
+      parent_ids: [drv_docs]
+      data: "# Hello World"
+```
+
+When no OAuth clients are configured, the emulator accepts any `client_id`. With clients configured, strict validation is enforced for `client_id`, `client_secret`, and `redirect_uri`.
+
+### Hosted domain (hd) claim
+
+Google Workspace accounts include an `hd` claim in ID tokens and userinfo responses identifying the user's hosted domain. The emulator derives this automatically from the user's email domain. Consumer domains (`gmail.com`, `googlemail.com`) omit the claim, matching real Google behavior.
+
+To override the derived value, set `hd` on a seeded user. To suppress the claim entirely, set `hd` to an empty string.
+
+## OAuth / OIDC Endpoints
+
+### OIDC Discovery
+
+```bash
+curl http://localhost:4002/.well-known/openid-configuration
+```
+
+### JWKS
+
+```bash
+curl http://localhost:4002/oauth2/v3/certs
+```
+
+Returns `{ "keys": [] }`. ID tokens are signed with HS256 using an internal secret.
+
+### Authorization
+
+```bash
+# Browser flow: redirects to a user picker page
+curl -v "http://localhost:4002/o/oauth2/v2/auth?\
+client_id=my-client-id.apps.googleusercontent.com&\
+redirect_uri=http://localhost:3000/api/auth/callback/google&\
+scope=openid+email+profile&\
+response_type=code&\
+state=random-state&\
+nonce=random-nonce"
+```
+
+Supports `code_challenge` and `code_challenge_method` for PKCE.
+
+### Token Exchange
+
+```bash
+curl -X POST http://localhost:4002/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<authorization_code>&\
+client_id=my-client-id.apps.googleusercontent.com&\
+client_secret=GOCSPX-secret&\
+redirect_uri=http://localhost:3000/api/auth/callback/google&\
+grant_type=authorization_code"
+```
+
+Also accepts `application/json` body. Returns:
+
+```json
+{
+  "access_token": "google_...",
+  "refresh_token": "google_refresh_...",
+  "id_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "openid email profile"
+}
+```
+
+### Refresh Token
+
+```bash
+curl -X POST http://localhost:4002/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "refresh_token=google_refresh_...&\
+client_id=my-client-id.apps.googleusercontent.com&\
+client_secret=GOCSPX-secret&\
+grant_type=refresh_token"
+```
+
+Returns a new `access_token` (no new `refresh_token` or `id_token` on refresh).
+
+### User Info
+
+```bash
+curl http://localhost:4002/oauth2/v2/userinfo \
+  -H "Authorization: Bearer google_..."
+```
+
+### Token Revocation
+
+```bash
+curl -X POST http://localhost:4002/oauth2/revoke \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=google_..."
+```
+
+## Gmail API
+
+All Gmail endpoints are under `/gmail/v1/users/:userId/...` where `:userId` is `me` or the authenticated user's email.
+
+### Messages
+
+```bash
+# List messages (filter by labels, search query)
+curl "http://localhost:4002/gmail/v1/users/me/messages?labelIds=INBOX&q=from:welcome&maxResults=10" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get message (format: full, metadata, minimal, raw)
+curl "http://localhost:4002/gmail/v1/users/me/messages/msg_welcome?format=full" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Send message
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/send \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"to": "someone@example.com", "subject": "Hello", "body_text": "Hi there"}'
+
+# Insert message (bypass send)
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"to": "test@example.com", "from": "me@example.com", "subject": "Test", "body_text": "Body", "labelIds": ["INBOX"]}'
+
+# Import message
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"to": "test@example.com", "from": "external@example.com", "subject": "Imported", "body_text": "Content"}'
+
+# Modify labels on a message
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/modify \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"addLabelIds": ["STARRED"], "removeLabelIds": ["UNREAD"]}'
+
+# Trash / untrash
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/trash \
+  -H "Authorization: Bearer $TOKEN"
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/msg_welcome/untrash \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete permanently
+curl -X DELETE http://localhost:4002/gmail/v1/users/me/messages/msg_welcome \
+  -H "Authorization: Bearer $TOKEN"
+
+# Batch modify
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/batchModify \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ids": ["msg_welcome", "msg_build"], "addLabelIds": ["STARRED"]}'
+
+# Batch delete
+curl -X POST http://localhost:4002/gmail/v1/users/me/messages/batchDelete \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ids": ["msg_welcome"]}'
+
+# Get attachment
+curl http://localhost:4002/gmail/v1/users/me/messages/msg_id/attachments/att_id \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Upload variants also available at `/upload/gmail/v1/users/:userId/messages`, `.../messages/send`, `.../messages/import`.
+
+### Drafts
+
+```bash
+# List drafts
+curl http://localhost:4002/gmail/v1/users/me/drafts \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create draft
+curl -X POST http://localhost:4002/gmail/v1/users/me/drafts \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": {"to": "someone@example.com", "subject": "Draft subject", "body_text": "Draft body"}}'
+
+# Get draft (format: full, metadata, minimal, raw)
+curl "http://localhost:4002/gmail/v1/users/me/drafts/draft_id?format=full" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Update draft
+curl -X PUT http://localhost:4002/gmail/v1/users/me/drafts/draft_id \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": {"subject": "Updated subject", "body_text": "Updated body"}}'
+
+# Send draft
+curl -X POST http://localhost:4002/gmail/v1/users/me/drafts/send \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "draft_id"}'
+
+# Delete draft
+curl -X DELETE http://localhost:4002/gmail/v1/users/me/drafts/draft_id \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Threads
+
+```bash
+# List threads (filter by labels, search query)
+curl "http://localhost:4002/gmail/v1/users/me/threads?labelIds=INBOX&maxResults=20" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get thread (all messages in thread)
+curl "http://localhost:4002/gmail/v1/users/me/threads/thr_welcome?format=full" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Modify labels on all messages in thread
+curl -X POST http://localhost:4002/gmail/v1/users/me/threads/thr_welcome/modify \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"addLabelIds": ["STARRED"], "removeLabelIds": ["UNREAD"]}'
+
+# Trash / untrash / delete thread
+curl -X POST http://localhost:4002/gmail/v1/users/me/threads/thr_welcome/trash \
+  -H "Authorization: Bearer $TOKEN"
+curl -X DELETE http://localhost:4002/gmail/v1/users/me/threads/thr_welcome \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Labels
+
+```bash
+# List labels
+curl http://localhost:4002/gmail/v1/users/me/labels \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get label
+curl http://localhost:4002/gmail/v1/users/me/labels/INBOX \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create label
+curl -X POST http://localhost:4002/gmail/v1/users/me/labels \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Label", "color": {"backgroundColor": "#DDEEFF", "textColor": "#111111"}}'
+
+# Update label (PUT replaces, PATCH merges)
+curl -X PATCH http://localhost:4002/gmail/v1/users/me/labels/Label_ops \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Ops/Reviewed"}'
+
+# Delete label (user labels only)
+curl -X DELETE http://localhost:4002/gmail/v1/users/me/labels/Label_ops \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### History & Watch
+
+```bash
+# List history changes since a given historyId
+curl "http://localhost:4002/gmail/v1/users/me/history?startHistoryId=1&historyTypes=messageAdded&maxResults=100" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Set up push notification watch (stub)
+curl -X POST http://localhost:4002/gmail/v1/users/me/watch \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"topicName": "projects/my-project/topics/gmail", "labelIds": ["INBOX"]}'
+
+# Stop watch
+curl -X POST http://localhost:4002/gmail/v1/users/me/stop \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Settings
+
+```bash
+# List filters
+curl http://localhost:4002/gmail/v1/users/me/settings/filters \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create filter (auto-label incoming messages matching criteria)
+curl -X POST http://localhost:4002/gmail/v1/users/me/settings/filters \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"criteria": {"from": "alerts@example.com"}, "action": {"addLabelIds": ["Label_ops"]}}'
+
+# Delete filter
+curl -X DELETE http://localhost:4002/gmail/v1/users/me/settings/filters/filter_id \
+  -H "Authorization: Bearer $TOKEN"
+
+# List forwarding addresses
+curl http://localhost:4002/gmail/v1/users/me/settings/forwardingAddresses \
+  -H "Authorization: Bearer $TOKEN"
+
+# List send-as aliases
+curl http://localhost:4002/gmail/v1/users/me/settings/sendAs \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Google Calendar API
+
+### Calendar List
+
+```bash
+curl http://localhost:4002/calendar/v3/users/me/calendarList \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Events
+
+```bash
+# List events (filter by time range, search, order)
+curl "http://localhost:4002/calendar/v3/calendars/primary/events?\
+timeMin=2025-01-01T00:00:00Z&timeMax=2025-12-31T23:59:59Z&maxResults=50&orderBy=startTime" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create event
+curl -X POST http://localhost:4002/calendar/v3/calendars/primary/events \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"summary": "Team Meeting", "start": {"dateTime": "2025-01-10T14:00:00Z"}, "end": {"dateTime": "2025-01-10T15:00:00Z"}, "attendees": [{"email": "dev@example.com"}]}'
+
+# Delete event
+curl -X DELETE http://localhost:4002/calendar/v3/calendars/primary/events/evt_kickoff \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### FreeBusy
+
+```bash
+curl -X POST http://localhost:4002/calendar/v3/freeBusy \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"timeMin": "2025-01-10T00:00:00Z", "timeMax": "2025-01-10T23:59:59Z", "items": [{"id": "primary"}]}'
+```
+
+## Google Drive API
+
+### Files
+
+```bash
+# List files (with query filter, pagination, ordering)
+curl "http://localhost:4002/drive/v3/files?q='root'+in+parents&pageSize=20" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create file (JSON metadata)
+curl -X POST http://localhost:4002/drive/v3/files \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "notes.txt", "mimeType": "text/plain", "parents": ["root"]}'
+
+# Create file with content (multipart/related upload)
+curl -X POST http://localhost:4002/upload/drive/v3/files \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: multipart/related; boundary=boundary" \
+  --data-binary $'--boundary\r\nContent-Type: application/json\r\n\r\n{"name":"data.csv","mimeType":"text/csv"}\r\n--boundary\r\nContent-Type: text/csv\r\n\r\na,b,c\n1,2,3\r\n--boundary--'
+
+# Get file metadata
+curl http://localhost:4002/drive/v3/files/drv_readme \
+  -H "Authorization: Bearer $TOKEN"
+
+# Download file content
+curl "http://localhost:4002/drive/v3/files/drv_readme?alt=media" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Update file (PATCH or PUT; move parents with query params)
+curl -X PATCH "http://localhost:4002/drive/v3/files/drv_readme?addParents=folder_id&removeParents=root" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "README-updated.md"}'
+```
+
+## Common Patterns
+
+### Full Authorization Code Flow
+
+```bash
+GOOGLE_URL="http://localhost:4002"
+CLIENT_ID="my-client-id.apps.googleusercontent.com"
+CLIENT_SECRET="GOCSPX-secret"
+REDIRECT_URI="http://localhost:3000/api/auth/callback/google"
+
+# 1. Open in browser (user picks a seeded account)
+#    $GOOGLE_URL/o/oauth2/v2/auth?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&scope=openid+email+profile&response_type=code&state=abc
+
+# 2. After user selection, emulator redirects to:
+#    $REDIRECT_URI?code=<code>&state=abc
+
+# 3. Exchange code for tokens
+curl -X POST $GOOGLE_URL/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<code>&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&redirect_uri=$REDIRECT_URI&grant_type=authorization_code"
+
+# 4. Fetch user info with the access_token
+curl $GOOGLE_URL/oauth2/v2/userinfo \
+  -H "Authorization: Bearer <access_token>"
+```
+
+### OIDC Discovery-Based Setup
+
+```typescript
+import { Issuer } from 'openid-client'
+
+const googleIssuer = await Issuer.discover(
+  process.env.GOOGLE_EMULATOR_URL ?? 'https://accounts.google.com'
+)
+
+const client = new googleIssuer.Client({
+  client_id: process.env.GOOGLE_CLIENT_ID,
+  client_secret: process.env.GOOGLE_CLIENT_SECRET,
+  redirect_uris: ['http://localhost:3000/api/auth/callback/google'],
+})
+```
+
+### Send a Gmail Message and Check the Thread
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4002"
+
+# Send a message
+curl -X POST $BASE/gmail/v1/users/me/messages/send \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"to": "someone@example.com", "subject": "Test", "body_text": "Hello"}'
+
+# List threads in INBOX
+curl "$BASE/gmail/v1/users/me/threads?labelIds=INBOX" \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/plugins/emulate/.agents/skills/linear/SKILL.md
+++ b/plugins/emulate/.agents/skills/linear/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: linear
+description: Emulated Linear GraphQL API for local development and testing. Use when the user needs to test Linear integrations locally, emulate Linear issues, comments, teams, workflow states, OAuth apps, webhooks, agent sessions, or work with the Linear API without hitting the real Linear service. Triggers include "Linear API", "emulate Linear", "mock Linear", "test Linear OAuth", "Linear webhook", "Linear agent", "local Linear", or any task requiring a local Linear API.
+allowed-tools: Bash(npx emulate:*)
+---
+
+# Linear API Emulator
+
+Stateful Linear GraphQL API emulation with organizations, users, teams, workflow states, issues, comments, labels, projects, cycles, OAuth apps, tokens, webhooks, and basic agent sessions.
+
+## Start
+
+```bash
+# Linear only
+npx emulate --service linear
+```
+
+Default URL: `http://localhost:4012` when all services are started, or `http://localhost:4000` when Linear is the only service.
+
+## URL Mapping
+
+| Real Linear URL | Emulator URL |
+|-----------------|--------------|
+| `https://api.linear.app/graphql` | `$LINEAR_EMULATOR_URL/graphql` |
+| `https://linear.app/oauth/authorize` | `$LINEAR_EMULATOR_URL/oauth/authorize` |
+| `https://api.linear.app/oauth/token` | `$LINEAR_EMULATOR_URL/oauth/token` |
+| `https://api.linear.app/oauth/revoke` | `$LINEAR_EMULATOR_URL/oauth/revoke` |
+
+## Auth
+
+GraphQL accepts a bearer token or bare personal API key:
+
+```bash
+curl "$LINEAR_EMULATOR_URL/graphql" \
+  -H "Authorization: Bearer lin_test_admin" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { id email } }"}'
+```
+
+Scope checks are relaxed by default. Set `linear.strict_scopes: true` in seed config to require supported operation scopes such as `read`, `write`, `issues:create`, `comments:create`, and `admin`.
+
+## Seed Config
+
+```yaml
+linear:
+  organization:
+    name: Acme
+    url_key: acme
+  users:
+    - email: admin@example.com
+      name: Admin User
+      admin: true
+    - email: dev@example.com
+      name: Developer
+  teams:
+    - key: ENG
+      name: Engineering
+  issues:
+    - team: ENG
+      title: Fix local checkout test
+      state: Todo
+      assignee: dev@example.com
+  oauth_apps:
+    - client_id: lin_example_client_id
+      client_secret: example_client_secret
+      name: My Linear App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/linear
+      scopes: [read, write, issues:create, comments:create]
+  tokens:
+    - token: lin_test_admin
+      user: admin@example.com
+      scopes: [read, write, issues:create, comments:create, admin]
+  strict_scopes: false
+```
+
+## GraphQL Surface
+
+Supported queries:
+
+- `viewer`
+- `organization`
+- `users`, `user`
+- `teams`, `team`
+- `workflowStates`, `workflowState`
+- `issues`, `issue`
+- `comments`, `comment`
+- `issueLabels`, `issueLabel`
+- `projects`, `project`
+- `cycles`, `cycle`
+- `webhooks`, `webhook`
+- `agentSessions`, `agentSession`
+
+Supported mutations:
+
+- `issueCreate`, `issueUpdate`, `issueDelete`, `issueArchive`, `issueUnarchive`
+- `commentCreate`, `commentUpdate`, `commentDelete`
+- `issueLabelCreate`, `issueLabelUpdate`, `issueLabelDelete`
+- `issueAddLabel`, `issueRemoveLabel`
+- `webhookCreate`, `webhookDelete`
+- `agentSessionCreateOnIssue`, `agentSessionCreateOnComment`, `agentSessionUpdate`
+- `agentActivityCreate`
+
+Connections use Relay-style cursors with `nodes`, `edges`, and `pageInfo`.
+
+## OAuth
+
+- `GET /oauth/authorize` - authorization endpoint with local user picker
+- `POST /oauth/authorize/callback` - local user picker callback
+- `POST /oauth/token` - authorization code, refresh token, and client credentials grants
+- `POST /oauth/revoke` - revoke access or refresh tokens
+
+OAuth apps can use `actor: user` or `actor: app`. The configured actor is authoritative. User actor apps use authorization code flows. App actor apps use the app install flow and can request client credentials tokens. App actor support is sufficient for local agent and service-account tests, but it is not full production Linear agent behavior.
+
+## Webhooks
+
+Create local webhook subscriptions through `webhookCreate` or seed config. Supported writes dispatch Linear-shaped payloads with `Linear-Delivery`, `Linear-Event`, and `Linear-Signature` headers when a secret is configured.
+
+## Inspector
+
+Open `GET /` in the Linear emulator to inspect issues, teams, users, projects, agent sessions, OAuth apps, tokens, webhook subscriptions, and webhook deliveries.
+
+## Current Limits
+
+Full Linear schema coverage, exact production rate limiting, notification inbox behavior, rich document APIs, customer APIs, initiative APIs, exact search relevance, and full production agent behavior are not implemented.

--- a/plugins/emulate/.agents/skills/microsoft/SKILL.md
+++ b/plugins/emulate/.agents/skills/microsoft/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: microsoft
+description: Emulated Microsoft Entra ID (Azure AD) OAuth 2.0 / OpenID Connect for local development and testing. Use when the user needs to test Microsoft sign-in locally, emulate Entra ID OIDC discovery, handle Microsoft token exchange, configure Azure AD OAuth clients, work with Microsoft Graph /me, or test PKCE/client credentials flows without hitting real Microsoft APIs. Triggers include "Microsoft OAuth", "Entra ID", "Azure AD", "emulate Microsoft", "mock Microsoft login", "test Microsoft sign-in", "Microsoft OIDC", "local Microsoft auth", or any task requiring a local Microsoft OAuth/OIDC provider.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Microsoft Entra ID Emulator
+
+Microsoft Entra ID (Azure AD) v2.0 OAuth 2.0 and OpenID Connect emulation with authorization code flow, PKCE, client credentials, RS256 ID tokens, OIDC discovery, and a Microsoft Graph `/v1.0/me` endpoint.
+
+## Start
+
+```bash
+# Microsoft only
+npx emulate --service microsoft
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const microsoft = await createEmulator({ service: 'microsoft', port: 4005 })
+// microsoft.url === 'http://localhost:4005'
+```
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+MICROSOFT_EMULATOR_URL=http://localhost:4005
+```
+
+### OAuth URL Mapping
+
+| Real Microsoft URL | Emulator URL |
+|--------------------|-------------|
+| `https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration` | `$MICROSOFT_EMULATOR_URL/{tenant}/v2.0/.well-known/openid-configuration` |
+| `https://login.microsoftonline.com/.well-known/openid-configuration` | `$MICROSOFT_EMULATOR_URL/.well-known/openid-configuration` |
+| `https://login.microsoftonline.com/common/oauth2/v2.0/authorize` | `$MICROSOFT_EMULATOR_URL/oauth2/v2.0/authorize` |
+| `https://login.microsoftonline.com/common/oauth2/v2.0/token` | `$MICROSOFT_EMULATOR_URL/oauth2/v2.0/token` |
+| `https://login.microsoftonline.com/common/discovery/v2.0/keys` | `$MICROSOFT_EMULATOR_URL/discovery/v2.0/keys` |
+| `https://graph.microsoft.com/oidc/userinfo` | `$MICROSOFT_EMULATOR_URL/oidc/userinfo` |
+| `https://graph.microsoft.com/v1.0/me` | `$MICROSOFT_EMULATOR_URL/v1.0/me` |
+
+### Auth.js / NextAuth.js
+
+```typescript
+import MicrosoftEntraId from '@auth/core/providers/microsoft-entra-id'
+
+MicrosoftEntraId({
+  clientId: process.env.MICROSOFT_CLIENT_ID,
+  clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+  authorization: {
+    url: `${process.env.MICROSOFT_EMULATOR_URL}/oauth2/v2.0/authorize`,
+    params: { scope: 'openid email profile User.Read' },
+  },
+  token: {
+    url: `${process.env.MICROSOFT_EMULATOR_URL}/oauth2/v2.0/token`,
+  },
+  userinfo: {
+    url: `${process.env.MICROSOFT_EMULATOR_URL}/oidc/userinfo`,
+  },
+  issuer: process.env.MICROSOFT_EMULATOR_URL,
+})
+```
+
+### Passport.js
+
+```typescript
+import { OIDCStrategy } from 'passport-azure-ad'
+
+const MICROSOFT_URL = process.env.MICROSOFT_EMULATOR_URL ?? 'https://login.microsoftonline.com'
+
+new OIDCStrategy({
+  identityMetadata: `${MICROSOFT_URL}/.well-known/openid-configuration`,
+  clientID: process.env.MICROSOFT_CLIENT_ID,
+  clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+  redirectUrl: 'http://localhost:3000/api/auth/callback/microsoft-entra-id',
+  responseType: 'code',
+  responseMode: 'query',
+  scope: ['openid', 'email', 'profile'],
+}, verifyCallback)
+```
+
+### MSAL.js
+
+```typescript
+import { ConfidentialClientApplication } from '@azure/msal-node'
+
+const msalConfig = {
+  auth: {
+    clientId: process.env.MICROSOFT_CLIENT_ID,
+    clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+    authority: process.env.MICROSOFT_EMULATOR_URL,
+    knownAuthorities: [process.env.MICROSOFT_EMULATOR_URL],
+  },
+}
+
+const cca = new ConfidentialClientApplication(msalConfig)
+```
+
+## Seed Config
+
+```yaml
+microsoft:
+  users:
+    - email: testuser@outlook.com
+      name: Test User
+      given_name: Test
+      family_name: User
+      tenant_id: 9188040d-6c67-4c5b-b112-36a304b66dad
+  oauth_clients:
+    - client_id: example-client-id
+      client_secret: example-client-secret
+      name: My Microsoft App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/microsoft-entra-id
+      tenant_id: 9188040d-6c67-4c5b-b112-36a304b66dad
+```
+
+When no OAuth clients are configured, the emulator accepts any `client_id`. With clients configured, strict validation is enforced for `client_id`, `client_secret`, and `redirect_uri`.
+
+## API Endpoints
+
+### OIDC Discovery
+
+```bash
+# Default tenant
+curl http://localhost:4005/.well-known/openid-configuration
+
+# Tenant-scoped (common, organizations, consumers, or specific tenant ID)
+curl http://localhost:4005/common/v2.0/.well-known/openid-configuration
+```
+
+Returns the standard OIDC discovery document:
+
+```json
+{
+  "issuer": "http://localhost:4005/{tenant}/v2.0",
+  "authorization_endpoint": "http://localhost:4005/oauth2/v2.0/authorize",
+  "token_endpoint": "http://localhost:4005/oauth2/v2.0/token",
+  "userinfo_endpoint": "http://localhost:4005/oidc/userinfo",
+  "end_session_endpoint": "http://localhost:4005/oauth2/v2.0/logout",
+  "jwks_uri": "http://localhost:4005/discovery/v2.0/keys",
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["pairwise"],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "scopes_supported": ["openid", "email", "profile", "User.Read", "offline_access"],
+  "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"]
+}
+```
+
+### JWKS
+
+```bash
+curl http://localhost:4005/discovery/v2.0/keys
+```
+
+Returns an RSA public key (`kid`: `emulate-microsoft-1`) for verifying `id_token` signatures.
+
+### Authorization
+
+```bash
+# Browser flow: redirects to a user picker page
+curl -v "http://localhost:4005/oauth2/v2.0/authorize?\
+client_id=example-client-id&\
+redirect_uri=http://localhost:3000/api/auth/callback/microsoft-entra-id&\
+scope=openid+email+profile&\
+response_type=code&\
+state=random-state&\
+nonce=random-nonce"
+```
+
+Query parameters:
+
+| Param | Description |
+|-------|-------------|
+| `client_id` | OAuth client ID |
+| `redirect_uri` | Callback URL |
+| `scope` | Space-separated scopes (`openid email profile User.Read`) |
+| `state` | Opaque state for CSRF protection |
+| `nonce` | Nonce for ID token (optional) |
+| `response_mode` | `query` (default) or `form_post` |
+| `code_challenge` | PKCE challenge (optional) |
+| `code_challenge_method` | `plain` or `S256` (optional) |
+
+### Token Exchange
+
+```bash
+curl -X POST http://localhost:4005/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<authorization_code>&\
+client_id=example-client-id&\
+client_secret=example-client-secret&\
+redirect_uri=http://localhost:3000/api/auth/callback/microsoft-entra-id&\
+grant_type=authorization_code"
+```
+
+Returns:
+
+```json
+{
+  "access_token": "microsoft_...",
+  "refresh_token": "r_microsoft_...",
+  "id_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "openid email profile"
+}
+```
+
+The `id_token` is an RS256 JWT containing `sub`, `oid`, `tid` (tenant ID), `email`, `name`, `preferred_username`, `ver` ("2.0"), and optional `nonce`.
+
+For PKCE, include `code_verifier` in the token request.
+
+Supports `Authorization: Basic` header with base64-encoded `client_id:client_secret` as an alternative to body parameters.
+
+### Client Credentials
+
+```bash
+curl -X POST http://localhost:4005/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "client_id=example-client-id&\
+client_secret=example-client-secret&\
+grant_type=client_credentials&\
+scope=https://graph.microsoft.com/.default"
+```
+
+Returns an `access_token` only (no `refresh_token` or `id_token`).
+
+### Refresh Token
+
+```bash
+curl -X POST http://localhost:4005/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "refresh_token=r_microsoft_...&\
+client_id=example-client-id&\
+grant_type=refresh_token"
+```
+
+Returns a new `access_token`, rotated `refresh_token`, and new `id_token`.
+
+### User Info
+
+```bash
+curl http://localhost:4005/oidc/userinfo \
+  -H "Authorization: Bearer microsoft_..."
+```
+
+Returns:
+
+```json
+{
+  "sub": "<oid>",
+  "email": "testuser@outlook.com",
+  "name": "Test User",
+  "given_name": "Test",
+  "family_name": "User",
+  "preferred_username": "testuser@outlook.com"
+}
+```
+
+### Microsoft Graph /me
+
+```bash
+curl http://localhost:4005/v1.0/me \
+  -H "Authorization: Bearer microsoft_..."
+```
+
+Returns an OData-style response:
+
+```json
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+  "displayName": "Test User",
+  "mail": "testuser@outlook.com",
+  "userPrincipalName": "testuser@outlook.com",
+  "id": "<oid>"
+}
+```
+
+### Logout
+
+```bash
+curl "http://localhost:4005/oauth2/v2.0/logout?post_logout_redirect_uri=http://localhost:3000"
+```
+
+Redirects to the `post_logout_redirect_uri` if provided and valid.
+
+### Token Revocation
+
+```bash
+curl -X POST http://localhost:4005/oauth2/v2.0/revoke \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=microsoft_..."
+```
+
+Returns `200 OK`. The token is removed from the emulator's token map.
+
+## Common Patterns
+
+### Full Authorization Code Flow
+
+```bash
+MICROSOFT_URL="http://localhost:4005"
+CLIENT_ID="example-client-id"
+CLIENT_SECRET="example-client-secret"
+REDIRECT_URI="http://localhost:3000/api/auth/callback/microsoft-entra-id"
+
+# 1. Open in browser (user picks a seeded account)
+#    $MICROSOFT_URL/oauth2/v2.0/authorize?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&scope=openid+email+profile&response_type=code&state=abc
+
+# 2. After user selection, emulator redirects to:
+#    $REDIRECT_URI?code=<code>&state=abc
+
+# 3. Exchange code for tokens
+curl -X POST $MICROSOFT_URL/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<code>&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&redirect_uri=$REDIRECT_URI&grant_type=authorization_code"
+
+# 4. Fetch user info with the access_token
+curl $MICROSOFT_URL/oidc/userinfo \
+  -H "Authorization: Bearer <access_token>"
+```
+
+### PKCE Flow
+
+```bash
+CODE_VERIFIER=$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-43)
+CODE_CHALLENGE=$(echo -n $CODE_VERIFIER | openssl dgst -sha256 -binary | base64 | tr -d '=' | tr '+/' '-_')
+
+# 1. Authorize with challenge
+# $MICROSOFT_URL/oauth2/v2.0/authorize?...&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256
+
+# 2. Token exchange with verifier
+curl -X POST $MICROSOFT_URL/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "code=<code>&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&redirect_uri=$REDIRECT_URI&grant_type=authorization_code&code_verifier=$CODE_VERIFIER"
+```
+
+### OIDC Discovery-Based Setup
+
+Libraries that support OIDC discovery can auto-configure from the discovery document:
+
+```typescript
+import { Issuer } from 'openid-client'
+
+const microsoftIssuer = await Issuer.discover(
+  process.env.MICROSOFT_EMULATOR_URL ?? 'https://login.microsoftonline.com/common/v2.0'
+)
+
+const client = new microsoftIssuer.Client({
+  client_id: process.env.MICROSOFT_CLIENT_ID,
+  client_secret: process.env.MICROSOFT_CLIENT_SECRET,
+  redirect_uris: ['http://localhost:3000/api/auth/callback/microsoft-entra-id'],
+})
+```

--- a/plugins/emulate/.agents/skills/next/SKILL.md
+++ b/plugins/emulate/.agents/skills/next/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: next
+description: Next.js adapter for embedding emulators directly in a Next.js app via @emulators/adapter-next. Use when the user needs to embed emulators in Next.js, set up same-origin OAuth for Vercel preview deployments, create an emulate catch-all route handler, configure Auth.js/NextAuth with embedded emulators, add persistence to embedded emulators, or wrap next.config with withEmulate. Triggers include "Next.js emulator", "adapter-next", "embedded emulator", "same-origin OAuth", "Vercel preview", "createEmulateHandler", "withEmulate", or any task requiring emulators inside a Next.js app.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*)
+---
+
+# Next.js Integration
+
+The `@emulators/adapter-next` package embeds emulators directly into a Next.js App Router app, running them on the same origin. This is particularly useful for Vercel preview deployments where OAuth callback URLs change with every deployment.
+
+## Install
+
+```bash
+npm install @emulators/adapter-next @emulators/github @emulators/google
+```
+
+Only install the emulators you need. Each `@emulators/*` package is published independently, keeping serverless bundles small.
+
+## Route Handler
+
+Create a catch-all route that serves emulator traffic:
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateHandler } from '@emulators/adapter-next'
+import * as github from '@emulators/github'
+import * as google from '@emulators/google'
+
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: {
+    github: {
+      emulator: github,
+      seed: {
+        users: [{ login: 'octocat', name: 'The Octocat' }],
+        repos: [{ owner: 'octocat', name: 'hello-world', auto_init: true }],
+      },
+    },
+    google: {
+      emulator: google,
+      seed: {
+        users: [{ email: 'test@example.com', name: 'Test User' }],
+      },
+    },
+  },
+})
+```
+
+This creates the following routes:
+
+- `/emulate/github/**` serves the GitHub emulator
+- `/emulate/google/**` serves the Google emulator
+
+## Auth.js / NextAuth Configuration
+
+Point your provider at the emulator paths on the same origin:
+
+```typescript
+import GitHub from 'next-auth/providers/github'
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : 'http://localhost:3000'
+
+GitHub({
+  clientId: 'any-value',
+  clientSecret: 'any-value',
+  authorization: { url: `${baseUrl}/emulate/github/login/oauth/authorize` },
+  token: { url: `${baseUrl}/emulate/github/login/oauth/access_token` },
+  userinfo: { url: `${baseUrl}/emulate/github/user` },
+})
+```
+
+No `oauth_apps` need to be seeded. When none are configured, the emulator skips `client_id`, `client_secret`, and `redirect_uri` validation.
+
+## Font Tracing for Serverless
+
+Emulator UI pages use bundled fonts. Wrap your Next.js config to include them in the serverless trace:
+
+```typescript
+// next.config.mjs
+import { withEmulate } from '@emulators/adapter-next'
+
+export default withEmulate({
+  // your normal Next.js config
+})
+```
+
+If you mount the catch-all at a custom path, pass the matching prefix:
+
+```typescript
+export default withEmulate(nextConfig, { routePrefix: '/api/emulate' })
+```
+
+## Persistence
+
+By default, emulator state is in-memory and resets on every cold start. To persist state across restarts, pass a `persistence` adapter.
+
+### Custom Adapter (Vercel KV, Redis, etc.)
+
+```typescript
+import { createEmulateHandler } from '@emulators/adapter-next'
+import * as github from '@emulators/github'
+
+const kvAdapter = {
+  async load() { return await kv.get('emulate-state') },
+  async save(data: string) { await kv.set('emulate-state', data) },
+}
+
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: { github: { emulator: github } },
+  persistence: kvAdapter,
+})
+```
+
+### File Persistence (Local Dev)
+
+For local development, `@emulators/core` ships a file-based adapter:
+
+```typescript
+import { filePersistence } from '@emulators/core'
+
+// persists to a JSON file
+persistence: filePersistence('.emulate/state.json'),
+```
+
+### How Persistence Works
+
+- **Cold start**: The adapter loads state from the persistence adapter. If found, it restores the full Store and token map (skipping seed). If not found, it seeds from config and saves the initial state.
+- **After mutating requests** (POST, PUT, PATCH, DELETE): State is saved. Saves are serialized via an internal queue to prevent race conditions.
+- **No persistence configured**: Falls back to pure in-memory. Seed data re-initializes on every cold start.
+
+## How It Works
+
+1. **Incoming request**: `/emulate/github/login/oauth/authorize?client_id=...`
+2. **Parse**: service = `github`, rest = `/login/oauth/authorize`
+3. **Strip prefix**: A new `Request` is created with the stripped path and forwarded to the GitHub service app
+4. **Rewrite response**: HTML `action` and `href` attributes, CSS `url()` font references, and `Location` headers get the service prefix prepended
+5. **Persist**: After mutating requests, state is saved via the persistence adapter
+
+## Limitations
+
+- Requires the Node.js runtime (not Edge) since emulators use `crypto.randomBytes`
+- Concurrent serverless instances writing to the same persistence adapter use last-write-wins semantics (acceptable for dev/preview traffic)
+
+## Config Reference
+
+### `createEmulateHandler(config)`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `services` | `Record<string, EmulatorEntry>` | Map of service name to emulator config |
+| `persistence?` | `PersistenceAdapter` | Optional persistence adapter for state across cold starts |
+
+Each `EmulatorEntry`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `emulator` | `EmulatorModule` | The emulator package (e.g. `import * as github from '@emulators/github'`) |
+| `seed?` | `Record<string, unknown>` | Seed data matching the service's config schema |
+
+### `withEmulate(nextConfig, options?)`
+
+Wraps a Next.js config to include emulator font files in the serverless output trace. Call it around your exported config in `next.config.mjs` or `next.config.ts`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `routePrefix` | `string` | `"/emulate"` | The path prefix where the catch-all route is mounted |
+
+### `PersistenceAdapter`
+
+```typescript
+interface PersistenceAdapter {
+  load(): Promise<string | null>
+  save(data: string): Promise<void>
+}
+```
+
+The built-in `filePersistence(path)` from `@emulators/core` provides a file-based adapter for local development.

--- a/plugins/emulate/.agents/skills/resend/SKILL.md
+++ b/plugins/emulate/.agents/skills/resend/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: resend
+description: Emulated Resend email API for local development and testing. Use when the user needs to send emails locally, test transactional email flows, implement magic link or verification code auth, inspect sent emails, manage domains/contacts/API keys, or work with the Resend API without sending real emails. Triggers include "Resend API", "emulate Resend", "send email locally", "test email", "magic link", "verification email", "email inbox", "RESEND_BASE_URL", or any task requiring a local email API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Resend Email API Emulator
+
+Fully stateful Resend API emulation. Emails, domains, API keys, audiences, and contacts persist in memory. Sent emails are captured and viewable through the inbox UI or the REST API.
+
+No real emails are sent. Every call to `POST /emails` stores the message locally so you can inspect it programmatically or in the browser.
+
+## Start
+
+```bash
+# Resend only
+npx emulate --service resend
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const resend = await createEmulator({ service: 'resend', port: 4000 })
+// resend.url === 'http://localhost:4000'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. Any `re_` prefixed token is accepted.
+
+```bash
+curl http://localhost:4000/emails \
+  -H "Authorization: Bearer re_test_key"
+```
+
+When no token is provided, requests fall back to the default user.
+
+## Pointing Your App at the Emulator
+
+### Environment Variable (Resend SDK)
+
+The official Resend Node.js SDK reads `RESEND_BASE_URL` at module load time. Set it to the emulator URL and the SDK works without any code changes:
+
+```bash
+RESEND_BASE_URL=http://localhost:4000
+```
+
+```typescript
+import { Resend } from 'resend'
+
+// No baseUrl argument needed; the SDK reads RESEND_BASE_URL automatically.
+const resend = new Resend('re_test_key')
+
+await resend.emails.send({
+  from: 'hello@example.com',
+  to: 'user@example.com',
+  subject: 'Hello',
+  html: '<p>It works!</p>',
+})
+```
+
+### Embedded in Next.js (adapter-next)
+
+When using `@emulators/adapter-next`, the emulator runs inside your Next.js app at `/emulate/resend`. Set `RESEND_BASE_URL` via `next.config.ts`:
+
+```typescript
+// next.config.ts
+import { withEmulate } from '@emulators/adapter-next'
+
+export default withEmulate({
+  env: {
+    RESEND_BASE_URL: `http://localhost:${process.env.PORT ?? '3000'}/emulate/resend`,
+  },
+})
+```
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateHandler } from '@emulators/adapter-next'
+import * as resend from '@emulators/resend'
+
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: {
+    resend: {
+      emulator: resend,
+      seed: {
+        domains: [{ name: 'example.com' }],
+      },
+    },
+  },
+})
+```
+
+### Direct fetch
+
+If you cannot use the SDK or env var, call the emulator directly:
+
+```typescript
+await fetch('http://localhost:4000/emails', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer re_test_key',
+  },
+  body: JSON.stringify({
+    from: 'hello@example.com',
+    to: 'user@example.com',
+    subject: 'Hello',
+    html: '<p>It works!</p>',
+  }),
+})
+```
+
+## Seed Config
+
+```yaml
+resend:
+  domains:
+    - name: example.com
+      region: us-east-1
+  contacts:
+    - email: test@example.com
+      first_name: Test
+      last_name: User
+      audience: Default
+```
+
+## Retrieving Sent Emails
+
+This is the key differentiator of the emulator: every email sent via `POST /emails` is stored and queryable.
+
+### Inbox UI
+
+Browse sent emails in the browser:
+
+```
+http://localhost:4000/inbox
+```
+
+### REST API
+
+```bash
+# List all sent emails
+curl http://localhost:4000/emails \
+  -H "Authorization: Bearer re_test_key"
+
+# Get a single email by ID
+curl http://localhost:4000/emails/<id> \
+  -H "Authorization: Bearer re_test_key"
+```
+
+### Extracting Data from Emails (tests, agents)
+
+Useful for completing magic link, verification code, or password reset flows programmatically:
+
+```bash
+# Get the latest email ID
+EMAIL_ID=$(curl -s http://localhost:4000/emails \
+  -H "Authorization: Bearer re_test_key" | jq -r '.data[0].id')
+
+# Extract a 6-digit code from the HTML body
+CODE=$(curl -s http://localhost:4000/emails/$EMAIL_ID \
+  -H "Authorization: Bearer re_test_key" | jq -r '.html' | grep -oE '[0-9]{6}')
+
+echo "Verification code: $CODE"
+```
+
+## API Endpoints
+
+### Emails
+
+```bash
+# Send an email
+curl -X POST http://localhost:4000/emails \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "hello@example.com", "to": "user@example.com", "subject": "Hello", "html": "<p>Hi</p>"}'
+
+# Send batch (up to 100)
+curl -X POST http://localhost:4000/emails/batch \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '[{"from": "a@example.com", "to": "b@example.com", "subject": "One", "html": "<p>1</p>"}]'
+
+# List all emails
+curl http://localhost:4000/emails \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get email by ID
+curl http://localhost:4000/emails/<id> \
+  -H "Authorization: Bearer $TOKEN"
+
+# Cancel a scheduled email
+curl -X POST http://localhost:4000/emails/<id>/cancel \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Supported fields: `from`, `to`, `subject`, `html`, `text`, `cc`, `bcc`, `reply_to`, `headers`, `tags`, `scheduled_at`.
+
+### Domains
+
+```bash
+# Create domain
+curl -X POST http://localhost:4000/domains \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "example.com", "region": "us-east-1"}'
+
+# List domains
+curl http://localhost:4000/domains \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get domain
+curl http://localhost:4000/domains/<id> \
+  -H "Authorization: Bearer $TOKEN"
+
+# Verify domain (instantly marks all records as verified)
+curl -X POST http://localhost:4000/domains/<id>/verify \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete domain
+curl -X DELETE http://localhost:4000/domains/<id> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### API Keys
+
+```bash
+# Create API key
+curl -X POST http://localhost:4000/api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Production"}'
+
+# List API keys
+curl http://localhost:4000/api-keys \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete API key
+curl -X DELETE http://localhost:4000/api-keys/<id> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Audiences
+
+```bash
+# Create audience
+curl -X POST http://localhost:4000/audiences \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Newsletter"}'
+
+# List audiences
+curl http://localhost:4000/audiences \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete audience
+curl -X DELETE http://localhost:4000/audiences/<id> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Contacts
+
+```bash
+# Create contact in an audience
+curl -X POST http://localhost:4000/audiences/<audience_id>/contacts \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "first_name": "Jane", "last_name": "Doe"}'
+
+# List contacts in an audience
+curl http://localhost:4000/audiences/<audience_id>/contacts \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete contact
+curl -X DELETE http://localhost:4000/audiences/<audience_id>/contacts/<id> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Webhooks
+
+The emulator dispatches webhook events when state changes:
+
+- `email.sent` and `email.delivered` on `POST /emails`
+- `domain.created` and `domain.deleted` on domain operations
+- `contact.created` and `contact.deleted` on contact operations
+
+## Common Patterns
+
+### Magic Link / Verification Code Flow
+
+```bash
+TOKEN="re_test_key"
+BASE="http://localhost:4000"
+
+# 1. Send verification email
+curl -X POST $BASE/emails \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "auth@example.com", "to": "user@example.com", "subject": "Your code", "html": "<p>Code: <strong>482910</strong></p>"}'
+
+# 2. Retrieve the email
+EMAIL_ID=$(curl -s $BASE/emails -H "Authorization: Bearer $TOKEN" | jq -r '.data[0].id')
+
+# 3. Read the HTML body
+curl -s $BASE/emails/$EMAIL_ID -H "Authorization: Bearer $TOKEN" | jq -r '.html'
+```
+
+### Send and Verify in a Test
+
+```typescript
+import { createEmulator } from 'emulate'
+import { Resend } from 'resend'
+
+const emu = await createEmulator({ service: 'resend', port: 4000 })
+
+process.env.RESEND_BASE_URL = emu.url
+const resend = new Resend('re_test_key')
+
+// Send
+await resend.emails.send({
+  from: 'auth@example.com',
+  to: 'user@test.com',
+  subject: 'Verify',
+  html: '<p>Code: <strong>123456</strong></p>',
+})
+
+// Retrieve
+const res = await fetch(`${emu.url}/emails`, {
+  headers: { Authorization: 'Bearer re_test_key' },
+})
+const { data: emails } = await res.json()
+console.log(emails[0].html) // contains "123456"
+```

--- a/plugins/emulate/.agents/skills/slack/SKILL.md
+++ b/plugins/emulate/.agents/skills/slack/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: slack
+description: Emulated Slack API for local development and testing. Use when the user needs to interact with Slack API endpoints locally, test Slack integrations, emulate channels/messages/users, set up Slack OAuth flows, test incoming webhooks, or work with the Slack Web API without hitting the real Slack API. Triggers include "Slack API", "emulate Slack", "mock Slack", "test Slack OAuth", "Slack bot", "incoming webhook", "local Slack", or any task requiring a local Slack API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Slack API Emulator
+
+Fully stateful Slack Web API emulation with channels, messages, threads, reactions, OAuth v2, and incoming webhooks. State changes dispatch `event_callback` payloads to configured webhook URLs.
+
+## Start
+
+```bash
+# Slack only
+npx emulate --service slack
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const slack = await createEmulator({ service: 'slack', port: 4003 })
+// slack.url === 'http://localhost:4003'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. All Web API endpoints require authentication.
+
+```bash
+curl -X POST http://localhost:4003/api/auth.test \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+When no token is provided, requests fall back to the first seeded user.
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+SLACK_EMULATOR_URL=http://localhost:4003
+```
+
+### Slack SDK / Bolt
+
+```typescript
+import { WebClient } from '@slack/web-api'
+
+const client = new WebClient(token, {
+  slackApiUrl: `${process.env.SLACK_EMULATOR_URL}/api/`,
+})
+```
+
+### OAuth URL Mapping
+
+| Real Slack URL | Emulator URL |
+|----------------|-------------|
+| `https://slack.com/oauth/v2/authorize` | `$SLACK_EMULATOR_URL/oauth/v2/authorize` |
+| `https://slack.com/api/oauth.v2.access` | `$SLACK_EMULATOR_URL/api/oauth.v2.access` |
+
+### Auth.js / NextAuth.js
+
+```typescript
+{
+  id: 'slack',
+  name: 'Slack',
+  type: 'oauth',
+  authorization: {
+    url: `${process.env.SLACK_EMULATOR_URL}/oauth/v2/authorize`,
+    params: { scope: 'chat:write,channels:read,users:read' },
+  },
+  token: {
+    url: `${process.env.SLACK_EMULATOR_URL}/api/oauth.v2.access`,
+  },
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+}
+```
+
+## Seed Config
+
+```yaml
+slack:
+  team:
+    name: My Workspace
+    domain: my-workspace
+  users:
+    - name: developer
+      real_name: Developer
+      email: dev@example.com
+      is_admin: true
+    - name: designer
+      real_name: Designer
+      email: designer@example.com
+  channels:
+    - name: general
+      topic: General discussion
+    - name: engineering
+      topic: Engineering discussions
+      is_private: true
+  bots:
+    - name: my-bot
+  oauth_apps:
+    - client_id: "12345.67890"
+      client_secret: example_client_secret
+      name: My Slack App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/slack
+  incoming_webhooks:
+    - channel: general
+      label: CI Notifications
+  signing_secret: my_signing_secret
+```
+
+When no OAuth apps are configured, the emulator accepts any `client_id`. With apps configured, strict validation is enforced for `client_id`, `client_secret`, and `redirect_uri`.
+
+## API Endpoints
+
+### Auth
+
+```bash
+# Test authentication
+curl -X POST http://localhost:4003/api/auth.test \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Chat
+
+```bash
+# Post message
+curl -X POST http://localhost:4003/api/chat.postMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "text": "Hello from the emulator!"}'
+
+# Post threaded reply
+curl -X POST http://localhost:4003/api/chat.postMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "text": "Thread reply", "thread_ts": "1234567890.123456"}'
+
+# Update message
+curl -X POST http://localhost:4003/api/chat.update \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "ts": "1234567890.123456", "text": "Updated message"}'
+
+# Delete message
+curl -X POST http://localhost:4003/api/chat.delete \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "ts": "1234567890.123456"}'
+
+# /me message
+curl -X POST http://localhost:4003/api/chat.meMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "text": "is thinking..."}'
+```
+
+### Conversations
+
+```bash
+# List channels (cursor pagination)
+curl -X POST http://localhost:4003/api/conversations.list \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get channel info
+curl -X POST http://localhost:4003/api/conversations.info \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001"}'
+
+# Create channel
+curl -X POST http://localhost:4003/api/conversations.create \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "new-channel", "is_private": false}'
+
+# Channel history (top-level messages only)
+curl -X POST http://localhost:4003/api/conversations.history \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001"}'
+
+# Thread replies
+curl -X POST http://localhost:4003/api/conversations.replies \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "ts": "1234567890.123456"}'
+
+# Join / leave channel
+curl -X POST http://localhost:4003/api/conversations.join \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001"}'
+
+# List members
+curl -X POST http://localhost:4003/api/conversations.members \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001"}'
+```
+
+### Users
+
+```bash
+# List users (cursor pagination)
+curl -X POST http://localhost:4003/api/users.list \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get user info
+curl -X POST http://localhost:4003/api/users.info \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user": "U000000001"}'
+
+# Lookup by email
+curl -X POST http://localhost:4003/api/users.lookupByEmail \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "dev@example.com"}'
+```
+
+### Reactions
+
+```bash
+# Add reaction
+curl -X POST http://localhost:4003/api/reactions.add \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "timestamp": "1234567890.123456", "name": "thumbsup"}'
+
+# Remove reaction
+curl -X POST http://localhost:4003/api/reactions.remove \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "timestamp": "1234567890.123456", "name": "thumbsup"}'
+
+# Get reactions
+curl -X POST http://localhost:4003/api/reactions.get \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "timestamp": "1234567890.123456"}'
+```
+
+### Team
+
+```bash
+# Get workspace info
+curl -X POST http://localhost:4003/api/team.info \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Bots
+
+```bash
+# Get bot info
+curl -X POST http://localhost:4003/api/bots.info \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"bot": "B000000001"}'
+```
+
+### Incoming Webhooks
+
+```bash
+# Post via incoming webhook
+curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Deployment complete!"}'
+
+# Post to a specific channel
+curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Alert!", "channel": "C000000002"}'
+
+# Post threaded webhook message
+curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Thread update", "thread_ts": "1234567890.123456"}'
+```
+
+### OAuth
+
+```bash
+# Authorize (browser flow, shows user picker)
+# GET /oauth/v2/authorize?client_id=...&redirect_uri=...&scope=...&state=...
+
+# Token exchange
+curl -X POST http://localhost:4003/api/oauth.v2.access \
+  -H "Content-Type: application/json" \
+  -d '{"client_id": "12345.67890", "client_secret": "example_client_secret", "code": "<code>"}'
+```
+
+Returns a Slack-style response:
+
+```json
+{
+  "ok": true,
+  "access_token": "xoxb-...",
+  "token_type": "bot",
+  "bot_user_id": "B000000001",
+  "team": { "id": "T000000001", "name": "Emulate" },
+  "authed_user": { "id": "U000000001" }
+}
+```
+
+## Event Dispatching
+
+When messages are posted or reactions are added/removed, the emulator dispatches `event_callback` payloads to configured webhook URLs. These payloads match Slack's Events API format:
+
+- `message` events on `chat.postMessage`, `chat.update`, `chat.delete`
+- `reaction_added` / `reaction_removed` events on `reactions.add` / `reactions.remove`
+- `message` with `subtype: bot_message` on incoming webhook posts
+
+## Common Patterns
+
+### Post Messages and React
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4003"
+
+# Post a message
+curl -X POST $BASE/api/chat.postMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "text": "Hello!"}'
+
+# React to it (use the ts from the response)
+curl -X POST $BASE/api/reactions.add \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "C000000001", "timestamp": "<ts>", "name": "wave"}'
+```
+
+### OAuth Flow
+
+1. Redirect user to `$SLACK_EMULATOR_URL/oauth/v2/authorize?client_id=...&redirect_uri=...&scope=chat:write,channels:read&state=...`
+2. User picks a seeded user on the emulator's UI
+3. Emulator redirects back with `?code=...&state=...`
+4. Exchange code for token via `POST /api/oauth.v2.access`
+5. Use `xoxb-` token to call Web API endpoints
+
+### CI Notifications via Webhook
+
+```bash
+# Use the default incoming webhook
+curl -X POST http://localhost:4003/services/T000000001/B000000001/X000000001 \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Build passed on main"}'
+```

--- a/plugins/emulate/.agents/skills/stripe/SKILL.md
+++ b/plugins/emulate/.agents/skills/stripe/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: stripe
+description: Emulated Stripe API for local development and testing. Use when the user needs to process payments locally, test checkout flows, create customers, manage products and prices, handle payment intents, work with webhooks, or use the Stripe SDK without hitting real Stripe servers. Triggers include "Stripe API", "emulate Stripe", "test payments locally", "checkout flow", "payment intent", "Stripe webhook", "Stripe SDK", "STRIPE_API_KEY", or any task requiring a local Stripe API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Stripe API Emulator
+
+Fully stateful Stripe API emulation. Customers, products, prices, checkout sessions, payment intents, charges, and payment methods persist in memory. Webhooks fire on state changes. The hosted checkout UI lets you complete payments in the browser.
+
+No real payments are processed. Every Stripe SDK call hits the emulator and produces realistic responses.
+
+## Start
+
+```bash
+# Stripe only
+npx emulate --service stripe
+
+# Default port (when run alone)
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const stripe = await createEmulator({ service: 'stripe', port: 4000 })
+// stripe.url === 'http://localhost:4000'
+```
+
+## Pointing Your App at the Emulator
+
+### Stripe SDK
+
+The Stripe Node.js SDK does not read an environment variable for the base URL. You must pass it when constructing the client:
+
+```typescript
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-12-18.acacia',
+  host: 'localhost',
+  port: 4000,
+  protocol: 'http',
+})
+```
+
+### Embedded in Next.js (adapter-next)
+
+When using `@emulators/adapter-next`, the emulator runs inside your Next.js app at `/emulate/stripe`. The SDK needs to point at `localhost` with a proxy route to forward `/v1/*` calls to `/emulate/stripe/v1/*`:
+
+```typescript
+// next.config.ts
+import { withEmulate } from '@emulators/adapter-next'
+
+export default withEmulate({
+  env: {
+    STRIPE_SECRET_KEY: 'sk_test_emulated',
+  },
+})
+```
+
+```typescript
+// lib/stripe.ts
+import Stripe from 'stripe'
+
+const port = process.env.PORT ?? '3000'
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-12-18.acacia',
+  host: 'localhost',
+  port: parseInt(port, 10),
+  protocol: 'http',
+})
+```
+
+```typescript
+// app/emulate/[...path]/route.ts
+import { createEmulateHandler } from '@emulators/adapter-next'
+import * as stripe from '@emulators/stripe'
+
+export const { GET, POST, PUT, PATCH, DELETE } = createEmulateHandler({
+  services: {
+    stripe: {
+      emulator: stripe,
+      seed: {
+        products: [
+          { id: 'prod_widget', name: 'Widget', description: 'A useful widget' },
+        ],
+        prices: [
+          { id: 'price_widget', product_name: 'Widget', currency: 'usd', unit_amount: 1000 },
+        ],
+        webhooks: [
+          {
+            url: `http://localhost:${process.env.PORT ?? '3000'}/api/webhooks/stripe`,
+            events: ['*'],
+          },
+        ],
+      },
+    },
+  },
+})
+```
+
+```typescript
+// app/v1/[...path]/route.ts  (proxy for Stripe SDK)
+const STRIPE_URL = `http://localhost:${process.env.PORT ?? '3000'}/emulate/stripe`
+
+async function handler(req: Request, ctx: { params: Promise<{ path: string[] }> }) {
+  const { path } = await ctx.params
+  const url = new URL(req.url)
+  const target = `${STRIPE_URL}/v1/${path.join('/')}${url.search}`
+
+  const res = await fetch(target, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+    duplex: 'half',
+  } as any)
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  })
+}
+
+export { handler as GET, handler as POST, handler as PUT, handler as PATCH, handler as DELETE }
+```
+
+### Direct fetch
+
+```bash
+curl http://localhost:4000/v1/customers \
+  -H "Authorization: Bearer sk_test_emulated"
+```
+
+## Seed Config
+
+Seed data is optional. All entities support an optional `id` field for deterministic IDs that survive server restarts.
+
+```yaml
+stripe:
+  customers:
+    - id: cus_demo
+      email: demo@example.com
+      name: Demo User
+  products:
+    - id: prod_tshirt
+      name: T-Shirt
+      description: A comfortable tee
+  prices:
+    - id: price_tshirt
+      product_name: T-Shirt
+      currency: usd
+      unit_amount: 2500
+  webhooks:
+    - url: http://localhost:3000/api/webhooks/stripe
+      events: ['*']
+      secret: whsec_test
+```
+
+The `product_name` field in prices links to the product by name. Use `events: ['*']` to receive all webhook events, or specify individual event types.
+
+## API Endpoints
+
+### Customers
+
+```bash
+# Create customer
+curl -X POST http://localhost:4000/v1/customers \
+  -d "email=user@example.com" -d "name=Jane Doe"
+
+# Retrieve customer
+curl http://localhost:4000/v1/customers/cus_xxx
+
+# Update customer
+curl -X POST http://localhost:4000/v1/customers/cus_xxx \
+  -d "name=Updated Name"
+
+# Delete customer
+curl -X DELETE http://localhost:4000/v1/customers/cus_xxx
+
+# List customers
+curl http://localhost:4000/v1/customers
+```
+
+### Products
+
+```bash
+# Create product
+curl -X POST http://localhost:4000/v1/products \
+  -d "name=Widget" -d "description=A useful widget"
+
+# Retrieve product
+curl http://localhost:4000/v1/products/prod_xxx
+
+# List products
+curl "http://localhost:4000/v1/products?active=true"
+```
+
+### Prices
+
+```bash
+# Create price
+curl -X POST http://localhost:4000/v1/prices \
+  -d "product=prod_xxx" -d "currency=usd" -d "unit_amount=1000"
+
+# Retrieve price
+curl http://localhost:4000/v1/prices/price_xxx
+
+# List prices
+curl "http://localhost:4000/v1/prices?active=true"
+```
+
+### Checkout Sessions
+
+```bash
+# Create checkout session
+curl -X POST http://localhost:4000/v1/checkout/sessions \
+  -d "mode=payment" \
+  -d "line_items[0][price]=price_xxx" \
+  -d "line_items[0][quantity]=1" \
+  -d "success_url=http://localhost:3000/success?session_id={CHECKOUT_SESSION_ID}" \
+  -d "cancel_url=http://localhost:3000/cart"
+
+# Retrieve session
+curl http://localhost:4000/v1/checkout/sessions/cs_xxx
+
+# List sessions
+curl http://localhost:4000/v1/checkout/sessions
+
+# Expire a session
+curl -X POST http://localhost:4000/v1/checkout/sessions/cs_xxx/expire
+```
+
+The session's `url` field points to a hosted checkout page at `/checkout/cs_xxx`. Clicking "Pay" on that page completes the session, fires the `checkout.session.completed` webhook, and redirects to `success_url`. The `{CHECKOUT_SESSION_ID}` template in `success_url` is replaced with the actual session ID.
+
+### Payment Intents
+
+```bash
+# Create payment intent
+curl -X POST http://localhost:4000/v1/payment_intents \
+  -d "amount=2000" -d "currency=usd"
+
+# Retrieve
+curl http://localhost:4000/v1/payment_intents/pi_xxx
+
+# Update
+curl -X POST http://localhost:4000/v1/payment_intents/pi_xxx \
+  -d "amount=3000"
+
+# Confirm (triggers payment_intent.succeeded + charge.succeeded webhooks)
+curl -X POST http://localhost:4000/v1/payment_intents/pi_xxx/confirm
+
+# Cancel
+curl -X POST http://localhost:4000/v1/payment_intents/pi_xxx/cancel
+
+# List
+curl http://localhost:4000/v1/payment_intents
+```
+
+### Charges
+
+```bash
+# Retrieve charge
+curl http://localhost:4000/v1/charges/ch_xxx
+
+# List charges
+curl http://localhost:4000/v1/charges
+```
+
+Charges are created automatically when a payment intent is confirmed.
+
+### Customer Sessions
+
+```bash
+# Create customer session
+curl -X POST http://localhost:4000/v1/customer_sessions \
+  -d "customer=cus_xxx"
+```
+
+### Payment Methods
+
+```bash
+# List payment methods
+curl http://localhost:4000/v1/payment_methods
+```
+
+## Webhooks
+
+The emulator dispatches webhook events when state changes. Register webhooks via seed config or programmatically.
+
+### Events dispatched
+
+| Event | Trigger |
+|-------|---------|
+| `customer.created` | Customer created |
+| `customer.updated` | Customer updated |
+| `customer.deleted` | Customer deleted |
+| `product.created` | Product created |
+| `price.created` | Price created |
+| `payment_intent.created` | Payment intent created |
+| `payment_intent.succeeded` | Payment intent confirmed |
+| `payment_intent.canceled` | Payment intent canceled |
+| `charge.succeeded` | Payment intent confirmed (charge auto-created) |
+| `checkout.session.completed` | Checkout completed via hosted page |
+| `checkout.session.expired` | Checkout session expired |
+
+### Webhook handler example
+
+```typescript
+// app/api/webhooks/stripe/route.ts
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const event = body.type as string
+  const obj = body.data?.object
+
+  switch (event) {
+    case 'customer.created':
+      console.log('Customer created:', obj.id, obj.email)
+      break
+    case 'checkout.session.completed':
+      console.log('Checkout completed:', obj.id)
+      break
+    case 'payment_intent.succeeded':
+      console.log('Payment succeeded:', obj.id)
+      break
+    case 'charge.succeeded':
+      console.log('Charge succeeded:', obj.id)
+      break
+  }
+
+  return NextResponse.json({ received: true })
+}
+```
+
+## Common Patterns
+
+### Checkout Flow (embedded Next.js)
+
+```typescript
+// Server action
+const customer = await stripe.customers.create({
+  email: 'shopper@example.com',
+  name: 'Demo Shopper',
+})
+
+const session = await stripe.checkout.sessions.create({
+  mode: 'payment',
+  customer: customer.id,
+  line_items: [{ price: 'price_widget', quantity: 2 }],
+  success_url: `${origin}/success?session_id={CHECKOUT_SESSION_ID}`,
+  cancel_url: `${origin}/cart`,
+})
+
+redirect(session.url!)
+```
+
+### Retrieve Session on Success Page
+
+```typescript
+const session = await stripe.checkout.sessions.retrieve(session_id)
+const customer = await stripe.customers.retrieve(session.customer as string)
+
+console.log(session.payment_status) // 'paid'
+console.log(customer.name)          // 'Demo Shopper'
+```
+
+### Payment Intent Flow (no checkout UI)
+
+```typescript
+const pi = await stripe.paymentIntents.create({
+  amount: 5000,
+  currency: 'usd',
+  customer: 'cus_xxx',
+})
+
+// Confirm triggers payment_intent.succeeded + charge.succeeded webhooks
+const confirmed = await stripe.paymentIntents.confirm(pi.id)
+console.log(confirmed.status) // 'succeeded'
+```

--- a/plugins/emulate/.agents/skills/vercel/SKILL.md
+++ b/plugins/emulate/.agents/skills/vercel/SKILL.md
@@ -1,0 +1,481 @@
+---
+name: vercel
+description: Emulated Vercel REST API for local development and testing. Use when the user needs to interact with Vercel API endpoints locally, test Vercel integrations, emulate projects/deployments/domains, set up Vercel OAuth flows, manage environment variables, create API keys, configure protection bypass, emulate Vercel Blob storage, or test without hitting the real Vercel API. Triggers include "Vercel API", "emulate Vercel", "mock Vercel", "test Vercel OAuth", "Vercel integration", "Vercel Blob", "local Vercel", or any task requiring a local Vercel API.
+allowed-tools: Bash(npx emulate:*), Bash(emulate:*), Bash(curl:*)
+---
+
+# Vercel API Emulator
+
+Fully stateful Vercel REST API emulation with Vercel-style JSON responses and cursor-based pagination.
+
+## Start
+
+```bash
+# Vercel only
+npx emulate --service vercel
+
+# Default port
+# http://localhost:4000
+```
+
+Or programmatically:
+
+```typescript
+import { createEmulator } from 'emulate'
+
+const vercel = await createEmulator({ service: 'vercel', port: 4000 })
+// vercel.url === 'http://localhost:4000'
+```
+
+## Auth
+
+Pass tokens as `Authorization: Bearer <token>`. All endpoints accept `teamId` or `slug` query params for team scoping.
+
+```bash
+curl http://localhost:4000/v2/user \
+  -H "Authorization: Bearer test_token_admin"
+```
+
+Team-scoped requests resolve the account from the `teamId` or `slug` query parameter. User-scoped requests resolve the account from the authenticated user.
+
+## Pointing Your App at the Emulator
+
+### Environment Variable
+
+```bash
+VERCEL_EMULATOR_URL=http://localhost:4000
+```
+
+### Vercel SDK / Custom Fetch
+
+```typescript
+const VERCEL_API = process.env.VERCEL_EMULATOR_URL ?? 'https://api.vercel.com'
+
+const res = await fetch(`${VERCEL_API}/v10/projects`, {
+  headers: { Authorization: `Bearer ${token}` },
+})
+```
+
+### OAuth URL Mapping
+
+| Real Vercel URL | Emulator URL |
+|-----------------|-------------|
+| `https://vercel.com/integrations/oauth/authorize` | `$VERCEL_EMULATOR_URL/oauth/authorize` |
+| `https://api.vercel.com/login/oauth/token` | `$VERCEL_EMULATOR_URL/login/oauth/token` |
+| `https://api.vercel.com/login/oauth/userinfo` | `$VERCEL_EMULATOR_URL/login/oauth/userinfo` |
+
+### Auth.js / NextAuth.js
+
+```typescript
+{
+  id: 'vercel',
+  name: 'Vercel',
+  type: 'oauth',
+  authorization: {
+    url: `${process.env.VERCEL_EMULATOR_URL}/oauth/authorize`,
+  },
+  token: {
+    url: `${process.env.VERCEL_EMULATOR_URL}/login/oauth/token`,
+  },
+  userinfo: {
+    url: `${process.env.VERCEL_EMULATOR_URL}/login/oauth/userinfo`,
+  },
+  clientId: process.env.VERCEL_CLIENT_ID,
+  clientSecret: process.env.VERCEL_CLIENT_SECRET,
+  profile(profile) {
+    return {
+      id: profile.sub,
+      name: profile.name,
+      email: profile.email,
+      image: profile.picture,
+    }
+  },
+}
+```
+
+## Seed Config
+
+```yaml
+tokens:
+  test_token_admin:
+    login: admin
+    scopes: []
+
+vercel:
+  users:
+    - username: developer
+      name: Developer
+      email: dev@example.com
+  teams:
+    - slug: my-team
+      name: My Team
+      description: Engineering team
+  projects:
+    - name: my-app
+      team: my-team
+      framework: nextjs
+      buildCommand: next build
+      outputDirectory: .next
+      rootDirectory: null
+      nodeVersion: "20.x"
+      envVars:
+        - key: DATABASE_URL
+          value: postgres://localhost/mydb
+          type: encrypted
+          target: [production, preview]
+  integrations:
+    - client_id: oac_abc123
+      client_secret: secret_abc123
+      name: My Vercel App
+      redirect_uris:
+        - http://localhost:3000/api/auth/callback/vercel
+```
+
+## Pagination
+
+Cursor-based pagination using `limit`, `since`, and `until` query params. Responses include a `pagination` object:
+
+```bash
+curl "http://localhost:4000/v10/projects?limit=10" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## API Endpoints
+
+### User & Teams
+
+```bash
+# Registration check
+curl http://localhost:4000/registration
+
+# Authenticated user
+curl http://localhost:4000/v2/user -H "Authorization: Bearer $TOKEN"
+
+# Update user
+curl -X PATCH http://localhost:4000/v2/user \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "New Name", "email": "new@example.com"}'
+
+# List teams (cursor paginated)
+curl http://localhost:4000/v2/teams -H "Authorization: Bearer $TOKEN"
+
+# Get team (by ID or slug)
+curl http://localhost:4000/v2/teams/my-team -H "Authorization: Bearer $TOKEN"
+
+# Create team
+curl -X POST http://localhost:4000/v2/teams \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"slug": "new-team", "name": "New Team"}'
+
+# Update team (name, slug, description)
+curl -X PATCH http://localhost:4000/v2/teams/my-team \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Updated Team", "description": "New description"}'
+
+# List members
+curl http://localhost:4000/v2/teams/my-team/members -H "Authorization: Bearer $TOKEN"
+
+# Add member (by uid or email, with role)
+curl -X POST "http://localhost:4000/v2/teams/team_id/members" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "dev@example.com", "role": "MEMBER"}'
+```
+
+Roles: `OWNER`, `MEMBER`, `DEVELOPER`, `VIEWER`.
+
+### Projects
+
+```bash
+# Create project (with optional env vars, git, and build config)
+curl -X POST http://localhost:4000/v11/projects \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-app", "framework": "nextjs", "buildCommand": "next build", "outputDirectory": ".next", "nodeVersion": "20.x", "environmentVariables": [{"key": "API_KEY", "value": "secret", "type": "encrypted", "target": ["production"]}]}'
+
+# List projects (search, cursor pagination)
+curl "http://localhost:4000/v10/projects?search=my-app" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get project (includes env vars)
+curl http://localhost:4000/v9/projects/my-app \
+  -H "Authorization: Bearer $TOKEN"
+
+# Update project (framework, buildCommand, devCommand, installCommand,
+#   outputDirectory, rootDirectory, nodeVersion, serverlessFunctionRegion,
+#   publicSource, autoAssignCustomDomains, gitForkProtection,
+#   commandForIgnoringBuildStep)
+curl -X PATCH http://localhost:4000/v9/projects/my-app \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"framework": "remix"}'
+
+# Delete project (cascades deployments, domains, env vars, protection bypasses)
+curl -X DELETE http://localhost:4000/v9/projects/my-app \
+  -H "Authorization: Bearer $TOKEN"
+
+# Promote aliases status
+curl http://localhost:4000/v1/projects/my-app/promote/aliases \
+  -H "Authorization: Bearer $TOKEN"
+
+# Protection bypass: generate, revoke, regenerate
+curl -X PATCH http://localhost:4000/v1/projects/my-app/protection-bypass \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"generate": {"note": "CI preview", "scope": "deployment"}}'
+
+# Revoke protection bypass secrets
+curl -X PATCH http://localhost:4000/v1/projects/my-app/protection-bypass \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"revoke": ["secret_to_revoke"]}'
+
+# Regenerate protection bypass secrets
+curl -X PATCH http://localhost:4000/v1/projects/my-app/protection-bypass \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"regenerate": ["old_secret"]}'
+```
+
+### Deployments
+
+```bash
+# Create deployment (auto-transitions to READY)
+curl -X POST http://localhost:4000/v13/deployments \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-app", "target": "production", "meta": {"commit": "abc123"}, "regions": ["iad1"], "gitSource": {"type": "github", "ref": "main", "sha": "abc123", "repoId": "123", "org": "my-org", "repo": "my-app", "message": "Deploy", "authorName": "dev", "commitAuthorName": "dev"}}'
+
+# Targets: "production", "preview", "staging"
+
+# Get deployment (by ID or URL)
+curl http://localhost:4000/v13/deployments/dpl_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+
+# List deployments (filter by projectId, app, target, state; cursor paginated)
+curl "http://localhost:4000/v6/deployments?projectId=my-app&target=production&limit=10" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete deployment
+curl -X DELETE http://localhost:4000/v13/deployments/dpl_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+
+# Cancel building deployment
+curl -X PATCH http://localhost:4000/v12/deployments/dpl_abc123/cancel \
+  -H "Authorization: Bearer $TOKEN"
+
+# List deployment aliases
+curl http://localhost:4000/v2/deployments/dpl_abc123/aliases \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get build events/logs (supports direction, limit)
+curl "http://localhost:4000/v3/deployments/dpl_abc123/events?direction=forward&limit=50" \
+  -H "Authorization: Bearer $TOKEN"
+
+# List deployment files
+curl http://localhost:4000/v6/deployments/dpl_abc123/files \
+  -H "Authorization: Bearer $TOKEN"
+
+# Upload file (by SHA digest)
+curl -X POST http://localhost:4000/v2/files \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  -H "x-vercel-digest: sha256hash" \
+  --data-binary @file.txt
+```
+
+### Domains
+
+```bash
+# Add domain (with optional redirect, gitBranch, customEnvironmentId)
+curl -X POST http://localhost:4000/v10/projects/my-app/domains \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "example.com", "redirect": null, "redirectStatusCode": null, "gitBranch": null}'
+
+# *.vercel.app domains are auto-verified
+
+# List domains (cursor paginated)
+curl http://localhost:4000/v9/projects/my-app/domains \
+  -H "Authorization: Bearer $TOKEN"
+
+# Get, update, remove domain
+curl http://localhost:4000/v9/projects/my-app/domains/example.com \
+  -H "Authorization: Bearer $TOKEN"
+
+# Verify domain
+curl -X POST http://localhost:4000/v9/projects/my-app/domains/example.com/verify \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Redirect status codes: `301`, `302`, `307`, `308`.
+
+### Environment Variables
+
+```bash
+# List env vars (with decrypt option; filter by gitBranch, customEnvironmentId)
+curl "http://localhost:4000/v10/projects/my-app/env?decrypt=true" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Create env vars (single, batch, or upsert)
+curl -X POST "http://localhost:4000/v10/projects/my-app/env?upsert=true" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "API_KEY", "value": "secret123", "type": "encrypted", "target": ["production", "preview"], "comment": "API key for service"}'
+
+# Get env var
+curl http://localhost:4000/v10/projects/my-app/env/env_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+
+# Update env var
+curl -X PATCH http://localhost:4000/v9/projects/my-app/env/env_abc123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"value": "newsecret"}'
+
+# Delete env var
+curl -X DELETE http://localhost:4000/v9/projects/my-app/env/env_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Env var types: `system`, `encrypted`, `plain`, `secret`, `sensitive`.
+
+### Blob
+
+Implements the Vercel Blob API used by the `@vercel/blob` SDK (`put`, `head`, `list`, `del`). Point the SDK at the emulator with two environment variables:
+
+```bash
+VERCEL_BLOB_API_URL=http://localhost:4000/api/blob
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_mystore_secret
+```
+
+Any token of the form `vercel_blob_rw_<storeId>_<secret>` is accepted; the store id is parsed from the token.
+
+```typescript
+import { put, head, list, del } from '@vercel/blob'
+
+const blob = await put('avatars/user.png', data, { access: 'public' })
+// blob.url serves the bytes from the emulator
+await head(blob.url)
+await list({ prefix: 'avatars/' })
+await del(blob.url)
+```
+
+Direct HTTP:
+
+```bash
+BLOB_TOKEN="vercel_blob_rw_mystore_secret"
+
+# Upload (honors x-add-random-suffix, x-allow-overwrite, x-content-type,
+#   x-cache-control-max-age, x-if-match headers)
+curl -X PUT "http://localhost:4000/api/blob?pathname=docs/readme.txt" \
+  -H "Authorization: Bearer $BLOB_TOKEN" \
+  --data-binary @readme.txt
+
+# Metadata (head)
+curl "http://localhost:4000/api/blob?url=docs/readme.txt" \
+  -H "Authorization: Bearer $BLOB_TOKEN"
+
+# List (prefix, limit, cursor, mode=folded)
+curl "http://localhost:4000/api/blob?prefix=docs/" \
+  -H "Authorization: Bearer $BLOB_TOKEN"
+
+# Delete
+curl -X POST http://localhost:4000/api/blob/delete \
+  -H "Authorization: Bearer $BLOB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"urls": ["docs/readme.txt"]}'
+
+# Serve content (public, no auth; ?download=1 forces attachment)
+curl http://localhost:4000/blob/mystore/docs/readme.txt
+```
+
+Multipart uploads and client (browser) uploads are not supported yet.
+
+### API Keys
+
+```bash
+# Create API key (optional teamId scope)
+curl -X POST "http://localhost:4000/v1/api-keys?teamId=team_abc123" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "CI Deploy Key"}'
+
+# List API keys (optional teamId filter)
+curl "http://localhost:4000/v1/api-keys?teamId=team_abc123" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Delete API key
+curl -X DELETE http://localhost:4000/v1/api-keys/ak_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Created API keys are automatically registered in the token map and can be used as Bearer tokens for all endpoints.
+
+### OAuth / Integrations
+
+```bash
+# Authorize (browser flow, shows user picker)
+# GET /oauth/authorize?client_id=...&redirect_uri=...&scope=...&state=...
+
+# Token exchange (supports PKCE; accepts JSON or form-urlencoded)
+curl -X POST http://localhost:4000/login/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{"client_id": "oac_abc123", "client_secret": "secret_abc123", "code": "<code>", "redirect_uri": "http://localhost:3000/api/auth/callback/vercel"}'
+
+# User info (returns sub, email, email_verified, name, preferred_username, picture)
+curl http://localhost:4000/login/oauth/userinfo \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Common Patterns
+
+### Create Project and Deploy
+
+```bash
+TOKEN="test_token_admin"
+BASE="http://localhost:4000"
+
+# Create project
+curl -X POST $BASE/v11/projects \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-app", "framework": "nextjs"}'
+
+# Add env var
+curl -X POST $BASE/v10/projects/my-app/env \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "DATABASE_URL", "value": "postgres://...", "type": "encrypted", "target": ["production"]}'
+
+# Create deployment
+curl -X POST $BASE/v13/deployments \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-app", "target": "production"}'
+```
+
+### OAuth Integration Flow
+
+1. Redirect user to `$VERCEL_EMULATOR_URL/oauth/authorize?client_id=...&redirect_uri=...&state=...`
+2. User picks a seeded user on the emulator's UI
+3. Emulator redirects back with `?code=...&state=...`
+4. Exchange code for token via `POST /login/oauth/token`
+5. Fetch user info via `GET /login/oauth/userinfo`
+
+PKCE is supported. Pass `code_challenge` and `code_challenge_method` on authorize, then `code_verifier` on token exchange.
+
+### Team-Scoped Requests
+
+All endpoints accept `teamId` or `slug` query params:
+
+```bash
+curl "http://localhost:4000/v10/projects?teamId=team_abc123" \
+  -H "Authorization: Bearer $TOKEN"
+
+curl "http://localhost:4000/v10/projects?slug=my-team" \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/plugins/emulate/.claude-plugin/plugin.json
+++ b/plugins/emulate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "emulate",
   "version": "1.1.1",
-  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
   "license": "Apache-2.0",
   "keywords": [
     "emulate",

--- a/plugins/emulate/.codex-plugin/plugin.json
+++ b/plugins/emulate/.codex-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "emulate",
-  "version": "1.0.0",
-  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+  "version": "1.1.1",
+  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
   "author": {
     "name": "Community"
   },
   "interface": {
     "displayName": "Emulate",
-    "shortDescription": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
-    "longDescription": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+    "shortDescription": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
+    "longDescription": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
     "developerName": "Community",
     "category": "Development",
     "capabilities": [

--- a/plugins/emulate/plugin.json
+++ b/plugins/emulate/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "emulate",
-  "version": "1.0.0",
-  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, and AWS",
+  "version": "1.1.1",
+  "description": "Local drop-in API emulator for Vercel, GitHub, Google, Slack, Apple, Microsoft, AWS, Linear, Stripe, Resend, and Next.js",
   "license": "Apache-2.0",
   "keywords": [
     "emulate",

--- a/plugins/emulate/skills-lock.json
+++ b/plugins/emulate/skills-lock.json
@@ -1,11 +1,77 @@
 {
   "version": 1,
   "skills": {
+    "apple": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/apple/SKILL.md",
+      "computedHash": "060a2c575f15d97df2d64eb2006ba40f9e5c40c9c041667bf2f6e228bbc1e370"
+    },
+    "aws": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/aws/SKILL.md",
+      "computedHash": "c3c9a12e4f2ca5c5c354f1825210e548a9abe4bd84ec6d912f9b63f478c6edf2"
+    },
     "emulate": {
       "source": "vercel-labs/emulate",
       "sourceType": "github",
       "skillPath": "skills/emulate/SKILL.md",
       "computedHash": "23671c39bae5555e725ba6346511c0bf88bb654dff5a2df592f5f0918f829e80"
+    },
+    "github": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/github/SKILL.md",
+      "computedHash": "9f35addc8b40f7e75804f07ec140044ab32cf00f9b4ef536d2d9c2e1a5b24a3c"
+    },
+    "google": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/google/SKILL.md",
+      "computedHash": "ae6509fa842e45ed027a29d78e2d03f7dd6ae9a821e4a36dd50abe16b8a0c2ee"
+    },
+    "linear": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/linear/SKILL.md",
+      "computedHash": "74f2ae3e6d6d7749bfb25f538c7d678cd0bb13a22407df80bf4a2c288c45565e"
+    },
+    "microsoft": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/microsoft/SKILL.md",
+      "computedHash": "de6afbc07c323e526d8f98c373da2aafbbb17f824b201e82e420946621305cd1"
+    },
+    "next": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/next/SKILL.md",
+      "computedHash": "105094c96ab29d6e081554c77bf30fe4393a81d91ddca385f215e09899af8a48"
+    },
+    "resend": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/resend/SKILL.md",
+      "computedHash": "befe9541ba124f54974f2af5ef7bbbb35b1e2009d4870ab3cb5f7ba80a0ae8e6"
+    },
+    "slack": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/slack/SKILL.md",
+      "computedHash": "b731bfcc2b50a7083b8258908bf320a42f07b16d5afa09b88b28b5581cbc085b"
+    },
+    "stripe": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/stripe/SKILL.md",
+      "computedHash": "406885aaa09f57d0a326d6af005e8cd432ea69d9fbbf07de5bda251cb92d8cd1"
+    },
+    "vercel": {
+      "source": "vercel-labs/emulate",
+      "sourceType": "github",
+      "skillPath": "skills/vercel/SKILL.md",
+      "computedHash": "3cd45b301312b61ce4663a1d8ec1f55daed567470cd62cee77f65a43a9d56905"
     }
   }
 }


### PR DESCRIPTION
## Summary

Vendor all 12 skills from the upstream `vercel-labs/emulate` repository into the `emulate` plugin. Previously only the `emulate` skill was present; this adds 11 more, bringing the total to 12.

## Changes

### New skills added (`plugins/emulate/.agents/skills/`)
Added via `bunx skills add vercel-labs/emulate --all` (the canonical vendoring mechanism for this repo):
- `apple`
- `aws`
- `github`
- `google`
- `linear`
- `microsoft`
- `next`
- `resend`
- `slack`
- `stripe`
- `vercel`

### Supporting metadata updates
- `plugins/emulate/skills-lock.json` — now tracks all 12 skills with `skillPath` + `computedHash` entries
- `plugins/emulate/.claude-plugin/plugin.json` — updated description to reflect broader provider coverage (Linear, Stripe, Resend, Next.js added)
- `.claude-plugin/marketplace.json` — matching description update for the emulate marketplace entry
- `plugins/emulate/plugin.json` (Antigravity manifest) — regenerated via `bun scripts/cli.ts multi-format`; also corrects pre-existing version drift from 1.0.0 → 1.1.1
- `plugins/emulate/.codex-plugin/plugin.json` (Codex manifest) — same regeneration and version correction

The `skills` field in `plugin.json` already points to `./.agents/skills/`, so all 12 skill directories are auto-discovered — no manifest wiring change was needed.

## Validation

- `claude plugin validate plugins/emulate` — passes (only pre-existing "no author" warning)
- `claude plugin validate .claude-plugin/marketplace.json` — passes
- All 12 `SKILL.md` files have valid `name:` frontmatter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendored all 12 upstream `vercel-labs/emulate` skills into the `emulate` plugin, expanding local API coverage to Apple, AWS, GitHub, Google, Linear, Microsoft, Next.js, Resend, Slack, Stripe, and Vercel. This upgrades the plugin from 1 to 12 skills.

- New Features
  - Added 11 vendor-synced emulator skills.
  - Skills are auto-discovered via `./.agents/skills/`; no manifest wiring changes.

- Dependencies
  - Vendored via `bunx skills add vercel-labs/emulate --all`; updated `skills-lock.json`.
  - Regenerated multi-format manifests and aligned version to `1.1.1`.
  - Updated descriptions in `plugins/emulate/plugin.json`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`.

<sup>Written for commit 071f962559eab46d6ab9809cac2b3c34bef32e19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emulator support for Linear, Stripe, Resend, and Next.js integration.
  * Expanded documentation for GitHub, Google, Slack, Apple, Microsoft, AWS, and Vercel emulators.

* **Documentation**
  * Added comprehensive guides for all emulator services with setup instructions, API endpoints, and usage examples.

* **Chores**
  * Updated plugin manifests and version to reflect expanded service coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->