### PR TITLE
feat(marketplace): add cloudflare plugin from cloudflare/skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -738,6 +738,18 @@
       "keywords": ["dev3000", "d3k", "debugging", "web", "logs", "screenshots"],
       "tags": ["skills", "vercel"],
       "source": "./plugins/dev3000"
+    },
+    {
+      "name": "cloudflare",
+      "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance",
+      "category": "cloud",
+      "keywords": ["cloudflare", "workers", "durable-objects", "agents-sdk", "wrangler", "mcp"],
+      "tags": ["skills", "cloud"],
+      "source": {
+        "source": "github",
+        "repo": "cloudflare/skills"
+      },
+      "homepage": "https://github.com/cloudflare/skills"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install playwright-cli@pleaseai
 /plugin install vercel@pleaseai
 /plugin install gemini@pleaseai
+/plugin install cloudflare@pleaseai
 
 # Built-in plugins
 /plugin install please-plugins@pleaseai

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Gemini CLI integration for Claude Code — use Google's Gemini models from withi
 
 **Install:** `/plugin install gemini@pleaseai` | **Repository:** [pleaseai/gemini-plugin-cc](https://github.com/pleaseai/gemini-plugin-cc/tree/main/plugins/gemini)
 
+#### Cloudflare
+Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.
+
+**Install:** `/plugin install cloudflare@pleaseai` | **Repository:** [cloudflare/skills](https://github.com/cloudflare/skills)
+
 ---
 
 ### Built-in Plugins


### PR DESCRIPTION
## Summary

Adds the `cloudflare` external plugin (GitHub source `cloudflare/skills`) to the marketplace and README.

## Changes

- Added `cloudflare` entry to `.claude-plugin/marketplace.json` referencing `github:cloudflare/skills`
- Added "Cloudflare" entry to README.md under External Plugins

## Plugin Description

Cloudflare developer platform skills covering:
- Workers & Durable Objects
- Agents SDK
- MCP servers
- Wrangler CLI
- Web performance

## Notes

`bun.lock` (unrelated gatekeeper version bump 1.4.0 → 1.5.0) is intentionally excluded from this commit to keep the change atomic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `cloudflare` external plugin from `cloudflare/skills` to the marketplace and README so users can install skills for Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance. Includes marketplace metadata (category, tags, homepage) and README updates: new External Plugins entry and the install command added to the install list.

<sup>Written for commit 553943952ad9f9bb16bfed1eedcad03db883a9c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloudflare plugin is now available and can be installed via `/plugin install cloudflare@pleaseai`

* **Documentation**
  * Updated plugin documentation to list Cloudflare as an available plugin with installation instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->