### PR TITLE
feat(lavish): add lavish-axi HTML artifact review skill plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -807,6 +807,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Tooling"
+    },
+    {
+      "name": "lavish",
+      "source": {
+        "source": "local",
+        "path": "./plugins/lavish"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tooling"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -738,6 +738,14 @@
       "keywords": ["dev3000", "d3k", "debugging", "web", "logs", "screenshots"],
       "tags": ["skills", "vercel"],
       "source": "./plugins/dev3000"
+    },
+    {
+      "name": "lavish",
+      "description": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.",
+      "category": "tooling",
+      "keywords": ["lavish", "html", "artifacts", "review", "visualization"],
+      "tags": ["skills"],
+      "source": "./plugins/lavish"
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -61,5 +61,6 @@
   "plugins/eve": "1.1.0",
   "plugins/skill-optimizer": "1.1.0",
   "plugins/nostics": "1.0.0",
-  "plugins/dev3000": "1.0.0"
+  "plugins/dev3000": "1.0.0",
+  "plugins/lavish": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install google-workspace@pleaseai
 /plugin install skill-optimizer@pleaseai
 /plugin install dev3000@pleaseai
+/plugin install lavish@pleaseai
 ```
 
 ## What Are Claude Code Plugins?

--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ dev3000 (d3k) debugging assistant — captures server logs, browser events, cons
 
 **Install:** `/plugin install dev3000@pleaseai` | **Source:** [plugins/dev3000](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/dev3000)
 
+#### Lavish
+
+Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.
+
+**Install:** `/plugin install lavish@pleaseai` | **Source:** [plugins/lavish](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/lavish)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:

--- a/plugins/lavish/.agents/skills/lavish/SKILL.md
+++ b/plugins/lavish/.agents/skills/lavish/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lavish
+description: Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.
+argument-hint: <what the artifact should show>
+author: Kun Chen (kunchenguid)
+metadata:
+  hermes:
+    tags: [html, review, artifacts, visualization]
+    category: productivity
+---
+
+# Lavish Editor
+
+Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. Whenever you are about to give user a complex response that will be easier to understand via a rich / interactive page, consider using Lavish Editor. First generate an interactive HTML artifact according to user request, then run `npx -y lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `npx -y lavish-axi poll`.
+
+You do not need lavish-axi installed globally - invoke it with `npx -y lavish-axi <html-file>`.
+If lavish-axi output shows a follow-up command starting with `lavish-axi`, run it as `npx -y lavish-axi ...` instead.
+
+## Request
+
+$ARGUMENTS
+
+If the request above is non-empty, the user invoked `/lavish` explicitly - build an HTML artifact for that request now, following the workflow below.
+If it is empty, infer what to visualize from the conversation.
+
+## When to use
+
+Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop
+
+## Workflow
+
+1. Create the HTML artifact (default location `.lavish/<name>.html` in the working directory).
+2. Run `npx -y lavish-axi <html-file>` to open or resume a review session in the browser.
+3. Run `npx -y lavish-axi poll <html-file>` to long-poll for the user's annotations, queued prompts, and browser-reported `layout_warnings`.
+   The poll stays silent until the user acts or the real browser reports fresh layout warnings - leave it running, never kill it.
+   If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost.
+4. If poll returns `layout_warnings`, fix overflow, clipped text, or overlapping unreadable content and re-check before involving the human.
+5. Apply human feedback, then poll again with `--agent-reply "<message>"` to reply in the browser and keep the loop going.
+6. Run `npx -y lavish-axi end <html-file>` when the review is finished.
+
+## Visual guidance
+
+- Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance
+- Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose
+- Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view
+- Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately
+
+## Playbooks
+
+Run `npx -y lavish-axi playbook <id>` for focused, detailed guidance on any of these.
+One artifact often combines several playbooks (for example a plan that includes a comparison and a diagram), so read every playbook relevant to your artifact, not just one, for the best quality:
+
+- `diagram` - Map relationships, flows, state, and architecture
+- `table` - Turn dense records into scan-friendly review surfaces
+- `comparison` - Show options, tradeoffs, and current vs target behavior
+- `plan` - Explain a product or technical plan before implementation
+- `code` - Render source code, code files, patches, PR diffs, and before/after code inside Lavish artifacts
+- `input` - Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact
+- `slides` - Create a deliberate presentation when slides are requested
+
+## Commands & rules
+
+- Run `npx -y lavish-axi <html-file>` to open or resume a Lavish Editor session
+- Unless the user specifies another location, create HTML artifacts in the current working directory under `.lavish/`
+- Lavish serves the html file through a local express.js server. If your html needs to reference other filesystem assets such as images, CSS, fonts, and local scripts, copy them into the same directory as the HTML file, then reference them with relative paths from that directory. Never prepend `/` to those asset paths - root paths won't work
+- Run `npx -y lavish-axi poll <html-file>` to wait for user feedback or browser-reported layout_warnings. It long-polls and stays silent until the user sends feedback, ends the session, or the real browser reports fresh layout_warnings, so leave it running - never kill it. Fix layout_warnings before involving the human. If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost
+- Run `npx -y lavish-axi end <html-file>` to end a session
+- Run `npx -y lavish-axi stop` to shut down the background server (it also self-stops when idle or after the last session ends with nothing connected)
+- Run `npx -y lavish-axi playbook <playbook_id>` for focused artifact guidance. One artifact often combines several playbooks (for example a plan that includes a comparison and a diagram), so read every playbook relevant to the artifact, not just one, for the best quality
+- Lavish does not auto-inject any design system - artifacts stay portable so they render identically when opened directly without lavish-axi running. Before writing any HTML, decide the design direction in this strict priority order, and only move to the next step when the current one truly yields nothing: (1) if the user asked for a specific look or named design system, use that; (2) otherwise you must first inspect the project the artifact is about - the subject or product whose content or UI it represents, which may differ from your current working directory - and match that project's design system: Tailwind or theme config, shared CSS variables or design tokens, component library, brand assets, or existing styled pages. If the artifact previews, proposes, or mocks a specific app's UI, render it in that app's own design system so it faithfully shows the product, even when you are running in a different repo; (3) only when both steps come up empty, use the Lavish-recommended Tailwind CSS browser runtime v4 + DaisyUI v5, available via CDN - run `npx -y lavish-axi design` for a copy-pasteable CDN snippet plus component reference, and prefer that CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. When you deliver the artifact, state which of the three design sources you used and why.
+- Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop

--- a/plugins/lavish/.claude-plugin/plugin.json
+++ b/plugins/lavish/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "lavish",
+  "version": "1.0.0",
+  "description": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.",
+  "author": {
+    "name": "Kun Chen",
+    "url": "https://github.com/kunchenguid"
+  },
+  "homepage": "https://github.com/kunchenguid/lavish-axi",
+  "repository": "https://github.com/kunchenguid/lavish-axi",
+  "license": "MIT",
+  "keywords": ["lavish", "html", "artifacts", "review", "visualization"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/lavish/.codex-plugin/plugin.json
+++ b/plugins/lavish/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "lavish",
+  "version": "1.0.0",
+  "description": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.",
+  "author": {
+    "name": "Kun Chen",
+    "url": "https://github.com/kunchenguid"
+  },
+  "interface": {
+    "displayName": "Lavish",
+    "shortDescription": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI",
+    "longDescription": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.",
+    "developerName": "Kun Chen",
+    "category": "Tooling",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Lavish for my current task."
+    ],
+    "websiteURL": "https://github.com/kunchenguid/lavish-axi"
+  },
+  "homepage": "https://github.com/kunchenguid/lavish-axi",
+  "repository": "https://github.com/kunchenguid/lavish-axi",
+  "license": "MIT",
+  "keywords": [
+    "lavish",
+    "html",
+    "artifacts",
+    "review",
+    "visualization"
+  ]
+}

--- a/plugins/lavish/plugin.json
+++ b/plugins/lavish/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "lavish",
+  "version": "1.0.0",
+  "description": "Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.",
+  "author": {
+    "name": "Kun Chen",
+    "url": "https://github.com/kunchenguid"
+  },
+  "homepage": "https://github.com/kunchenguid/lavish-axi",
+  "repository": "https://github.com/kunchenguid/lavish-axi",
+  "license": "MIT",
+  "keywords": [
+    "lavish",
+    "html",
+    "artifacts",
+    "review",
+    "visualization"
+  ]
+}

