### PR TITLE
feat(marketplace): add asana plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -518,6 +518,17 @@
       }
     },
     {
+      "name": "asana",
+      "description": "Manage Asana from the terminal with the `asana` CLI — tasks, projects, subtasks, comments, dependencies, tags, custom fields, and CSV/JSON batch import.",
+      "category": "productivity",
+      "keywords": ["asana", "cli", "task-management", "productivity"],
+      "tags": ["cli", "productivity"],
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/asana"
+      }
+    },
+    {
       "name": "please-plugins",
       "description": "Auto-detect project dependencies and recommend matching Claude Code plugins from the pleaseai marketplace",
       "category": "tooling",


### PR DESCRIPTION
## Summary

Adds the `asana` productivity plugin to the Claude Code marketplace.

## Changes

- Registers `asana` in `.claude-plugin/marketplace.json` sourced from `pleaseai/asana` on GitHub

## Plugin Details

The Asana plugin is a CLI-backed MCP integration for Asana, providing access to:
- Tasks (create, list, update, complete)
- Projects and subtasks
- Comments and dependencies
- Tags, custom fields
- CSV/JSON import

## Installation

```bash
/plugin install asana@pleaseai
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `asana` productivity plugin to the Claude Code marketplace by registering it in `.claude-plugin/marketplace.json` (source: `pleaseai/asana`). Install with `/plugin install asana@pleaseai` to manage tasks, projects, subtasks, comments, tags, custom fields, and CSV/JSON imports via the CLI.

<sup>Written for commit 4269c2fe7f1045f4b9a93700ac11ea9082b4af5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asana plugin is now available in the marketplace, enabling seamless integration with your projects and task management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->