### PR TITLE
feat: add run-verify plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1498,6 +1498,17 @@
           "cli": ["greptile"]
         }
       }
+    },
+    {
+      "name": "run-verify",
+      "description": "Run and verify code changes by driving the real app — launch it, interact with it, capture evidence. Ships run, verify, and run-skill-generator skills for Claude Code, Codex, and Antigravity.",
+      "category": "development",
+      "keywords": ["run", "verify", "verification", "e2e", "smoke-test", "runtime-observation"],
+      "tags": ["workflow", "testing"],
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/run-verify-plugin"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Fetch Claude Code docs as markdown — rewrites code.claude.com/docs page URLs t
 
 **Install:** `/plugin install claude-code-docs@pleaseai` | **Repository:** [pleaseai/claude-code-docs](https://github.com/pleaseai/claude-code-docs)
 
+#### Run Verify
+Run and verify code changes by driving the real app — the `run`, `verify`, and `run-skill-generator` skills, generalized for Claude Code, Codex, and Antigravity.
+
+**Install:** `/plugin install run-verify@pleaseai` | **Repository:** [pleaseai/run-verify-plugin](https://github.com/pleaseai/run-verify-plugin)
+
 
 ### Built-in Plugins
 


### PR DESCRIPTION
## Summary

Registers **run-verify** — the `run`, `verify`, and `run-skill-generator` skills bundled with Claude Code, generalized for cross-agent use (Claude Code, OpenAI Codex CLI, Google Antigravity) — as an external marketplace plugin sourced from [`pleaseai/run-verify-plugin`](https://github.com/pleaseai/run-verify-plugin).

- Adds the `run-verify` entry to `.claude-plugin/marketplace.json` with a `github` source (external plugin — intentionally not in the generated Codex/Cursor marketplaces, which cover local plugins only; the plugin repo ships its own `.codex-plugin`/`.cursor-plugin`/Antigravity manifests)
- Adds the README **External Plugins** entry

> ⚠️ Merge after the `pleaseai/run-verify-plugin` repository is published — the marketplace entry resolves against it.

## Related issue

N/A

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`) — marketplace/README only, suite passes
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `run-verify` as an external marketplace plugin sourced from `pleaseai/run-verify-plugin`. Adds README install docs; merge after the repo is public.

- **New Features**
  - Added `run-verify` to `.claude-plugin/marketplace.json` with `github` source pointing to `pleaseai/run-verify-plugin`.
  - Documented install in README: `/plugin install run-verify@pleaseai`.

<sup>Written for commit 6dd00f0e8b62a00e77841fa874f36a722aa7f644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new marketplace plugin entry, “Run Verify,” with its description, category, keywords, tags, and source information.
  * Documented the new plugin in the available plugins list, including the install command and repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->