### PR TITLE
chore: enable csp plugin in shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,8 @@
     "vueuse@pleaseai": true,
     "fetch@pleaseai": true,
     "ask@pleaseai": true,
-    "modern-web-guidance@pleaseai": true
+    "modern-web-guidance@pleaseai": true,
+    "csp@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "code-intelligence": {


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds `"csp@pleaseai": true` to `enabledPlugins` in `.claude/settings.json`, enabling the csp (code search) plugin in the shared team settings.

## Related issue

None — simple config toggle.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`)
- [ ] Lint/format pass (`bun run lint`)
- [ ] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `csp@pleaseai` code search plugin in shared Claude settings by adding it to `enabledPlugins` in `.claude/settings.json`. This makes code search available to the team by default.

<sup>Written for commit 38c7c484ce25ac42dcb54ef630e949a3cf09ec4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

