### PR TITLE
ci: remove Graphite CI optimizer and its token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,44 +16,8 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
-  # Graphite CI optimizer gate. On PRs, asks the Graphite API whether this
-  # PR's position in its stack means CI can be skipped (e.g., it's a mid-stack
-  # PR that will be retested when the top of the stack runs). On pushes to
-  # main, the optimizer is bypassed so post-merge CI always runs.
-  # Docs: https://graphite.com/docs/stacking-and-ci
-  optimize_ci:
-    name: Optimize CI
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      skip: ${{ steps.graphite.outputs.skip || steps.bypass.outputs.skip }}
-    steps:
-      - name: Bypass optimizer on push events
-        id: bypass
-        if: github.event_name != 'pull_request'
-        run: echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - name: Verify Graphite token is configured
-        if: github.event_name == 'pull_request'
-        env:
-          TOKEN: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::GRAPHITE_CI_OPTIMIZER_TOKEN secret is not set. Add it under Settings → Secrets and variables → Actions, or remove the optimize_ci job."
-            exit 1
-          fi
-
-      - name: Graphite CI optimizer
-        id: graphite
-        if: github.event_name == 'pull_request'
-        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
-        with:
-          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
-
   lint:
     name: Lint
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -91,8 +55,6 @@ jobs:
 
   build:
     name: Build
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -118,8 +80,6 @@ jobs:
 
   typecheck:
     name: Type Check
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -145,8 +105,6 @@ jobs:
 
   test:
     name: Test
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

Removes the `optimize_ci` job and its associated `GRAPHITE_CI_OPTIMIZER_TOKEN` secret dependency from `.github/workflows/ci.yml`.

## Changes

- Dropped the entire `optimize_ci` job, which was the sole consumer of `GRAPHITE_CI_OPTIMIZER_TOKEN`
- Removed `needs: optimize_ci` from `lint`, `build`, `typecheck`, and `test` jobs
- Removed `if: needs.optimize_ci.outputs.skip == 'false'` conditions from those jobs
- The four CI jobs now run unconditionally on every push/PR to `main`

## Notes

`bun.lock` drift (gatekeeper 1.4.0→1.5.0 sync) was intentionally excluded from this commit to keep the change atomic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies CI by removing the Graphite optimizer job and its token, so lint, build, typecheck, and test run on every push and PR.

- **Refactors**
  - Removed `optimize_ci` job from `.github/workflows/ci.yml`.
  - Dropped `needs: optimize_ci` and `if: needs.optimize_ci.outputs.skip == 'false'` from `lint`, `build`, `typecheck`, and `test`.
  - Removed dependency on the `GRAPHITE_CI_OPTIMIZER_TOKEN` secret.

<sup>Written for commit 236e4df422711f871bf61fb7a46bdc3d65097901. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the continuous integration workflow by removing an optimization step.
  * Validation jobs now run directly without conditional gating, making checks more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->