### PR TITLE
feat(greptile): add greptile skills plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1101,6 +1101,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Development"
+    },
+    {
+      "name": "greptile",
+      "source": {
+        "source": "local",
+        "path": "./plugins/greptile"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -823,6 +823,11 @@
         "ref": "main"
       },
       "homepage": "https://github.com/pleaseai/code-search"
+    },
+    {
+      "name": "greptile",
+      "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+      "source": "./plugins/greptile"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -358,6 +358,11 @@
       "name": "axi",
       "source": "./plugins/axi",
       "description": "Agent eXperience Interface (AXI) — ergonomic standards for building CLI tools that agents use via shell execution. Use when building, modifying, or reviewing any agent-facing CLI."
+    },
+    {
+      "name": "greptile",
+      "source": "./plugins/greptile",
+      "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5"
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -65,5 +65,6 @@
   "plugins/dev3000": "1.2.0",
   "plugins/lavish": "1.2.0",
   "plugins/axi": "1.2.0",
-  "plugins/playwright-cli": "1.0.0"
+  "plugins/playwright-cli": "1.0.0",
+  "plugins/greptile": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ Agent eXperience Interface (AXI) — ergonomic standards for building CLI tools 
 
 **Install:** `/plugin install axi@pleaseai` | **Source:** [plugins/axi](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/axi)
 
+#### Greptile
+
+Greptile agent skills for PR quality: check PR review comments and status checks (`check-pr`), run Greptile CLI reviews on local branches (`cli-review`), and iteratively improve PRs until they score 5/5 (`greploop`).
+
+**Install:** `/plugin install greptile@pleaseai` | **Source:** [plugins/greptile](https://github.com/pleaseai/claude-code-plugins/tree/main/plugins/greptile)
+
 ## Quick Start
 
 The fastest way to get started — install the marketplace and let the plugin recommender auto-detect what you need:

--- a/plugins/greptile/.agents/skills/check-pr/SKILL.md
+++ b/plugins/greptile/.agents/skills/check-pr/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: check-pr
+description: >
+  Checks a GitHub, GitLab, or Perforce (p4) pull request (or merge request, or shelved changelist)
+  for unresolved review comments, failing status checks, and incomplete PR descriptions. Waits for
+  pending checks to complete, categorizes issues as actionable or informational, and optionally fixes
+  and resolves them. Use when the user wants to check a PR/MR/CL, address review feedback, or prepare
+  a change for submission.
+license: MIT
+compatibility: Requires git and gh (GitHub CLI), glab (GitLab CLI), or p4 (Perforce CLI) installed and authenticated.
+metadata:
+  author: greptileai
+  version: "1.3"
+allowed-tools: Bash(gh:*) Bash(glab:*) Bash(git:*) Bash(p4:*)
+---
+
+# Check PR
+
+Analyze a pull request (GitHub), merge request (GitLab), or shelved changelist (Perforce) for review comments, status checks, and description completeness, then help address any issues found.
+
+## Inputs
+
+- **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+
+## Instructions
+
+### 0. Detect platform
+
+First check if the user is working in a Perforce depot by looking for a `.p4config` file or `P4CLIENT`/`P4PORT` environment variables:
+
+```bash
+# Check for Perforce environment
+if p4 info >/dev/null 2>&1; then
+  VCS="perforce"
+else
+  # Fall back to git remote detection
+  REMOTE_URL=$(git remote get-url origin)
+  if echo "$REMOTE_URL" | grep -qi "gitlab"; then
+    VCS="gitlab"
+  else
+    VCS="github"
+  fi
+fi
+```
+
+For self-hosted GitLab instances whose hostname doesn't contain "gitlab", the user can override by passing `--vcs gitlab` as an input. For Perforce, the user can override by passing `--vcs perforce`.
+
+### 1. Identify the PR/MR/CL
+
+If a number was provided, use it. Otherwise, detect it:
+
+**GitHub:**
+```bash
+gh pr view --json number -q .number
+```
+
+**GitLab:**
+```bash
+glab mr view --output json | jq '.iid'
+```
+
+**Perforce:**
+```bash
+# List pending changelists for the current user/client
+p4 changes -s pending -u $P4USER -c $P4CLIENT
+```
+
+Key field differences between platforms:
+- GitHub: `number`, `headRefName`, `headRefOid`
+- GitLab: `iid`, `source_branch`, `sha`
+- Perforce: changelist number (CL), `shelved` files for in-review CLs
+
+### 2. Fetch PR/MR/CL details
+
+**GitHub:**
+```bash
+gh pr view <PR_NUMBER> --json title,body,state,reviews,comments,headRefName,statusCheckRollup
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments?per_page=100"
+```
+
+GitHub PRs are also issues, so general PR comments live on the issue comments endpoint. Greptile may edit a single general PR comment on each review cycle instead of creating a new review or comment. Always inspect the latest Greptile-authored general comment by `updated_at`, including any "Prompt to fix all with AI" section, before concluding that the PR is clear.
+
+**GitLab:**
+```bash
+glab mr view <MR_IID> --output json
+# Fetch discussions (inline diff comments are type "DiffNote"; general comments have null type)
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions"
+```
+
+For GitLab, paginate discussions if needed (add `?per_page=100&page=N`).
+
+**Perforce:**
+```bash
+# Get changelist description, files, and status
+p4 describe -s <CL_NUMBER>
+
+# Get shelved files (for in-review CLs)
+p4 describe -S <CL_NUMBER>
+
+# Get the diff of the shelved changelist
+p4 diff2 //...@=<CL_NUMBER> //...@=<CL_NUMBER>
+
+# List review comments (if using p4 review workflow)
+p4 review -c <CL_NUMBER>
+```
+
+Key Perforce CL fields:
+- `Change`: changelist number
+- `Status`: `pending`, `submitted`, `shelved`
+- `Description`: the CL description / commit message
+- `Files`: list of files in the CL
+
+### 3. Wait for pending checks
+
+Before analyzing, ensure all status checks have completed. If any checks are `PENDING` or `IN_PROGRESS` (GitHub) / `running` or `pending` (GitLab), poll every 30 seconds until all checks reach a terminal state.
+
+**GitHub:** poll `statusCheckRollup` from `gh pr view`.
+
+**GitLab:**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+Pipeline statuses: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`. Poll until no pipeline has `running` or `pending` status.
+
+**Perforce:** Perforce doesn't have built-in CI checks natively. If the team uses a review tool (Swarm, etc.) or an external CI triggered by shelve events, check the relevant system. Otherwise, proceed to analysis immediately.
+
+### 4. Analyze the PR/MR
+
+Once all checks are complete, evaluate these areas:
+
+#### A. Status Checks
+
+- Are all CI checks passing?
+- If any are failing, identify which ones and the failure reason.
+
+#### B. PR/MR Description
+
+- Is the description complete and follows team conventions?
+- Are all required sections filled in?
+- Are there TODOs or placeholders that need updating?
+
+#### C. Review Comments
+
+- Inline code review comments that need addressing
+- Look for bot review comments (e.g. from `greptile-apps[bot]` on GitHub, or the Greptile bot user on GitLab, linters, etc.)
+- Human reviewer comments
+- **Perforce:** review comments from `p4 review` or external review tools
+
+#### D. General Comments
+
+- Discussion comments on the PR/MR
+- For GitHub, check the issue comments endpoint and use `updated_at` to catch bot comments edited in place. Greptile's latest edited summary can contain actionable items even when there are no new inline comments.
+- Bot comments (deploy previews, etc.) — usually informational
+- **Perforce:** CL description should include a clear summary, affected files rationale, and testing notes
+
+### 5. Categorize issues
+
+For each issue found, categorize as:
+
+| Category | Meaning |
+|---|---|
+| **Actionable** | Code changes, test improvements, or fixes needed |
+| **Informational** | Verification notes, questions, or FYIs that don't require changes |
+| **Already addressed** | Issues that appear to be resolved by subsequent commits |
+
+### 6. Report findings
+
+Present a summary table:
+
+| Area | Issue | Status | Action Needed |
+|------|-------|--------|---------------|
+| Status Checks | CI build failing | Failing | Fix type error in `src/api.ts` |
+| Review | "Add null check" — @reviewer | Actionable | Add guard clause |
+| Description | TODO placeholder in test plan | Actionable | Fill in test plan |
+| Review | "Looks good" — @teammate | Informational | None |
+
+### 7. Fix issues (if requested)
+
+If there are actionable items:
+
+1. Switch to the PR/MR's branch (git) or ensure files are open in the correct CL (Perforce) if not already.
+2. Ask the user if they want to fix the issues.
+3. If yes, make the fixes, then:
+
+**GitHub/GitLab:** commit and push:
+```bash
+git add <files>
+git commit -m "address review feedback"
+git push
+```
+
+**Perforce:** open files for edit, make changes, and re-shelve:
+```bash
+p4 edit <file>
+# make changes
+p4 shelve -f -c <CL_NUMBER>
+```
+
+### 8. Resolve review threads
+
+After addressing comments, resolve the corresponding review threads.
+
+**Perforce** — Perforce does not have a native "resolve thread" concept. Instead, mark comments as addressed by updating the CL description or by responding in the review tool being used (Swarm, etc.). If using `p4 review`:
+
+```bash
+# Mark files as reviewed after addressing feedback
+p4 review -c <CL_NUMBER>
+```
+
+**GitHub** — fetch unresolved thread IDs (paginate if needed — see [the GraphQL reference](references/graphql-queries.md)):
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body path }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+If `hasNextPage` is true, repeat with `-f cursor=ENDCURSOR` to get remaining threads.
+
+Then resolve threads that have been addressed or are informational:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Batch multiple resolutions into a single mutation using aliases (`t1`, `t2`, etc.).
+
+**GitLab** — fetch unresolved discussions (see [the GitLab API reference](references/gitlab-api.md)):
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Filter for discussions where `"resolved": false`. Collect each discussion's `id`.
+
+Resolve each discussion individually (GitLab has no batch resolution):
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+Repeat for each unresolved discussion ID.
+
+### 9. Multiple PRs/MRs/CLs
+
+If checking a chain of PRs/MRs/CLs, process them sequentially.
+
+**Perforce** — to check multiple changelists at once:
+```bash
+p4 changes -s pending -u $P4USER -c $P4CLIENT -l
+```
+
+## Output format
+
+Summarize:
+- PR/MR/CL title or description and current state
+- Platform detected (GitHub / GitLab / Perforce)
+- Status checks summary (passing/failing/pending) — or N/A for Perforce
+- Total issues found
+- Actionable items with descriptions
+- Items that can be ignored with reasons
+- Recommended next steps

--- a/plugins/greptile/.agents/skills/check-pr/references/gitlab-api.md
+++ b/plugins/greptile/.agents/skills/check-pr/references/gitlab-api.md
@@ -1,0 +1,91 @@
+# GitLab API Reference
+
+Useful GitLab REST API calls for working with merge request discussions, using `glab api`.
+
+`glab api` automatically resolves `:fullpath` to the URL-encoded project path from the local git remote.
+
+## Fetch MR details
+
+```bash
+glab mr view <MR_IID> --output json
+```
+
+Key fields (compared to GitHub equivalents):
+- `iid` — internal MR number (use this, not `id`)
+- `source_branch` — equivalent to GitHub's `headRefName`
+- `sha` — HEAD commit SHA, equivalent to GitHub's `headRefOid`
+- `description` — equivalent to GitHub's `body`
+
+## Fetch all discussions (inline + general comments)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Paginate with `&page=2`, `&page=3`, etc. until the response array length is less than `per_page`.
+
+Each discussion object:
+- `id` — discussion ID (used for resolution)
+- `resolved` — `true` or `false`
+- `notes` — array of note objects
+
+Each note object:
+- `type` — `"DiffNote"` for inline diff comments, `null` for general comments
+- `author.username` — author's username
+- `body` — comment text
+- `position.new_path` — file path (for `DiffNote` type)
+
+## Filter for unresolved inline diff comments
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100" | \
+  jq '[.[] | select(.resolved == false and (.notes[0].type == "DiffNote"))]'
+```
+
+## Resolve a single discussion
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+There is no batch resolution in GitLab — issue one PUT per discussion.
+
+## Fetch pipeline status for an MR
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+
+Pipeline statuses: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`.
+
+## Fetch jobs for a specific pipeline
+
+```bash
+glab api "projects/:fullpath/pipelines/<PIPELINE_ID>/jobs"
+```
+
+Each job has `name`, `status`, `stage`, and `web_url`.
+
+## Fetch MR notes (general comments and bot reviews)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes?per_page=100"
+```
+
+Filter by `author.username` to find Greptile bot comments. The exact bot username depends on the Greptile installation — check the first Greptile comment to identify it.
+
+## Post a comment on an MR
+
+```bash
+glab mr note <MR_IID> --message "your message here"
+```
+
+Or via API:
+
+```bash
+glab api --method POST \
+  "projects/:fullpath/merge_requests/<MR_IID>/notes" \
+  --field body="your message here"
+```

--- a/plugins/greptile/.agents/skills/check-pr/references/graphql-queries.md
+++ b/plugins/greptile/.agents/skills/check-pr/references/graphql-queries.md
@@ -1,0 +1,87 @@
+# GraphQL Queries Reference
+
+Useful GitHub GraphQL queries for working with PR review threads.
+
+## Fetch unresolved review threads (with pagination)
+
+```graphql
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          comments(first: 3) {
+            nodes {
+              body
+              path
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Pass `-f cursor=ENDCURSOR` on subsequent requests if `hasNextPage` is `true`.
+
+## Resolve a single review thread
+
+```graphql
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}
+```
+
+## Batch-resolve multiple threads
+
+Use GraphQL aliases to resolve several threads in one request:
+
+```graphql
+mutation {
+  t1: resolveReviewThread(input: {threadId: "THREAD_ID_1"}) {
+    thread { isResolved }
+  }
+  t2: resolveReviewThread(input: {threadId: "THREAD_ID_2"}) {
+    thread { isResolved }
+  }
+  t3: resolveReviewThread(input: {threadId: "THREAD_ID_3"}) {
+    thread { isResolved }
+  }
+}
+```
+
+## Fetch PR details (REST)
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,state,reviews,comments,headRefName,statusCheckRollup
+```
+
+## Fetch inline review comments (REST)
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+## Fetch general PR comments edited in place (REST)
+
+General PR comments are issue comments. Greptile may update one summary comment repeatedly, so select by `updated_at` instead of `created_at`:
+
+```bash
+gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments?per_page=100" \
+  | jq -s 'add
+    | map(select(.user.login | test("greptile"; "i")))
+    | sort_by(.updated_at)
+    | last
+    | {author: .user.login, updated_at, body}'
+```

--- a/plugins/greptile/.agents/skills/cli-review/SKILL.md
+++ b/plugins/greptile/.agents/skills/cli-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cli-review
+description: >
+  Runs a Greptile CLI review for the current local branch, installing or authenticating the CLI
+  when needed, then summarizes JSON findings for the user. Use when the user wants Greptile
+  feedback before opening a PR, outside a hosted PR review flow, or directly from a local checkout.
+license: MIT
+metadata:
+  author: greptileai
+  version: "1.0"
+allowed-tools: Bash(git:*) Bash(greptile:*) Bash(command:*) Bash(curl:*) Bash(npm:*)
+---
+
+# CLI Review
+
+Run a Greptile review from the local checkout and summarize the findings.
+
+## Instructions
+
+### 1. Confirm repository context
+
+Start from the current repository root:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+If the command fails, tell the user that the Greptile CLI review must be run from a git repository.
+
+### 2. Check for the Greptile CLI
+
+Check whether `greptile` is installed:
+
+```bash
+command -v greptile
+```
+
+If it is missing, do not install it automatically. Ask the user for permission, then show the recommended install command:
+
+```bash
+npm i -g greptile
+```
+
+If npm is unavailable, offer the shell installer fallback:
+
+```bash
+curl -fsSL "https://greptile.com/cli/install" | sh
+```
+
+After installation, re-run `command -v greptile`.
+
+### 3. Ensure authentication
+
+Check the signed-in account:
+
+```bash
+greptile whoami
+```
+
+If the CLI reports that authentication is missing, run:
+
+```bash
+greptile login
+```
+
+Wait for the user to complete the login flow before continuing.
+
+### 4. Run the review
+
+Prefer JSON output:
+
+```bash
+greptile review --json
+```
+
+If JSON output is unsupported or fails with a usage error, fall back to:
+
+```bash
+greptile review --agent
+```
+
+Do not hide the raw command failure if both commands fail. Summarize the failing command and the next action the user needs to take.
+
+### 5. Summarize results
+
+Parse JSON output when available and report:
+
+- Review status
+- Number of findings
+- Highest severity findings first
+- Files that need edits
+- Suggested next command or fix path
+
+When output is plain text, preserve the same structure as much as possible. Keep the summary concise and focused on actionable findings.

--- a/plugins/greptile/.agents/skills/greploop/SKILL.md
+++ b/plugins/greptile/.agents/skills/greploop/SKILL.md
@@ -1,0 +1,432 @@
+---
+name: greploop
+description: >
+  Iteratively improves a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile
+  gives it a 5/5 confidence score with zero unresolved comments. Triggers Greptile review, fixes all
+  actionable comments, pushes/re-shelves, re-triggers review, and repeats. Use when the user wants to
+  fully optimize a PR/MR/CL against Greptile's code review standards.
+license: MIT
+compatibility: Requires git, gh (GitHub CLI) or glab (GitLab CLI) authenticated, and Greptile installed on the repo. For Perforce, requires p4 CLI authenticated.
+metadata:
+  author: greptileai
+  version: "1.3"
+allowed-tools: Bash(gh:*) Bash(glab:*) Bash(git:*) Bash(p4:*)
+---
+
+# Greploop
+
+Iteratively fix a PR/MR/CL until Greptile gives a perfect review: 5/5 confidence, zero unresolved comments.
+
+## Inputs
+
+- **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+
+## Instructions
+
+### 0. Detect platform
+
+First check for Perforce, then fall back to git remote detection:
+
+```bash
+# Check for Perforce environment
+if p4 info >/dev/null 2>&1; then
+  VCS="perforce"
+else
+  REMOTE_URL=$(git remote get-url origin)
+  if echo "$REMOTE_URL" | grep -qi "gitlab"; then
+    VCS="gitlab"
+  else
+    VCS="github"
+  fi
+fi
+```
+
+For self-hosted GitLab instances whose hostname doesn't contain "gitlab", the user can override by passing `--vcs gitlab` as an input. For Perforce, pass `--vcs perforce`.
+
+### 1. Identify the PR/MR/CL
+
+**GitHub:**
+```bash
+gh pr view --json number,headRefName -q '{number: .number, branch: .headRefName}'
+```
+
+**GitLab:**
+```bash
+glab mr view --output json | jq '{iid: .iid, branch: .source_branch}'
+```
+
+Switch to the PR/MR branch if not already on it.
+
+**Perforce:**
+```bash
+# List pending changelists for current user/client
+p4 changes -s pending -u $P4USER -c $P4CLIENT
+
+# Describe a specific CL
+p4 describe -s <CL_NUMBER>
+```
+
+Ensure the correct workspace (`p4 client`) is set before proceeding.
+
+Key field differences:
+- GitHub: `number`, `headRefName`, `headRefOid`
+- GitLab: `iid`, `source_branch`, `sha`
+- Perforce: changelist number, `P4CLIENT`, shelved files
+
+### 2. Loop
+
+Repeat the following cycle. **Max 5 iterations** to avoid runaway loops.
+
+#### A. Trigger Greptile review
+
+Push/shelve the latest changes (if any):
+
+**GitHub/GitLab:**
+```bash
+git push
+```
+
+**Perforce:**
+```bash
+# Re-shelve to update the shelved files for review
+p4 shelve -f -c <CL_NUMBER>
+```
+
+Wait for checks to start after push/shelve:
+
+```bash
+sleep 5
+```
+
+**GitHub** — check if Greptile is already running before posting a new trigger comment:
+
+```bash
+GREPTILE_STATE=$(gh pr checks <PR_NUMBER> --json name,state | jq -r '.[] | select(.name | test("greptile"; "i")) | .state')
+```
+
+If Greptile is **not** already running (`PENDING` or `IN_PROGRESS`), request a fresh review:
+
+```bash
+if [ "$GREPTILE_STATE" != "PENDING" ] && [ "$GREPTILE_STATE" != "IN_PROGRESS" ]; then
+  gh pr comment <PR_NUMBER> --body "@greptile review"
+fi
+```
+
+Then poll for the Greptile check run to complete:
+
+```bash
+HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid -q .headRefOid)
+
+while true; do
+  GREPTILE_CHECK=$(gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/check-runs" \
+    --jq '.check_runs[] | select(.name | test("greptile"; "i"))' 2>/dev/null)
+  
+  if [ -z "$GREPTILE_CHECK" ]; then
+    echo "Waiting for Greptile check to appear..."
+    sleep 5
+    continue
+  fi
+  
+  STATUS=$(echo "$GREPTILE_CHECK" | jq -r '.status // "completed"')
+  CONCLUSION=$(echo "$GREPTILE_CHECK" | jq -r '.conclusion // "pending"')
+  
+  if [ "$STATUS" = "completed" ]; then
+    if [ "$CONCLUSION" = "success" ]; then
+      echo "Greptile check passed!"
+    else
+      echo "Greptile check completed with: $CONCLUSION"
+    fi
+    break
+  fi
+  
+  echo "Waiting for Greptile... (status: $STATUS)"
+  sleep 10
+done
+```
+
+**GitLab** — check if Greptile is already running before posting a trigger comment:
+
+```bash
+PIPELINES=$(glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines")
+GREPTILE_RUNNING=$(echo "$PIPELINES" | jq '[.[] | select(.status == "running" or .status == "pending")] | length')
+```
+
+If no pipeline is running, post a trigger comment:
+
+```bash
+if [ "$GREPTILE_RUNNING" = "0" ]; then
+  glab mr note <MR_IID> --message "@greptile review"
+fi
+```
+
+**Perforce** — Perforce does not have native check runs. If Greptile is integrated via a webhook triggered on `p4 shelve`, wait for it to process. Check your Greptile installation's webhook endpoint or dashboard for the review status. Poll by re-fetching the Greptile review comment on the CL until a score appears.
+
+Then poll for the Greptile pipeline job to complete (see [GitLab API reference](references/gitlab-api.md)):
+
+```bash
+HEAD_SHA=$(glab mr view <MR_IID> --output json | jq -r '.sha')
+
+while true; do
+  PIPELINES=$(glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines")
+  # Find the most recent pipeline for this SHA
+  PIPELINE_ID=$(echo "$PIPELINES" | jq -r --arg sha "$HEAD_SHA" \
+    '[.[] | select(.sha == $sha)] | sort_by(.id) | last | .id // empty')
+
+  if [ -z "$PIPELINE_ID" ]; then
+    echo "Waiting for Greptile pipeline to appear..."
+    sleep 5
+    continue
+  fi
+
+  JOBS=$(glab api "projects/:fullpath/pipelines/$PIPELINE_ID/jobs")
+  GREPTILE_JOB=$(echo "$JOBS" | jq '.[] | select(.name | test("greptile"; "i"))')
+
+  if [ -z "$GREPTILE_JOB" ]; then
+    echo "Waiting for Greptile job to appear..."
+    sleep 5
+    continue
+  fi
+
+  JOB_STATUS=$(echo "$GREPTILE_JOB" | jq -r '.status')
+
+  if [ "$JOB_STATUS" = "success" ] || [ "$JOB_STATUS" = "failed" ] || [ "$JOB_STATUS" = "canceled" ]; then
+    echo "Greptile job completed with: $JOB_STATUS"
+    break
+  fi
+
+  echo "Waiting for Greptile... (status: $JOB_STATUS)"
+  sleep 10
+done
+```
+
+#### B. Fetch Greptile review results
+
+Greptile may surface its score in several places — check **all** of the relevant sources:
+
+**GitHub:**
+
+**1. PR description (body):**
+```bash
+gh pr view <PR_NUMBER> --json body -q '.body'
+```
+
+**2. General PR comments (issue comments):**
+```bash
+gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments?per_page=100"
+```
+
+Filter for Greptile-authored comments and use the body from the most recently updated comment (`updated_at`), not the most recently created comment. Greptile may edit the same general PR comment on each review cycle; parse the current body, including the "Prompt to fix all with AI" section, before deciding there are no remaining issues.
+
+**3. PR reviews:**
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews
+```
+
+Look for the most recent entry from `greptile-apps[bot]` or `greptile-apps-staging[bot]`.
+
+**GitLab:**
+
+**1. MR description (body):**
+```bash
+glab mr view <MR_IID> --output json | jq -r '.description'
+```
+
+**2. MR notes (comments):**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes"
+```
+
+Filter for notes from the Greptile bot user (check the `author.username` field — the exact username may vary per installation; verify on first run).
+
+**Perforce:**
+
+**1. CL description:**
+```bash
+p4 describe -s <CL_NUMBER>
+```
+Check the description field for a Greptile-appended score block.
+
+**2. CL comments / review notes:**
+If your installation uses a review tool such as Helix Swarm, fetch comments via its API.
+
+Example (Swarm API):
+GET /api/v11/comments?topic=reviews/<REVIEW_ID>
+
+Response fields of interest typically include:
+- user (author username)
+- body (comment text)
+- flags/state indicating whether the comment is resolved
+
+Filter to comments authored by the Greptile bot:
+- Prefer exact username match if known
+- Otherwise, use a heuristic where the author name contains "greptile" (case-insensitive)
+
+For all platforms, parse the text for:
+- **Confidence score**: a pattern like `3/5` or `5/5` (or `Confidence: 3/5`).
+- **Comment count**: Number of inline review comments noted in the summary.
+
+Use whichever source has the **most recently updated** score. For GitHub, prefer `updated_at` from issue comments when comparing an edited Greptile summary against older review entries.
+
+Also fetch all unresolved inline comments:
+
+**GitHub:**
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+Also carry forward actionable items from the latest Greptile general PR comment, especially the "Prompt to fix all with AI" section, even if the inline comment endpoint returns zero unresolved comments.
+
+**GitLab:**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions"
+```
+
+Filter to `DiffNote` type discussions (`notes[0].type == "DiffNote"`) from Greptile that are on the latest commit and not yet resolved (`"resolved": false`).
+
+**Perforce:**
+If using Swarm:
+
+# Fetch inline diff comments for the review associated with the CL
+GET /api/v11/comments?topic=reviews/<REVIEW_ID>
+
+Filter to comments from the Greptile bot user that have not been marked as resolved/addressed.
+
+#### C. Check exit conditions
+
+Stop the loop if **any** of these are true:
+
+- Confidence score is **5/5** AND there are **zero unresolved comments**
+- Max iterations reached (report current state)
+
+#### D. Fix actionable comments
+
+For each unresolved Greptile comment:
+
+1. Read the file and understand the comment in context.
+2. Determine if it's actionable (code change needed) or informational.
+3. If actionable, make the fix.
+4. If informational or a false positive, note it but still resolve the thread.
+
+#### E. Resolve threads
+
+**GitHub** — fetch unresolved review threads and resolve all that have been addressed (see [GraphQL reference](references/graphql-queries.md)):
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body path author { login } }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Resolve addressed threads:
+
+```bash
+gh api graphql -f query='
+mutation {
+  t1: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
+}'
+```
+
+**GitLab** — fetch unresolved discussions and resolve each one (see [GitLab API reference](references/gitlab-api.md)):
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Filter for `"resolved": false` discussions. Then resolve each by its `id`:
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+Repeat for each unresolved discussion ID. (GitLab has no batch resolution — loop through each one.)
+
+#### F. Commit and push / re-shelve
+
+**GitHub/GitLab:**
+```bash
+git add -A
+git commit -m "address greptile review feedback (greploop iteration N)"
+git push
+```
+
+**Perforce:**
+```bash
+# Stage changes back into the CL and re-shelve for the next review round
+p4 shelve -f -c <CL_NUMBER>
+```
+
+Wait for checks to start after push/shelve:
+
+```bash
+sleep 5
+```
+
+Then go back to step **A**.
+
+### 3. Report
+
+After exiting the loop, summarize:
+
+| Field              | Value      |
+| ------------------ | ---------- |
+| Platform           | GitHub / GitLab / Perforce |
+| Iterations         | N          |
+| Final confidence   | X/5        |
+| Comments resolved  | N          |
+| Remaining comments | N (if any) |
+
+If the loop exited due to max iterations, list any remaining unresolved comments and suggest next steps.
+
+## Output format
+
+```
+Greploop complete.
+  Platform:      GitHub
+  Iterations:    2
+  Confidence:    5/5
+  Resolved:      7 comments
+  Remaining:     0
+```
+
+If not fully resolved:
+
+```
+Greploop stopped after 5 iterations.
+  Platform:      GitLab
+  Confidence:    4/5
+  Resolved:      12 comments
+  Remaining:     2
+
+Remaining issues:
+  - src/auth.ts:45 — "Consider rate limiting this endpoint"
+  - src/db.ts:112 — "Missing index on user_id column"
+```
+
+**Perforce example:**
+
+```
+Greploop complete.
+  Platform:      Perforce
+  Changelist:    12345
+  Iterations:    3
+  Confidence:    5/5
+  Resolved:      9 comments
+  Remaining:     0
+```

--- a/plugins/greptile/.agents/skills/greploop/references/gitlab-api.md
+++ b/plugins/greptile/.agents/skills/greploop/references/gitlab-api.md
@@ -1,0 +1,93 @@
+# GitLab API Reference
+
+Useful GitLab REST API calls for the greploop workflow, using `glab api`.
+
+`glab api` automatically resolves `:fullpath` to the URL-encoded project path from the local git remote.
+
+## Fetch MR details
+
+```bash
+glab mr view <MR_IID> --output json
+```
+
+Key fields:
+- `iid` — internal MR number (use this, not `id`)
+- `source_branch` — equivalent to GitHub's `headRefName`
+- `sha` — HEAD commit SHA
+- `description` — MR body (Greptile may update this with the confidence score)
+
+## Trigger Greptile review
+
+```bash
+glab mr note <MR_IID> --message "@greptile review"
+```
+
+## Fetch pipelines for an MR
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+
+Check `status` field: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`.
+
+## Fetch jobs for a pipeline (to find the Greptile job)
+
+```bash
+glab api "projects/:fullpath/pipelines/<PIPELINE_ID>/jobs"
+```
+
+Filter jobs where `name` matches `greptile` (case-insensitive). Terminal statuses: `success`, `failed`, `canceled`.
+
+## Check if any pipeline is running
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines" | \
+  jq '[.[] | select(.status == "running" or .status == "pending")] | length'
+```
+
+Returns `0` if no pipelines are running/pending.
+
+## Find pipeline for a specific commit SHA
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines" | \
+  jq -r --arg sha "COMMIT_SHA" '[.[] | select(.sha == $sha)] | sort_by(.id) | last | .id // empty'
+```
+
+## Fetch MR notes (to find Greptile's confidence score)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes?per_page=100&sort=desc&order_by=created_at"
+```
+
+Filter by `author.username` for the Greptile bot. Scan `body` for a confidence pattern like `3/5` or `5/5`.
+
+The Greptile bot username on GitLab may differ from GitHub's `greptile-apps[bot]` — check the first Greptile comment on the MR to identify the exact username.
+
+## Fetch unresolved discussions (inline comments)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Paginate with `&page=2`, etc. until response array length < `per_page`.
+
+Filter for unresolved inline diff comments from Greptile:
+```bash
+jq '[.[] | select(.resolved == false and (.notes[0].type == "DiffNote") and (.notes[0].author.username == "GREPTILE_BOT_USERNAME"))]'
+```
+
+Each discussion has:
+- `id` — use this for resolution
+- `notes[0].body` — the comment text
+- `notes[0].position.new_path` — file path
+
+## Resolve a discussion
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+GitLab has no batch resolution — issue one PUT per discussion.

--- a/plugins/greptile/.agents/skills/greploop/references/graphql-queries.md
+++ b/plugins/greptile/.agents/skills/greploop/references/graphql-queries.md
@@ -1,0 +1,49 @@
+# GraphQL Queries Reference
+
+## Fetch unresolved review threads (paginated)
+
+```graphql
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 3) {
+            nodes {
+              body
+              path
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Batch-resolve threads
+
+```graphql
+mutation {
+  t1: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
+}
+```
+
+## Fetch general PR comments edited in place (REST)
+
+General PR comments are issue comments. Greptile may update one summary comment repeatedly, so select by `updated_at` instead of `created_at`:
+
+```bash
+gh api --paginate "repos/{owner}/{repo}/issues/<PR_NUMBER>/comments?per_page=100" \
+  | jq -s 'add
+    | map(select(.user.login | test("greptile"; "i")))
+    | sort_by(.updated_at)
+    | last
+    | {author: .user.login, updated_at, body}'
+```

--- a/plugins/greptile/.claude-plugin/plugin.json
+++ b/plugins/greptile/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "greptile",
+  "version": "1.0.0",
+  "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+  "license": "MIT",
+  "keywords": ["greptile", "code-review", "pull-request"],
+  "skills": "./.agents/skills/"
+}

--- a/plugins/greptile/.codex-plugin/plugin.json
+++ b/plugins/greptile/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "greptile",
+  "version": "1.0.0",
+  "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+  "author": {
+    "name": "Community"
+  },
+  "interface": {
+    "displayName": "Greptile",
+    "shortDescription": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs unt...",
+    "longDescription": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+    "developerName": "Community",
+    "category": "Productivity",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Greptile for my current task."
+    ]
+  },
+  "license": "MIT",
+  "keywords": [
+    "greptile",
+    "code-review",
+    "pull-request"
+  ]
+}

