### PR TITLE
feat(marketplace): add shunt provider plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1548,6 +1548,111 @@
           ]
         }
       }
+    },
+    {
+      "name": "shunt-codex",
+      "displayName": "shunt · Codex models",
+      "description": "Subagents on ChatGPT/Codex GPT-5.6 models (Luna, Sol, Terra), routed through shunt at the inference layer.",
+      "category": "ai",
+      "keywords": ["shunt", "codex", "chatgpt", "gpt-5.6", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-codex",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-codex"
+    },
+    {
+      "name": "shunt-xai",
+      "displayName": "shunt · xAI Grok models",
+      "description": "Subagents on xAI Grok models (grok-build-0.1, grok-4.5, grok-4.3), routed through shunt at the inference layer. EXPERIMENTAL — the xAI provider is not yet verified against the live API.",
+      "category": "ai",
+      "keywords": ["shunt", "xai", "grok", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-xai",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai"
+    },
+    {
+      "name": "shunt-kimi",
+      "displayName": "shunt · Kimi models",
+      "description": "Subagent on Moonshot AI's kimi-k2.7-code, routed through shunt at the inference layer via Moonshot's Anthropic-compatible endpoint.",
+      "category": "ai",
+      "keywords": ["shunt", "kimi", "moonshot", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-kimi",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-kimi"
+    },
+    {
+      "name": "shunt-deepseek",
+      "displayName": "shunt · DeepSeek models",
+      "description": "Subagents on DeepSeek models (deepseek-v4-pro, deepseek-v4-flash), routed through shunt at the inference layer via DeepSeek's Anthropic-compatible endpoint.",
+      "category": "ai",
+      "keywords": ["shunt", "deepseek", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-deepseek",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-deepseek"
+    },
+    {
+      "name": "shunt-zai",
+      "displayName": "shunt · Z.ai GLM models",
+      "description": "Subagents on Z.ai GLM models (glm-5.2, glm-4.7), routed through shunt at the inference layer via Z.ai's Anthropic-compatible endpoint.",
+      "category": "ai",
+      "keywords": ["shunt", "zai", "glm", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-zai",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-zai"
+    },
+    {
+      "name": "shunt-minimax",
+      "displayName": "shunt · MiniMax models",
+      "description": "Subagent on MiniMax-M3 (1M context), routed through shunt at the inference layer via MiniMax's Anthropic-compatible endpoint.",
+      "category": "ai",
+      "keywords": ["shunt", "minimax", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-minimax",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-minimax"
+    },
+    {
+      "name": "shunt-mimo",
+      "displayName": "shunt · Mimo models",
+      "description": "Subagent on Xiaomi's mimo-v2.5-pro, routed through shunt at the inference layer via Mimo's Anthropic-compatible endpoint.",
+      "category": "ai",
+      "keywords": ["shunt", "mimo", "xiaomi", "subagent", "llm-gateway"],
+      "tags": ["ai", "subagent"],
+      "source": {
+        "source": "git-subdir",
+        "url": "pleaseai/shunt",
+        "path": "plugins/shunt-mimo",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/pleaseai/shunt/tree/main/plugins/shunt-mimo"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds 7 provider plugins from the `pleaseai/shunt` marketplace as new entries in `.claude-plugin/marketplace.json`. Each entry is a `git-subdir` source pointing at `pleaseai/shunt` at `plugins/shunt-<name>` (ref `main`):

- `shunt-codex` — ChatGPT/Codex GPT-5.6 (Luna, Sol, Terra)
- `shunt-xai` — xAI Grok (EXPERIMENTAL, unverified upstream)
- `shunt-kimi` — Moonshot kimi-k2.7-code
- `shunt-deepseek` — deepseek-v4-pro / -flash
- `shunt-zai` — Z.ai GLM (5.2, 4.7)
- `shunt-minimax` — MiniMax-M3 (1M ctx)
- `shunt-mimo` — Xiaomi mimo-v2.5-pro

## Related issue

<!-- No linked issue for this change -->

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`) — n/a (marketplace config only)
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed — n/a
- [x] No breaking change, or a `BREAKING CHANGE:` note is included — no breaking change

## Notes

- These are remote `git-subdir` sources, so the Codex/Cursor generated marketplaces (`.agents/plugins/marketplace.json`, `.cursor-plugin/marketplace.json`) are intentionally **not** updated — `multi-format` only includes local `./plugins/*` sources.
- `claude plugin validate .claude-plugin/marketplace.json` passes with only pre-existing informational warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seven `shunt` provider plugins to `.claude-plugin/marketplace.json` to expand available LLM providers via remote `git-subdir` sources.

- **New Features**
  - Added `shunt-codex`, `shunt-xai` (experimental), `shunt-kimi`, `shunt-deepseek`, `shunt-zai`, `shunt-minimax`, `shunt-mimo`.
  - Each plugin points to `pleaseai/shunt` at `plugins/shunt-<name>` on `main` using `git-subdir`.
  - Only `.claude-plugin/marketplace.json` is updated; other marketplace files are unchanged.

<sup>Written for commit 93eda54321b7c8e5f54a285c3bf195798c2dde02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

