### PR TITLE
feat(marketplace): add asana plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -763,6 +763,18 @@
       "name": "axi",
       "description": "Agent eXperience Interface (AXI) — ergonomic standards for building CLI tools that agents use via shell execution. Use when building, modifying, or reviewing any agent-facing CLI.",
       "source": "./plugins/axi"
+    },
+    {
+      "name": "asana",
+      "description": "Manage Asana from the terminal with the `asana` CLI — tasks, projects, subtasks, comments, dependencies, tags, custom fields, and CSV/JSON batch import.",
+      "category": "productivity",
+      "keywords": ["asana", "cli", "task-management", "productivity"],
+      "tags": ["skills", "productivity"],
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/asana"
+      },
+      "homepage": "https://github.com/pleaseai/asana"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Register the **asana** plugin in the pleaseai marketplace, sourced from [`pleaseai/asana`](https://github.com/pleaseai/asana).

The repo packages the `asana-cli` skill as a Claude Code plugin (`.claude-plugin/plugin.json` + top-level `skills/asana-cli/`). See pleaseai/asana#41.

## Entry

```json
{
  "name": "asana",
  "description": "Manage Asana from the terminal with the `asana` CLI — ...",
  "category": "productivity",
  "keywords": ["asana", "cli", "task-management", "productivity"],
  "tags": ["skills", "productivity"],
  "source": { "source": "github", "repo": "pleaseai/asana" },
  "homepage": "https://github.com/pleaseai/asana"
}
```

## Note

Merge **after** pleaseai/asana#41 lands, so the `.claude-plugin/plugin.json` manifest exists on the source repo's default branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `asana` plugin to the marketplace, sourced from `pleaseai/asana`, so users can install and use the `asana` CLI via Claude Code. Listed under productivity.

- **Dependencies**
  - Merge after `pleaseai/asana` adds `.claude-plugin/plugin.json` (pleaseai/asana#41).

<sup>Written for commit 259d3d9684e856103d2fbf916eae84f10d4b9797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asana CLI plugin is now available in the marketplace, enabling task and project management from the command line with support for subtasks, comments, dependencies, tags, custom fields, and batch imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->