### PR TITLE
feat(dev3000): add dev3000 (d3k) debugging plugin via skills.sh

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -783,6 +783,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Tooling"
+    },
+    {
+      "name": "dev3000",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dev3000"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tooling"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -722,6 +722,14 @@
       "keywords": ["skill-optimizer", "skills", "evals", "optimization", "benchmark"],
       "tags": ["skills"],
       "source": "./plugins/skill-optimizer"
+    },
+    {
+      "name": "dev3000",
+      "description": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging.",
+      "category": "tooling",
+      "keywords": ["dev3000", "d3k", "debugging", "web", "logs", "screenshots"],
+      "tags": ["skills", "vercel"],
+      "source": "./plugins/dev3000"
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -59,5 +59,6 @@
   "plugins/mcp-dev": "1.0.0",
   "plugins/vercel-sandbox": "1.1.0",
   "plugins/eve": "1.1.0",
-  "plugins/skill-optimizer": "1.1.0"
+  "plugins/skill-optimizer": "1.1.0",
+  "plugins/dev3000": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ Measure and improve how well a plugin's skills help agents solve real tasks. Run
 
 **Install:** `/plugin install skill-optimizer@pleaseai` | **Source:** [plugins/skill-optimizer](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/skill-optimizer)
 
+#### dev3000
+
+dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging. Bootstraps d3k as the dev runtime and drives its monitored browser instead of running npm/bun dev directly.
+
+**Install:** `/plugin install dev3000@pleaseai` | **Source:** [plugins/dev3000](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/dev3000)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:
@@ -543,6 +549,7 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install portone@pleaseai
 /plugin install google-workspace@pleaseai
 /plugin install skill-optimizer@pleaseai
+/plugin install dev3000@pleaseai
 ```
 
 ## What Are Claude Code Plugins?

--- a/plugins/dev3000/.agents/skills/d3k/PUBLISH.md
+++ b/plugins/dev3000/.agents/skills/d3k/PUBLISH.md
@@ -1,0 +1,46 @@
+# Publish Notes (skills.sh)
+
+## Skill Path
+
+- Local folder: `skills/d3k`
+- Skill id: `d3k`
+
+## Publish Copy (ready to paste)
+
+### Title
+
+`d3k`
+
+### Short description
+
+`Bootstraps d3k runtime for standalone AI apps`
+
+### Long description
+
+`Installs/initializes dev3000 (d3k) for standalone agent shells (Codex, Cursor, Claude Code), starts d3k as the default runtime, and uses unified logs plus CDP browser control instead of raw npm/bun dev.`
+
+### Default prompt
+
+`Use $d3k to initialize d3k, start the correct runtime, and drive debugging with unified logs and CDP browser controls.`
+
+## Source URL
+
+Use the GitHub path to this skill folder in your repo:
+
+`https://github.com/vercel-labs/dev3000/tree/main/skills/d3k`
+
+If you publish from another branch/ref, replace `main` with that ref.
+
+## Test Install (Codex)
+
+From Codex skill installer flow, install from URL:
+
+`https://github.com/vercel-labs/dev3000/tree/main/skills/d3k`
+
+Then restart Codex and invoke:
+
+`$d3k`
+
+## Smoke Test Prompt
+
+`Use $d3k in this repo and initialize d3k for me.`

--- a/plugins/dev3000/.agents/skills/d3k/SKILL.md
+++ b/plugins/dev3000/.agents/skills/d3k/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: "d3k"
+description: "Bootstrap d3k in standalone AI apps (Codex, Cursor, Claude Code): detect/install dev3000, start d3k as the runtime, and use unified logs plus CDP browser control instead of running npm/bun dev directly."
+---
+
+# d3k Standalone Bootstrap
+
+Use this skill when working in a standalone AI app and you need reliable local web debugging with browser + server context.
+
+## Why d3k-first
+
+- `d3k` captures server logs, browser console, network events, and screenshots in one timeline.
+- `d3k` exposes a stable CDP endpoint so the agent can control the same browser session being monitored.
+- Running `npm run dev` or `bun run dev` directly omits this unified telemetry and usually leads to weaker diagnoses.
+
+## Bootstrap Workflow
+
+1. Confirm whether `d3k` is installed:
+```bash
+command -v d3k >/dev/null && d3k --version
+```
+
+2. If `d3k` is missing, install dev3000 globally (prefer Bun):
+```bash
+bun install -g dev3000
+```
+Fallback if Bun is unavailable:
+```bash
+npm install -g dev3000
+```
+
+3. Start d3k as the runtime (preferred default in agent shells):
+```bash
+d3k --no-agent --no-tui -t
+```
+
+4. Keep d3k running while editing code. Do not start a second dev server with `npm/bun dev`.
+
+## Codex Fresh Browser/Profile Startup
+
+Use this workflow when the user asks Codex to start d3k with a fresh browser/profile.
+
+1. Close any stale `agent-browser` daemon before launching with `--profile`. Otherwise `agent-browser` will reuse the existing daemon and print `--profile ignored`.
+   ```bash
+   d3k agent-browser close --all
+   ```
+
+2. Start the app through d3k in `servers-only` mode and keep that command running. In Codex, this is more reliable than asking d3k to launch the browser itself when a fresh profile is required.
+   ```bash
+   d3k --no-agent --no-skills --servers-only --command "npm run dev -- -H 127.0.0.1 -p 3000" --port 3000 --startup-timeout 90 --no-tui
+   ```
+
+   Adjust the package-manager command and port for the project. Prefer `--command` over `--script` when passing framework flags. For npm scripts, put flags after `--`; otherwise tools like Next.js can interpret the port as a project directory.
+
+3. Verify the server before opening more browser windows:
+   ```bash
+   curl -I http://127.0.0.1:3000
+   ```
+
+4. Open the fresh profile as a separate browser step:
+   ```bash
+   d3k agent-browser --profile /tmp/d3k-fresh-profile --headed open http://127.0.0.1:3000
+   ```
+
+5. Sanity-check the opened page:
+   ```bash
+   d3k agent-browser get title
+   d3k agent-browser snapshot -i
+   d3k errors
+   ```
+
+Practical rules:
+
+- Prefer `127.0.0.1` for this workflow. If `localhost` hangs or flips between IPv4/IPv6 behavior, do not keep retrying browser launches.
+- If `curl -I` hangs, the server is wedged even if the port appears occupied; restart the d3k server process before opening a browser.
+- In `servers-only` mode there is no d3k-monitored CDP browser. Use regular `d3k agent-browser` commands, not `d3k cdp-port`.
+- In sandboxed agent environments, rerun local-network checks and `agent-browser` opens outside the sandbox when sandbox networking blocks access to `127.0.0.1`.
+
+## Debugging Commands
+
+Use these first before ad-hoc log scraping:
+
+```bash
+d3k errors --context
+d3k logs -n 200
+d3k logs --type browser
+d3k logs --type server
+```
+
+## CDP Browser Control
+
+Use the already-monitored browser session instead of launching a separate automation browser.
+
+```bash
+d3k agent-browser open http://localhost:3000
+d3k agent-browser snapshot -i
+d3k agent-browser click @e2
+d3k agent-browser screenshot /tmp/d3k-current.png
+```
+
+`d3k agent-browser` auto-connects to the active session's browser via CDP. To target a different browser, run `d3k agent-browser connect <port>` first.
+
+## Browser Tool Choice
+
+Use the browser tool that matches the task instead of treating them as interchangeable:
+
+- `agent-browser`
+  - Default choice.
+  - Best for generic web apps and for driving the exact headed browser session that d3k is already monitoring via CDP.
+  - Use it when you need `snapshot`, ref-based `click`, `fill`, or to reproduce what the user sees in the monitored tab.
+- `next-browser`
+  - Next.js-specific tool.
+  - Best for React/Next introspection: `tree`, `errors`, `logs`, `routes`, `project`, PPR inspection, and related Next dev-server signals.
+  - It is not a drop-in replacement for `agent-browser`: no accessibility `snapshot`, no ref-based `click`, and no `fill`.
+  - It launches its own daemon/browser flow and does not use the d3k session's CDP port.
+
+Practical rule:
+
+- Need to drive the same browser d3k is monitoring: use `agent-browser`.
+- Need Next.js component tree or Next-specific diagnostics: use `next-browser`.
+
+Examples:
+
+```bash
+# Same monitored browser session
+d3k agent-browser snapshot -i
+d3k agent-browser click @e2
+
+# Next.js-specific inspection
+d3k next-browser open http://localhost:3000
+d3k next-browser tree
+d3k next-browser errors
+d3k next-browser logs
+```
+
+## Artifacts to Read
+
+- `~/.d3k/{project}/d3k.log`
+- `~/.d3k/{project}/logs/`
+- `~/.d3k/{project}/screenshots/`
+- `~/.d3k/{project}/session.json`
+
+## Operating Rules
+
+- Prefer headed mode for interactive debugging.
+- Use `--headless` only for CI or when explicitly requested.
+- Use `--servers-only` only when browser monitoring is intentionally disabled.

--- a/plugins/dev3000/.agents/skills/d3k/agents/openai.yaml
+++ b/plugins/dev3000/.agents/skills/d3k/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "d3k"
+  short_description: "Bootstraps d3k runtime for standalone AI apps"
+  default_prompt: "Use $d3k to initialize d3k, start the correct runtime, and drive debugging with unified logs and CDP browser controls."

--- a/plugins/dev3000/.claude-plugin/plugin.json
+++ b/plugins/dev3000/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "dev3000",
+  "version": "1.0.0",
+  "description": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging. Bootstraps d3k as the dev runtime and drives its monitored browser instead of running npm/bun dev directly.",
+  "author": {
+    "name": "Vercel Labs",
+    "url": "https://github.com/vercel-labs"
+  },
+  "homepage": "https://github.com/vercel-labs/dev3000",
+  "repository": "https://github.com/vercel-labs/dev3000",
+  "license": "MIT",
+  "keywords": [
+    "dev3000",
+    "d3k",
+    "debugging",
+    "web",
+    "logs",
+    "screenshots"
+  ],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/dev3000/.codex-plugin/plugin.json
+++ b/plugins/dev3000/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "dev3000",
+  "version": "1.0.0",
+  "description": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging. Bootstraps d3k as the dev runtime and drives its monitored browser instead of running npm/bun dev directly.",
+  "author": {
+    "name": "Vercel Labs",
+    "url": "https://github.com/vercel-labs"
+  },
+  "interface": {
+    "displayName": "Dev3000",
+    "shortDescription": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped tim...",
+    "longDescription": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging. Bootstraps d3k as the dev runtime and drives its monitored browser instead of running npm/bun dev directly.",
+    "developerName": "Vercel Labs",
+    "category": "Tooling",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Dev3000 for my current task."
+    ],
+    "websiteURL": "https://github.com/vercel-labs/dev3000"
+  },
+  "homepage": "https://github.com/vercel-labs/dev3000",
+  "repository": "https://github.com/vercel-labs/dev3000",
+  "license": "MIT",
+  "keywords": [
+    "dev3000",
+    "d3k",
+    "debugging",
+    "web",
+    "logs",
+    "screenshots"
+  ]
+}

