### PR TITLE
feat(astro): add Astro Docs MCP plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -497,6 +497,18 @@
       "category": "Framework"
     },
     {
+      "name": "astro",
+      "source": {
+        "source": "local",
+        "path": "./plugins/astro"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Framework"
+    },
+    {
       "name": "tosspayments",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -427,6 +427,14 @@
       "source": "./plugins/docus"
     },
     {
+      "name": "astro",
+      "description": "Access Astro's official documentation through the Astro Docs MCP server.",
+      "category": "framework",
+      "keywords": ["astro", "docs", "documentation", "ssg", "web-framework"],
+      "tags": ["mcp", "docs"],
+      "source": "./plugins/astro"
+    },
+    {
       "name": "tosspayments",
       "description": "TossPayments payment integration guide - access official documentation for payment widget, checkout, and API integration",
       "category": "development",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -36,6 +36,7 @@
   "plugins/ast-grep": "1.2.1",
   "plugins/chat-sdk": "1.1.3",
   "plugins/docus": "1.1.2",
+  "plugins/astro": "1.0.0",
   "plugins/please-plugins": "1.6.0",
   "plugins/wordpress": "1.1.1",
   "plugins/vinext": "1.1.1",

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ Write beautiful documentations with Nuxt and Markdown.
 
 **Install:** `/plugin install docus@pleaseai` | **Source:** [plugins/docus](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/docus)
 
+#### Astro
+Access Astro's official documentation through the Astro Docs MCP server.
+
+**Install:** `/plugin install astro@pleaseai` | **Source:** [plugins/astro](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/astro)
+
 #### WordPress
 Expert-level WordPress knowledge for AI coding assistants — blocks, themes, plugins, and best practices.
 
@@ -554,6 +559,7 @@ Once the marketplace is added (or files copied), the following plugins are avail
 /plugin install markitdown@pleaseai
 /plugin install chat-sdk@pleaseai
 /plugin install docus@pleaseai
+/plugin install astro@pleaseai
 /plugin install wordpress@pleaseai
 /plugin install vinext@pleaseai
 /plugin install next@pleaseai

--- a/plugins/astro/.claude-plugin/plugin.json
+++ b/plugins/astro/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "astro",
+  "version": "1.0.0",
+  "description": "Access Astro's official documentation through the Astro Docs MCP server.",
+  "author": {
+    "name": "Astro",
+    "url": "https://github.com/withastro"
+  },
+  "homepage": "https://astro.build",
+  "repository": "https://github.com/withastro/docs",
+  "license": "MIT",
+  "keywords": [
+    "astro",
+    "docs",
+    "documentation",
+    "ssg",
+    "web-framework"
+  ],
+  "mcpServers": {
+    "astro-docs": {
+      "type": "http",
+      "url": "https://mcp.docs.astro.build/mcp"
+    }
+  }
+}

--- a/plugins/astro/.codex-plugin/plugin.json
+++ b/plugins/astro/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "astro",
+  "version": "1.0.0",
+  "description": "Access Astro's official documentation through the Astro Docs MCP server.",
+  "author": {
+    "name": "Astro",
+    "url": "https://github.com/withastro"
+  },
+  "interface": {
+    "displayName": "Astro",
+    "shortDescription": "Access Astro's official documentation through the Astro Docs MCP server.",
+    "longDescription": "Access Astro's official documentation through the Astro Docs MCP server.",
+    "developerName": "Astro",
+    "category": "Framework",
+    "capabilities": [
+      "Tool"
+    ],
+    "defaultPrompt": [
+      "Use Astro for my current task."
+    ],
+    "websiteURL": "https://astro.build"
+  },
+  "homepage": "https://astro.build",
+  "repository": "https://github.com/withastro/docs",
+  "license": "MIT",
+  "keywords": [
+    "astro",
+    "docs",
+    "documentation",
+    "ssg",
+    "web-framework"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/astro/.mcp.json
+++ b/plugins/astro/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "astro-docs": {
+      "type": "http",
+      "url": "https://mcp.docs.astro.build/mcp"
+    }
+  }
+}

--- a/plugins/astro/mcp_config.json
+++ b/plugins/astro/mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "astro-docs": {
+      "type": "http",
+      "url": "https://mcp.docs.astro.build/mcp"
+    }
+  }
+}

--- a/plugins/astro/plugin.json
+++ b/plugins/astro/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "astro",
+  "version": "1.0.0",
+  "description": "Access Astro's official documentation through the Astro Docs MCP server.",
+  "author": {
+    "name": "Astro",
+    "url": "https://github.com/withastro"
+  },
+  "homepage": "https://astro.build",
+  "repository": "https://github.com/withastro/docs",
+  "license": "MIT",
+  "keywords": [
+    "astro",
+    "docs",
+    "documentation",
+    "ssg",
+    "web-framework"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -468,6 +468,27 @@
         }
       ]
     },
+    "plugins/astro": {
+      "release-type": "simple",
+      "component": "astro",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
     "plugins/please-plugins": {
       "release-type": "simple",
       "component": "please-plugins",


### PR DESCRIPTION
## Summary

Adds a new **Astro Docs MCP plugin** (MCP-only, no slash commands or skills) to the marketplace. The plugin wraps the official Astro Docs streamable-HTTP MCP server at `https://mcp.docs.astro.build/mcp`, giving Claude Code access to up-to-date Astro documentation via MCP.

## Changes

- `plugins/astro/` — new plugin directory with five generated manifest files:
  - `.claude-plugin/plugin.json` — Claude Code manifest (source of truth)
  - `.codex-plugin/plugin.json` — Codex manifest (generated via multi-format)
  - `plugin.json` — Antigravity root manifest (generated)
  - `.mcp.json` — Codex MCP config (generated)
  - `mcp_config.json` — Antigravity MCP config (generated)
- `.claude-plugin/marketplace.json` — added astro entry (source of truth)
- `.agents/plugins/marketplace.json` — regenerated Codex marketplace with astro entry
- `release-please-config.json` — added `plugins/astro` package entry
- `.release-please-manifest.json` — added `"plugins/astro": "1.0.0"`
- `README.md` — added astro to Built-in Plugins list and install command

## MCP Endpoint

The plugin uses the official Astro Docs MCP endpoint:
```
https://mcp.docs.astro.build/mcp
```
Transport: streamable-HTTP (no local process required).

## Multi-runtime manifests

All runtime artifacts were generated by:
```bash
bun scripts/cli.ts multi-format
```
Claude Code manifest is the source of truth; Codex and Antigravity manifests are generated and should not be hand-edited.

## Notes

- `bun.lock` was intentionally **excluded** from this PR — it contains a pre-existing, unrelated change (`plugins/gatekeeper` 1.4.0 → 1.5.0) that will be committed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MCP-only `astro` plugin to give up-to-date Astro docs access via the official Astro Docs MCP server. Includes marketplace wiring, generated manifests for all runtimes, release automation, and README updates.

- **New Features**
  - Adds `plugins/astro` wrapping the Astro Docs MCP server at https://mcp.docs.astro.build/mcp (streamable HTTP; no local process).
  - Generates multi-runtime manifests (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `plugin.json`, `.mcp.json`, `mcp_config.json`) and adds marketplace entries.
  - Adds release automation entries and pins version to `1.0.0`.
  - Updates README with install command and source links.

<sup>Written for commit 8dd763f5553936418dcb2a1417c41dcf80e3533c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Astro plugin to the available plugin marketplace, making Astro documentation access easier to discover and install.
  * Included the plugin in the install list with the `astro` install command.

* **Documentation**
  * Updated the plugin catalog and README to show Astro as an available option with its description and source link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->