--- a/plugins/greptile/.cursor-plugin/plugin.json
+++ b/plugins/greptile/.cursor-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "greptile",
+  "displayName": "Greptile",
+  "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+  "version": "1.0.0",
+  "author": {
+    "name": "Community"
+  },
+  "category": "Productivity",
+  "license": "MIT",
+  "keywords": [
+    "greptile",
+    "code-review",
+    "pull-request"
+  ]
+}

--- a/plugins/greptile/plugin.json
+++ b/plugins/greptile/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "greptile",
+  "version": "1.0.0",
+  "description": "Greptile agent skills for PR quality: check PR review comments and status checks, run Greptile CLI reviews on local branches, and iteratively improve PRs until they score 5/5",
+  "license": "MIT",
+  "keywords": [
+    "greptile",
+    "code-review",
+    "pull-request"
+  ]
+}

--- a/plugins/greptile/skills-lock.json
+++ b/plugins/greptile/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "check-pr": {
+      "source": "greptileai/skills",
+      "sourceType": "github",
+      "skillPath": "check-pr/SKILL.md",
+      "computedHash": "c25ca1259f825b202949a643aa8aa931bb6bb02ac02ccb4b969a4508c2e146dd"
+    },
+    "cli-review": {
+      "source": "greptileai/skills",
+      "sourceType": "github",
+      "skillPath": "cli-review/SKILL.md",
+      "computedHash": "1b1fe57c18746de2a85068770ec01fa7ac26471f5c9cb8047553ca433fea1acd"
+    },
+    "greploop": {
+      "source": "greptileai/skills",
+      "sourceType": "github",
+      "skillPath": "greploop/SKILL.md",
+      "computedHash": "13849c1cfc853dd4ebdef9caa05e73ea322355dcee6114df64879fdf37ad6f19"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1167,6 +1167,32 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/greptile": {
+      "release-type": "simple",
+      "component": "greptile",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".cursor-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "release-type": "node",


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds a new built-in plugin `greptile` (v1.0.0) bundling three skills.sh-managed agent skills from [greptileai/skills](https://github.com/greptileai/skills) (MIT license):

- **check-pr** — checks a PR/MR/changelist for unresolved review comments, failing status checks, and incomplete descriptions
- **cli-review** — runs a Greptile CLI review for the current local branch
- **greploop** — iteratively improves a PR until Greptile gives a 5/5 confidence score

The skills are installed under `plugins/greptile/.agents/skills/{check-pr,cli-review,greploop}/` via `bunx skills add`, tracked by `skills-lock.json`. `.claude-plugin/plugin.json` is the source-of-truth manifest (`"skills": "./.agents/skills/"`); the Codex, Antigravity, and Cursor runtime manifests (`.codex-plugin/plugin.json`, `plugin.json`, `.cursor-plugin/plugin.json`) were generated with `bun scripts/cli.ts multi-format`.

## Changes

- `plugins/greptile/` — new plugin: installed skills, `skills-lock.json`, and the four version-bearing runtime manifests
- `.claude-plugin/marketplace.json` — registers the `greptile` entry (source of truth)
- `.agents/plugins/marketplace.json`, `.cursor-plugin/marketplace.json` — regenerated via `multi-format` (greptile entry only, no unrelated drift)
- `release-please-config.json` — adds `plugins/greptile` package with `extra-files` covering all 4 version-bearing manifests
- `.release-please-manifest.json` — adds `"plugins/greptile": "1.0.0"`
- `README.md` — adds the Greptile entry under Built-in Plugins

`claude plugin validate plugins/greptile` passes (one pre-existing-pattern warning: missing `author` field, consistent with other built-in plugins in this repo).

**Note:** `claude plugin validate .claude-plugin/marketplace.json` currently reports a pre-existing duplicate `asana` marketplace entry validation error. This is unrelated to this PR — the `asana` plugin entry already existed before this change and is untouched here.

## Related issue

N/A — not tied to a tracked issue.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`) — N/A, no test suite for static plugin manifests/skills
- [ ] Lint/format pass (`bun run lint`) — N/A, not run for this static content change
- [x] Documentation updated if behavior changed (README Built-in Plugins section)
- [x] No breaking change, or a `BREAKING CHANGE:` note is included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new built-in `greptile` plugin (v1.0.0) with three agent skills—`check-pr`, `cli-review`, and `greploop`—to automate PR checks and Greptile reviews on GitHub, GitLab, and Perforce. Registers the plugin in all marketplaces and sets up release automation.

- **New Features**
  - New `plugins/greptile` with skills managed by `skills.sh`: `check-pr`, `cli-review`, `greploop` (tracked in `skills-lock.json`).
  - Runtime manifests added: `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `plugin.json` (all at v1.0.0).
  - Marketplace entries updated: `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `.cursor-plugin/marketplace.json`.
  - Release automation: `release-please-config.json` and `.release-please-manifest.json` updated to version `plugins/greptile` and bump all manifests together.
  - Docs: README updated under Built-in Plugins.
  - Validation: `claude plugin validate plugins/greptile` passes; a duplicate `asana` entry warning is pre-existing and unchanged.

<sup>Written for commit e820a0a9fe54abc6b11af47606ca3a847f0843d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