--- a/plugins/lavish/skills-lock.json
+++ b/plugins/lavish/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "lavish": {
+      "source": "kunchenguid/lavish-axi",
+      "sourceType": "github",
+      "skillPath": "skills/lavish/SKILL.md",
+      "computedHash": "32bc766ecb6cbaa1c049fa3543166210eb12510c6784ebac939bd0c0916e7797"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -974,6 +974,27 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/lavish": {
+      "release-type": "simple",
+      "component": "lavish",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
## Summary

Adds the `lavish` built-in skill plugin to the marketplace. The skill is sourced
from [github.com/kunchenguid/lavish-axi](https://github.com/kunchenguid/lavish-axi)
(MIT) and installed via skills.sh (`bunx skills add`).

## Changes

- `plugins/lavish/` — new plugin directory with:
  - `.agents/skills/lavish/SKILL.md` — skills.sh-managed skill (vendor-synced, do not edit directly)
  - `skills-lock.json` — skills.sh lock file
  - `.claude-plugin/plugin.json` — Claude Code manifest
  - `.codex-plugin/plugin.json` — Codex manifest
  - `plugin.json` (root) — Antigravity manifest
- `.claude-plugin/marketplace.json` — source-of-truth marketplace entry added
- `.agents/plugins/marketplace.json` — Codex marketplace entry added (generated)
- `release-please-config.json` — `plugins/lavish` package entry with extra-files coverage
- `.release-please-manifest.json` — `plugins/lavish` version initialized
- `README.md` — Built-in Plugins table entry added

## Notes

- To refresh the skill to the latest upstream: `bunx skills update` inside `plugins/lavish/`
- This diff is scoped to lavish only — unrelated repo-wide drift from `bun scripts/cli.ts multi-format` was reverted before committing
- The `SKILL.md` file is vendor-synced; fix upstream at kunchenguid/lavish-axi rather than editing it directly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `lavish`, an HTML artifact review skill powered by `lavish-axi`, so agents can turn complex outputs into rich, reviewable pages. Registers the plugin in marketplaces, hooks it into release automation, and updates docs (including the bulk install list).

- **New Features**
  - Added `plugins/lavish/` with vendor-synced `.agents/skills/lavish/SKILL.md`, `skills-lock.json`, and manifests for Claude/Codex/root.
  - Registered `lavish` in `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`.
  - Set up `release-please` for `plugins/lavish` in `release-please-config.json` and `.release-please-manifest.json`.
  - README: added Lavish section, source link, and `/plugin install lavish@pleaseai` to the built-in install block.

- **Migration**
  - Install: `/plugin install lavish@pleaseai`.
  - To update the skill to upstream: run `bunx skills update` in `plugins/lavish/`.

<sup>Written for commit 6fb1e1a490f8c3bdb874088969fd5c220197fdc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Lavish** built-in plugin to the available plugins list, including installation support via `/plugin install lavish@pleaseai`.
  * Registered the plugin across marketplace and editor variants with versioning and skill integration.
* **Documentation**
  * Added end-to-end guidance for the Lavish skill, including how to generate rich HTML artifacts and run the recommended review/annotation loop.
  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->