--- a/plugins/dev3000/plugin.json
+++ b/plugins/dev3000/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "dev3000",
+  "version": "1.0.0",
+  "description": "dev3000 (d3k) debugging assistant — captures server logs, browser events, console messages, network requests, and screenshots into a unified, timestamped timeline for AI debugging. Bootstraps d3k as the dev runtime and drives its monitored browser instead of running npm/bun dev directly.",
+  "author": {
+    "name": "Vercel Labs",
+    "url": "https://github.com/vercel-labs"
+  },
+  "homepage": "https://github.com/vercel-labs/dev3000",
+  "repository": "https://github.com/vercel-labs/dev3000",
+  "license": "MIT",
+  "keywords": [
+    "dev3000",
+    "d3k",
+    "debugging",
+    "web",
+    "logs",
+    "screenshots"
+  ]
+}

--- a/plugins/dev3000/skills-lock.json
+++ b/plugins/dev3000/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "d3k": {
+      "source": "vercel-labs/dev3000",
+      "sourceType": "github",
+      "skillPath": "skills/d3k/SKILL.md",
+      "computedHash": "ef9c69719d6a84cc71d3183d95854e5b49478a45c84f3ffbc1142d901ed4e09c"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -932,6 +932,27 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/dev3000": {
+      "release-type": "simple",
+      "component": "dev3000",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

Add the **dev3000** plugin to the marketplace. dev3000 is Vercel Labs' official
debugging skill (`d3k`) that captures server logs, browser console output, and
screenshots into a unified timeline — making it easy to diagnose Next.js and
other web-app issues without manually correlating multiple sources.

## What changed

- **`plugins/dev3000/`** — new plugin directory containing:
  - `.claude-plugin/plugin.json` — source-of-truth Claude Code manifest
    (`"skills": "./.agents/skills/"`)
  - `.agents/skills/d3k/` — skill files installed via `bunx skills add`
    (SKILL.md, PUBLISH.md, agents/openai.yaml); tracked by `skills-lock.json`
  - `.codex-plugin/plugin.json` + root `plugin.json` — generated Codex and
    Antigravity manifests (via `bun scripts/cli.ts multi-format`)
- **`.claude-plugin/marketplace.json`** — added dev3000 entry (source of truth)
- **`.agents/plugins/marketplace.json`** — regenerated Codex marketplace
  (only dev3000 added, unrelated churn reverted)
- **`release-please-config.json`** — added `plugins/dev3000` package
- **`.release-please-manifest.json`** — added `plugins/dev3000`: "1.0.0"
- **`README.md`** — added Built-in Plugins entry and install-list line

## Approach: skills.sh (not SessionStart hook)

This plugin uses the recommended skill-based activation pattern:
`bunx skills add` installs the upstream d3k skill under
`.agents/skills/d3k/`, and Claude loads it only when debugging context
is detected — avoiding the per-session token cost of a SessionStart hook.

## Validation

`claude plugin validate` passed for both the plugin manifest and the
marketplace manifest before this PR was opened.

## Install

```sh
/plugin marketplace add pleaseai/claude-code-plugins
/plugin install dev3000@pleaseai
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `dev3000` plugin that wraps Vercel Labs’ `d3k` skill to provide unified server and browser logs, network events, and screenshots. Runs `d3k` as the dev runtime and uses its monitored browser via CDP instead of `npm/bun dev`.

- New Features
  - Added `plugins/dev3000` with `.agents/skills/d3k` (installed via `bunx skills add`) and `skills-lock.json`.
  - Added manifests: `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and root `plugin.json`.
  - Added marketplace entries in `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`.
  - Registered package in `release-please-config.json` and `.release-please-manifest.json` at version `1.0.0`.
  - Updated `README.md` with install instructions and Built-in Plugins entry.

- Migration
  - Add the marketplace: `/plugin marketplace add pleaseai/claude-code-plugins`
  - Install: `/plugin install dev3000@pleaseai`

<sup>Written for commit 9eda4d2e9f6e0de6569bf8a29ccf1f156fe653b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **dev3000** built-in plugin—an assistant that captures **logs, browser events, console output, network activity, and screenshots** into a unified timeline.
  * **dev3000** is now available as a built-in plugin across all supported runtimes (installable via the available-plugins quick list).

* **Documentation**
  * Added **d3k** skill setup guides, including publish instructions and a recommended workflow for launching and using the debugging session (with verification and artifact locations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->